### PR TITLE
fix(sqlite): improve SQLite database handling

### DIFF
--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -42,8 +42,12 @@ database:
   # Database version for Docker image
   version: "16"
 
-  # Managed: if true (default), FrankenDeploy creates a DB container
+  # Path: SQLite database file path (only for sqlite driver)
+  # path: var/data.db
+
+  # Managed: if true (default for pgsql/mysql), FrankenDeploy creates a DB container
   # If false, expects external DATABASE_URL in .env.local
+  # Note: SQLite does NOT support managed mode (file-based database)
   managed: true
 
 # Symfony Messenger Workers (optional)
@@ -165,14 +169,32 @@ Common extensions:
 | `mysql` | mysql:VERSION |
 | `sqlite` | No container needed |
 
+### `database.path`
+
+**SQLite only.** The file path for the SQLite database (relative to project root).
+
+```yaml
+database:
+  driver: sqlite
+  path: var/data.db
+```
+
+When using SQLite, FrankenDeploy automatically adds the database directory (e.g., `var`) to `shared_dirs` to ensure data persistence across deployments.
+
 ### `database.managed`
 
 Controls how the database is provisioned in production:
 
 | Value | Behavior |
 |-------|----------|
-| `true` (default) | FrankenDeploy creates a Docker container for the DB |
+| `true` (default for pgsql/mysql) | FrankenDeploy creates a Docker container for the DB |
 | `false` | Use external database, set `DATABASE_URL` in `.env.local` |
+
+:::caution[SQLite Limitation]
+SQLite does **not** support `managed: true`. SQLite is a file-based database and cannot run as a container. If you set `managed: true` with SQLite, validation will fail with an error.
+
+For SQLite persistence in production, ensure the database directory is in `shared_dirs`.
+:::
 
 ### `messenger`
 

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -90,6 +90,27 @@ database:
   version: "16"       # Database version
 ```
 
+#### SQLite Configuration
+
+SQLite is a file-based database and is handled differently from PostgreSQL and MySQL:
+
+```yaml
+database:
+  driver: sqlite
+  version: "3"
+  path: var/data.db   # Automatically detected from DATABASE_URL
+```
+
+Key differences for SQLite:
+- **No `managed` option**: SQLite cannot run as a container, so `managed: true` is not allowed
+- **Automatic shared_dirs**: The SQLite database directory is automatically added to `shared_dirs` for persistence
+- **Path detection**: The file path is extracted from your `DATABASE_URL` in `.env`
+
+Example `.env` for SQLite:
+```bash
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
+```
+
 ### `assets`
 
 Frontend asset build configuration.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -27,8 +27,11 @@ type DatabaseConfig struct {
 	Host    string `yaml:"host,omitempty"`
 	Port    int    `yaml:"port,omitempty"`
 	Name    string `yaml:"name,omitempty"`
+	// Path: file path for SQLite database (relative to project root)
+	Path string `yaml:"path,omitempty"`
 	// Managed: if true, FrankenDeploy creates a DB container in production
 	// If false, expects external DATABASE_URL in .env.local
+	// Note: SQLite does not support managed mode (file-based database)
 	Managed *bool `yaml:"managed,omitempty"`
 }
 

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 )
 
+// boolPtr returns a pointer to a bool value
+func boolPtr(b bool) *bool {
+	return &b
+}
+
 func TestValidateProjectConfig(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -79,6 +84,78 @@ func TestValidateProjectConfig(t *testing.T) {
 				Database: DatabaseConfig{
 					Driver:  "pgsql",
 					Version: "16",
+				},
+			},
+			wantErrors: false,
+		},
+		{
+			name: "sqlite without managed is valid",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP: PHPConfig{
+					Version: "8.3",
+				},
+				Database: DatabaseConfig{
+					Driver: "sqlite",
+					Path:   "var/data.db",
+				},
+			},
+			wantErrors: false,
+		},
+		{
+			name: "sqlite with managed=false is valid",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP: PHPConfig{
+					Version: "8.3",
+				},
+				Database: DatabaseConfig{
+					Driver:  "sqlite",
+					Path:    "var/data.db",
+					Managed: boolPtr(false),
+				},
+			},
+			wantErrors: false,
+		},
+		{
+			name: "sqlite with managed=true is invalid",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP: PHPConfig{
+					Version: "8.3",
+				},
+				Database: DatabaseConfig{
+					Driver:  "sqlite",
+					Managed: boolPtr(true),
+				},
+			},
+			wantErrors: true,
+		},
+		{
+			name: "pdo_sqlite with managed=true is invalid",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP: PHPConfig{
+					Version: "8.3",
+				},
+				Database: DatabaseConfig{
+					Driver:  "pdo_sqlite",
+					Managed: boolPtr(true),
+				},
+			},
+			wantErrors: true,
+		},
+		{
+			name: "pgsql with managed=true is valid",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP: PHPConfig{
+					Version: "8.3",
+				},
+				Database: DatabaseConfig{
+					Driver:  "pgsql",
+					Version: "16",
+					Managed: boolPtr(true),
 				},
 			},
 			wantErrors: false,

--- a/internal/scanner/database_test.go
+++ b/internal/scanner/database_test.go
@@ -1,0 +1,180 @@
+package scanner
+
+import (
+	"testing"
+)
+
+func TestExtractSQLitePath(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "simple sqlite URL",
+			url:      "sqlite:///var/data.db",
+			expected: "var/data.db",
+		},
+		{
+			name:     "sqlite URL with kernel.project_dir",
+			url:      "sqlite:///%kernel.project_dir%/var/data.db",
+			expected: "var/data.db",
+		},
+		{
+			name:     "sqlite URL with nested path",
+			url:      "sqlite:///var/database/app.db",
+			expected: "var/database/app.db",
+		},
+		{
+			name:     "empty path defaults to var/data.db",
+			url:      "sqlite://",
+			expected: "var/data.db",
+		},
+		{
+			name:     "sqlite: prefix without double slash",
+			url:      "sqlite:/var/data.db",
+			expected: "var/data.db",
+		},
+		{
+			name:     "uppercase SQLITE URL",
+			url:      "SQLITE:///var/data.db",
+			expected: "var/data.db",
+		},
+		{
+			name:     "mixed case sqlite URL",
+			url:      "SQLite:///var/DATA.db",
+			expected: "var/DATA.db",
+		},
+		{
+			name:     "path with multiple kernel.project_dir",
+			url:      "sqlite:///%kernel.project_dir%/var/%kernel.project_dir%/data.db",
+			expected: "var//data.db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractSQLitePath(tt.url)
+			if result != tt.expected {
+				t.Errorf("extractSQLitePath(%q) = %q, want %q", tt.url, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetSQLiteDirectory(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected string
+	}{
+		{
+			name:     "path with directory",
+			path:     "var/data.db",
+			expected: "var",
+		},
+		{
+			name:     "nested path",
+			path:     "var/database/app.db",
+			expected: "var/database",
+		},
+		{
+			name:     "file in root",
+			path:     "data.db",
+			expected: "",
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: "",
+		},
+		{
+			name:     "deep nested path",
+			path:     "var/lib/sqlite/data/app.db",
+			expected: "var/lib/sqlite/data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getSQLiteDirectory(tt.path)
+			if result != tt.expected {
+				t.Errorf("getSQLiteDirectory(%q) = %q, want %q", tt.path, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseDBURL_SQLite(t *testing.T) {
+	tests := []struct {
+		name           string
+		url            string
+		expectedDriver string
+		expectedVer    string
+	}{
+		{
+			name:           "sqlite URL",
+			url:            "sqlite:///var/data.db",
+			expectedDriver: "sqlite",
+			expectedVer:    "3",
+		},
+		{
+			name:           "postgresql URL",
+			url:            "postgresql://user:pass@localhost:5432/db",
+			expectedDriver: "pgsql",
+			expectedVer:    "16",
+		},
+		{
+			name:           "mysql URL",
+			url:            "mysql://user:pass@localhost:3306/db",
+			expectedDriver: "mysql",
+			expectedVer:    "8.0",
+		},
+		{
+			name:           "postgres URL alias",
+			url:            "postgres://user:pass@localhost:5432/db",
+			expectedDriver: "pgsql",
+			expectedVer:    "16",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driver, version := parseDBURL(tt.url)
+			if driver != tt.expectedDriver {
+				t.Errorf("parseDBURL(%q) driver = %q, want %q", tt.url, driver, tt.expectedDriver)
+			}
+			if version != tt.expectedVer {
+				t.Errorf("parseDBURL(%q) version = %q, want %q", tt.url, version, tt.expectedVer)
+			}
+		})
+	}
+}
+
+func TestNormalizeDriver(t *testing.T) {
+	tests := []struct {
+		driver   string
+		expected string
+	}{
+		{"pdo_pgsql", "pgsql"},
+		{"postgresql", "pgsql"},
+		{"postgres", "pgsql"},
+		{"pgsql", "pgsql"},
+		{"pdo_mysql", "mysql"},
+		{"mysql", "mysql"},
+		{"mysqli", "mysql"},
+		{"pdo_sqlite", "sqlite"},
+		{"sqlite", "sqlite"},
+		{"sqlite3", "sqlite"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.driver, func(t *testing.T) {
+			result := normalizeDriver(tt.driver)
+			if result != tt.expected {
+				t.Errorf("normalizeDriver(%q) = %q, want %q", tt.driver, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -155,6 +155,14 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 	cfg.Database = result.Database
 	cfg.Assets = result.Assets
 
+	// For SQLite, add the database directory to shared_dirs for persistence
+	if result.Database.Driver == "sqlite" && result.Database.Path != "" {
+		sqliteDir := getSQLiteDirectory(result.Database.Path)
+		if sqliteDir != "" && !contains(cfg.Deploy.SharedDirs, sqliteDir) {
+			cfg.Deploy.SharedDirs = append(cfg.Deploy.SharedDirs, sqliteDir)
+		}
+	}
+
 	// Auto-fill Messenger config if detected
 	if result.HasMessenger {
 		cfg.Messenger = config.MessengerConfig{
@@ -168,6 +176,16 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 	cfg.Deploy.Hooks = s.generateDefaultHooks(result)
 
 	return cfg
+}
+
+// contains checks if a string slice contains a specific value
+func contains(slice []string, value string) bool {
+	for _, v := range slice {
+		if v == value {
+			return true
+		}
+	}
+	return false
 }
 
 // generateDefaultHooks creates default deployment hooks based on detected features


### PR DESCRIPTION
## Summary

- Don't generate `managed: true` for SQLite (file-based database)
- Add `path` field to DatabaseConfig for SQLite file path
- Auto-add SQLite directory to `shared_dirs` for persistence
- Validate and reject `managed: true` for SQLite with clear error message
- Extract SQLite path from DATABASE_URL during project scan

## Changes

| File | Change |
|------|--------|
| `internal/config/types.go` | Add `Path` field to `DatabaseConfig` |
| `internal/scanner/database.go` | Add `extractSQLitePath()`, `getSQLiteDirectory()`, update `DetectDatabase()` |
| `internal/config/validation.go` | Add validation rejecting SQLite + `managed: true` |
| `internal/scanner/scanner.go` | Auto-add SQLite dir to `shared_dirs` in `ToProjectConfig()` |
| `internal/config/validation_test.go` | Add tests for SQLite validation |
| `internal/scanner/database_test.go` | Add tests for SQLite path extraction |
| `docs/src/content/docs/config/project.md` | Document SQLite behavior |
| `docs/src/content/docs/guides/configuration.md` | Add SQLite configuration guide |

## Test plan

- [x] `make test` passes
- [x] `make lint` passes
- [x] Manual test with Symfony project using SQLite
- [x] Verify `managed` is not generated for SQLite
- [x] Verify SQLite directory added to `shared_dirs`
- [x] Verify validation error when `managed: true` is set for SQLite

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)