### PR TITLE
feat(deploy): warn when migrations directory is empty but entities exist

### DIFF
--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -95,6 +95,33 @@ deploy:
 **Pre-deploy hooks** run in the new container before traffic is switched.
 **Post-deploy hooks** run after successful deployment.
 
+## Database Migration Warning
+
+FrankenDeploy automatically detects when your project has Doctrine entities but no migration files. This can happen when you forget to generate migrations after creating entities.
+
+When this situation is detected (entities in `src/Entity/` but no files in `migrations/`), FrankenDeploy displays a warning:
+
+```
+⚠️  Warning: No database migrations found but entities exist!
+
+   Entities found: 5 files in src/Entity/
+   Migrations:     0 files in migrations/
+
+   This may cause 'no such table' errors at runtime.
+
+   To fix this, run locally:
+      php bin/console make:migration
+      php bin/console doctrine:migrations:migrate
+      git add migrations/
+      git commit -m "Add database migrations"
+
+   Then redeploy your application.
+```
+
+This warning only appears once per application. Once you add migrations and redeploy, the warning is automatically cleared.
+
+**Note:** This check only runs when you have a migration hook configured in your `pre_deploy` hooks.
+
 ## Release Management
 
 FrankenDeploy keeps multiple releases for instant rollback:

--- a/internal/deploy/migrationcheck.go
+++ b/internal/deploy/migrationcheck.go
@@ -1,0 +1,124 @@
+package deploy
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// MigrationCheckResult holds the result of migration directory check
+type MigrationCheckResult struct {
+	MigrationFilesCount int
+	EntityFilesCount    int
+	HasPotentialProblem bool
+}
+
+// CheckMigrationState checks if migrations exist when entities are present
+// It runs docker exec commands to count files in migrations/ and src/Entity/
+func CheckMigrationState(client *ssh.Client, containerName string) (*MigrationCheckResult, error) {
+	result := &MigrationCheckResult{}
+
+	// Count migration files (.php files in /app/migrations/)
+	migrationCmd := fmt.Sprintf(
+		"docker exec %s sh -c 'find /app/migrations -name \"*.php\" -type f 2>/dev/null | wc -l'",
+		containerName,
+	)
+	migrationResult, err := client.Exec(migrationCmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check migrations: %w", err)
+	}
+	result.MigrationFilesCount = parseCount(migrationResult.Stdout)
+
+	// Count entity files (.php files in /app/src/Entity/)
+	entityCmd := fmt.Sprintf(
+		"docker exec %s sh -c 'find /app/src/Entity -name \"*.php\" -type f 2>/dev/null | wc -l'",
+		containerName,
+	)
+	entityResult, err := client.Exec(entityCmd)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check entities: %w", err)
+	}
+	result.EntityFilesCount = parseCount(entityResult.Stdout)
+
+	// Determine if there's a potential problem
+	// Problem: entities exist (> 0) but no migrations (== 0)
+	result.HasPotentialProblem = result.EntityFilesCount > 0 && result.MigrationFilesCount == 0
+
+	return result, nil
+}
+
+// parseCount extracts an integer from command output
+func parseCount(output string) int {
+	trimmed := strings.TrimSpace(output)
+	count, err := strconv.Atoi(trimmed)
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
+// HasMigrationWarningBeenShown checks if the warning marker exists on the server
+func HasMigrationWarningBeenShown(client *ssh.Client, appName string) bool {
+	markerPath := getMigrationWarningMarkerPath(appName)
+	cmd := fmt.Sprintf("test -f %s && echo 'exists'", markerPath)
+	result, err := client.Exec(cmd)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(result.Stdout) == "exists"
+}
+
+// MarkMigrationWarningShown creates the warning marker file on the server
+func MarkMigrationWarningShown(client *ssh.Client, appName string) error {
+	markerPath := getMigrationWarningMarkerPath(appName)
+	// Ensure directory exists and create marker file
+	cmd := fmt.Sprintf("mkdir -p $(dirname %s) && touch %s", markerPath, markerPath)
+	_, err := client.Exec(cmd)
+	return err
+}
+
+// ClearMigrationWarningMarker removes the marker when the problem is resolved
+func ClearMigrationWarningMarker(client *ssh.Client, appName string) error {
+	markerPath := getMigrationWarningMarkerPath(appName)
+	cmd := fmt.Sprintf("rm -f %s", markerPath)
+	_, err := client.Exec(cmd)
+	return err
+}
+
+// getMigrationWarningMarkerPath returns the path to the warning marker file
+func getMigrationWarningMarkerPath(appName string) string {
+	return filepath.Join("/opt/frankendeploy/apps", appName, "shared", ".migration_warning_shown")
+}
+
+// FormatMigrationWarning formats the warning message for display
+func FormatMigrationWarning(result *MigrationCheckResult) string {
+	var sb strings.Builder
+
+	sb.WriteString("Warning: No database migrations found but entities exist!\n\n")
+	sb.WriteString(fmt.Sprintf("   Entities found: %d files in src/Entity/\n", result.EntityFilesCount))
+	sb.WriteString(fmt.Sprintf("   Migrations:     %d files in migrations/\n", result.MigrationFilesCount))
+	sb.WriteString("\n")
+	sb.WriteString("   This may cause 'no such table' errors at runtime.\n\n")
+	sb.WriteString("   To fix this, run locally:\n")
+	sb.WriteString("      php bin/console make:migration\n")
+	sb.WriteString("      php bin/console doctrine:migrations:migrate\n")
+	sb.WriteString("      git add migrations/\n")
+	sb.WriteString("      git commit -m \"Add database migrations\"\n\n")
+	sb.WriteString("   Then redeploy your application.\n")
+
+	return sb.String()
+}
+
+// HasMigrationHook checks if the hooks list contains a Doctrine migration command
+func HasMigrationHook(hooks []string) bool {
+	for _, hook := range hooks {
+		if strings.Contains(hook, "doctrine:migrations:migrate") ||
+			strings.Contains(hook, "d:m:m") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/deploy/migrationcheck_test.go
+++ b/internal/deploy/migrationcheck_test.go
@@ -1,0 +1,199 @@
+package deploy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMigrationCheckResult_HasPotentialProblem(t *testing.T) {
+	tests := []struct {
+		name            string
+		migrationFiles  int
+		entityFiles     int
+		expectedProblem bool
+	}{
+		{
+			name:            "no entities, no migrations - no problem",
+			migrationFiles:  0,
+			entityFiles:     0,
+			expectedProblem: false,
+		},
+		{
+			name:            "entities exist, no migrations - problem",
+			migrationFiles:  0,
+			entityFiles:     5,
+			expectedProblem: true,
+		},
+		{
+			name:            "entities exist, migrations exist - no problem",
+			migrationFiles:  3,
+			entityFiles:     5,
+			expectedProblem: false,
+		},
+		{
+			name:            "no entities, migrations exist - no problem",
+			migrationFiles:  3,
+			entityFiles:     0,
+			expectedProblem: false,
+		},
+		{
+			name:            "single entity, no migrations - problem",
+			migrationFiles:  0,
+			entityFiles:     1,
+			expectedProblem: true,
+		},
+		{
+			name:            "single entity, single migration - no problem",
+			migrationFiles:  1,
+			entityFiles:     1,
+			expectedProblem: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := &MigrationCheckResult{
+				MigrationFilesCount: tt.migrationFiles,
+				EntityFilesCount:    tt.entityFiles,
+				HasPotentialProblem: tt.entityFiles > 0 && tt.migrationFiles == 0,
+			}
+
+			if result.HasPotentialProblem != tt.expectedProblem {
+				t.Errorf("HasPotentialProblem = %v, expected %v", result.HasPotentialProblem, tt.expectedProblem)
+			}
+		})
+	}
+}
+
+func TestFormatMigrationWarning(t *testing.T) {
+	result := &MigrationCheckResult{
+		MigrationFilesCount: 0,
+		EntityFilesCount:    5,
+		HasPotentialProblem: true,
+	}
+
+	warning := FormatMigrationWarning(result)
+
+	expectedStrings := []string{
+		"No database migrations found but entities exist",
+		"5 files in src/Entity/",
+		"0 files in migrations/",
+		"no such table",
+		"make:migration",
+		"doctrine:migrations:migrate",
+		"git add migrations/",
+		"git commit",
+		"redeploy",
+	}
+
+	for _, expected := range expectedStrings {
+		if !strings.Contains(warning, expected) {
+			t.Errorf("FormatMigrationWarning() missing expected string: %s", expected)
+		}
+	}
+}
+
+func TestHasMigrationHook(t *testing.T) {
+	tests := []struct {
+		name     string
+		hooks    []string
+		expected bool
+	}{
+		{
+			name:     "empty hooks",
+			hooks:    []string{},
+			expected: false,
+		},
+		{
+			name:     "no migration hook",
+			hooks:    []string{"php bin/console cache:clear"},
+			expected: false,
+		},
+		{
+			name:     "full migration command",
+			hooks:    []string{"php bin/console doctrine:migrations:migrate --no-interaction"},
+			expected: true,
+		},
+		{
+			name:     "short migration command",
+			hooks:    []string{"php bin/console d:m:m --no-interaction"},
+			expected: true,
+		},
+		{
+			name:     "migration among other hooks",
+			hooks:    []string{"php bin/console cache:clear", "php bin/console doctrine:migrations:migrate --no-interaction", "php bin/console assets:install"},
+			expected: true,
+		},
+		{
+			name:     "messenger stop workers (not migration)",
+			hooks:    []string{"php bin/console messenger:stop-workers"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := HasMigrationHook(tt.hooks)
+			if result != tt.expected {
+				t.Errorf("HasMigrationHook() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected int
+	}{
+		{
+			name:     "simple number",
+			input:    "5",
+			expected: 5,
+		},
+		{
+			name:     "number with whitespace",
+			input:    "  10  \n",
+			expected: 10,
+		},
+		{
+			name:     "zero",
+			input:    "0",
+			expected: 0,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: 0,
+		},
+		{
+			name:     "invalid input",
+			input:    "not a number",
+			expected: 0,
+		},
+		{
+			name:     "newline only",
+			input:    "\n",
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseCount(tt.input)
+			if result != tt.expected {
+				t.Errorf("parseCount(%q) = %d, expected %d", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetMigrationWarningMarkerPath(t *testing.T) {
+	path := getMigrationWarningMarkerPath("my-app")
+	expected := "/opt/frankendeploy/apps/my-app/shared/.migration_warning_shown"
+
+	if path != expected {
+		t.Errorf("getMigrationWarningMarkerPath() = %s, expected %s", path, expected)
+	}
+}


### PR DESCRIPTION
## Summary

- Add detection for empty migrations directory when Doctrine entities exist
- Display warning with actionable fix instructions after pre-deploy hooks
- Warning shown only once per application (uses marker file on server)
- Marker automatically cleared when migrations are added

## Changes

| File | Description |
|------|-------------|
| `internal/deploy/migrationcheck.go` | New file with migration check logic |
| `internal/deploy/migrationcheck_test.go` | Unit tests for migration check |
| `internal/cmd/deploy.go` | Integration after pre-deploy hooks |
| `docs/.../deployment.md` | Documentation for the new warning |

## Test plan

- [x] `make lint` passes
- [x] `make test` passes
- [x] `make build` compiles successfully
- [x] Manual test: first deploy shows warning (4 entities, 0 migrations)
- [x] Manual test: second deploy does NOT show warning (marker file works)

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/code)