### PR TITLE
feat(init): add --domain flag to set deploy domain during init

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -52,8 +52,8 @@ Handles everything: building, transferring, starting containers, health checks, 
 # In your Symfony project
 cd my-symfony-app
 
-# Initialize FrankenDeploy
-frankendeploy init
+# Initialize FrankenDeploy (with optional domain)
+frankendeploy init --domain my-app.com
 
 # Generate Docker files
 frankendeploy build

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -174,6 +174,23 @@ When you run `frankendeploy init`, it automatically detects:
 | Database | `doctrine.yaml`, `.env` DATABASE_URL |
 | Assets | `package.json`, `vite.config.js`, `importmap.php` |
 
+### Init Options
+
+You can pass additional options to `frankendeploy init`:
+
+```bash
+# Set your production domain during initialization
+frankendeploy init --domain my-app.com
+
+# Overwrite existing configuration
+frankendeploy init --force
+
+# Custom project name
+frankendeploy init --name my-custom-name
+```
+
+If no domain is provided, you can add it later in `frankendeploy.yaml` under `deploy.domain`.
+
 ## Validation
 
 FrankenDeploy validates your configuration. Run:

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -18,6 +18,12 @@ cd my-symfony-app
 frankendeploy init
 ```
 
+You can also specify your production domain directly:
+
+```bash
+frankendeploy init --domain my-app.com
+```
+
 FrankenDeploy will:
 - Detect your PHP version
 - Identify required extensions

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -228,6 +228,8 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Tag: %s\n", deployTag)
 	if projectCfg.Deploy.Domain != "" {
 		fmt.Printf("  URL: https://%s\n", projectCfg.Deploy.Domain)
+	} else {
+		fmt.Println("  URL: (no public domain configured)")
 	}
 
 	return nil
@@ -570,7 +572,15 @@ func rollbackDeployment(client *ssh.Client, appName, appPath string) error {
 func updateCaddyConfig(client *ssh.Client, cfg *config.ProjectConfig) error {
 	domain := cfg.Deploy.Domain
 	if domain == "" {
-		PrintWarning("No domain configured in frankendeploy.yaml (deploy.domain)")
+		fmt.Println()
+		PrintWarning("No domain configured. The application will be accessible via container network only.")
+		PrintInfo("To configure a public domain, add to frankendeploy.yaml:")
+		fmt.Println()
+		fmt.Println("   deploy:")
+		fmt.Println("       domain: your-domain.com")
+		fmt.Println()
+		PrintInfo("Or run: frankendeploy init --domain your-domain.com")
+		fmt.Println()
 		return nil
 	}
 

--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -26,14 +26,16 @@ This command will:
 }
 
 var (
-	initName  string
-	initForce bool
+	initName   string
+	initForce  bool
+	initDomain string
 )
 
 func init() {
 	rootCmd.AddCommand(initCmd)
 	initCmd.Flags().StringVarP(&initName, "name", "n", "", "Project name (default: directory name)")
 	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "Overwrite existing configuration")
+	initCmd.Flags().StringVarP(&initDomain, "domain", "d", "", "Domain for the application (e.g., demo.example.com)")
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
@@ -62,6 +64,11 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	// Convert scan result to config
 	cfg := s.ToProjectConfig(result, projectName)
+
+	// Apply domain if provided
+	if initDomain != "" {
+		cfg.Deploy.Domain = initDomain
+	}
 
 	// Validate configuration
 	if errors := config.ValidateProjectConfig(cfg); errors.HasErrors() {
@@ -111,6 +118,10 @@ func printInitSummary(result *config.ScanResult, cfg *config.ProjectConfig) {
 
 	if cfg.Assets.BuildTool != "" {
 		fmt.Printf("   Assets:      %s\n", cfg.Assets.BuildTool)
+	}
+
+	if cfg.Deploy.Domain != "" {
+		fmt.Printf("   Domain:      %s\n", cfg.Deploy.Domain)
 	}
 
 	fmt.Println()


### PR DESCRIPTION
## Summary

- Add `--domain` (`-d`) flag to `frankendeploy init` command to configure the production domain during initialization
- Improve deploy warning when no domain is configured with clear instructions on how to add one
- Show "(no public domain configured)" in deploy summary when domain is missing

## Changes

### `internal/cmd/init.go`
- Add `initDomain` variable and `--domain` flag registration
- Apply domain to config when provided
- Display domain in init summary

### `internal/cmd/deploy.go`
- Improve warning message in `updateCaddyConfig()` with helpful instructions
- Add fallback message in deploy summary when no domain configured

### Documentation
- `docs/src/content/docs/quickstart.md`: Add example with `--domain` flag
- `docs/src/content/docs/getting-started.md`: Update Quick Example
- `docs/src/content/docs/guides/configuration.md`: Add "Init Options" section

## Test plan

- [x] `frankendeploy init --domain demo.example.com --force` → domain added to YAML
- [x] `frankendeploy init --force` (without `--domain`) → no domain in YAML
- [x] `make build` passes
- [x] `make test` passes
- [x] `make lint` passes

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)