### PR TITLE
feat(deploy): auto-detect cross-architecture builds and suggest remote build

### DIFF
--- a/docs/src/content/docs/config/global.md
+++ b/docs/src/content/docs/config/global.md
@@ -27,6 +27,7 @@ servers:
     user: deploy
     port: 22
     key_path: ~/.ssh/id_ed25519
+    remote_build: true  # Build images on server (for cross-architecture)
     apps:
       my-app: /opt/frankendeploy/apps/my-app
 
@@ -66,7 +67,20 @@ Use `--skip-test` to skip the automatic SSH connection test.
 | `user` | SSH username | Required |
 | `port` | SSH port | 22 |
 | `key_path` | Path to SSH private key | Auto-detected |
+| `remote_build` | Build Docker images on server instead of locally | Auto-detected |
 | `apps` | Deployed applications | Auto-populated |
+
+### Configuring Server Options
+
+Use `frankendeploy server set` to configure server-specific options:
+
+```bash
+# Enable remote build for a server
+frankendeploy server set production remote_build true
+
+# Disable remote build
+frankendeploy server set production remote_build false
+```
 
 ### Managing Servers
 

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -27,6 +27,30 @@ frankendeploy deploy production --tag v1.2.3
 
 By default, tags are timestamps like `20240115-143052`.
 
+### Cross-Architecture Detection
+
+FrankenDeploy automatically detects architecture mismatches between your local machine and the server. When deploying from Apple Silicon (ARM) to an x86_64 VPS, you'll see:
+
+```
+⚠️  Architecture mismatch detected:
+   Local:  arm64 (Apple Silicon)
+   Server: x86_64
+
+   Local builds will not run on this server.
+```
+
+In **interactive mode**, FrankenDeploy prompts you to enable remote build and saves your preference for future deployments.
+
+In **CI/CD mode** (`--yes`), you must explicitly use `--remote-build` or pre-configure the server:
+
+```bash
+# Configure server for remote builds
+frankendeploy server set production remote_build true
+
+# Or use the flag
+frankendeploy deploy production --remote-build --yes
+```
+
 ### Remote Build (Recommended for Apple Silicon)
 Build the Docker image directly on the server instead of locally:
 ```bash
@@ -42,6 +66,12 @@ How it works:
 1. Transfers source code via `rsync` (fast, excludes node_modules/vendor)
 2. Builds Docker image on the VPS
 3. Deploys normally
+
+### Force Local Build
+If remote build is configured but you want to build locally anyway:
+```bash
+frankendeploy deploy production --no-remote-build
+```
 
 ### Skip Build
 If you've already built the image:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -87,12 +87,13 @@ type GlobalConfig struct {
 
 // ServerConfig represents a configured server
 type ServerConfig struct {
-	Name    string            `yaml:"name,omitempty"`
-	Host    string            `yaml:"host"`
-	User    string            `yaml:"user"`
-	Port    int               `yaml:"port,omitempty"`
-	KeyPath string            `yaml:"key_path,omitempty"`
-	Apps    map[string]string `yaml:"apps,omitempty"`
+	Name        string            `yaml:"name,omitempty"`
+	Host        string            `yaml:"host"`
+	User        string            `yaml:"user"`
+	Port        int               `yaml:"port,omitempty"`
+	KeyPath     string            `yaml:"key_path,omitempty"`
+	Apps        map[string]string `yaml:"apps,omitempty"`
+	RemoteBuild *bool             `yaml:"remote_build,omitempty"`
 }
 
 // AppConfig represents a deployed application on a server

--- a/internal/ssh/exec.go
+++ b/internal/ssh/exec.go
@@ -81,6 +81,11 @@ func (c *Client) ExecWithOutput(command string) (string, error) {
 	return output, nil
 }
 
+// GetServerArchitecture returns the server's CPU architecture (e.g., "x86_64", "aarch64")
+func (c *Client) GetServerArchitecture() (string, error) {
+	return c.ExecWithOutput("uname -m")
+}
+
 // ExecMultiple executes multiple commands in sequence
 func (c *Client) ExecMultiple(commands []string) error {
 	for _, cmd := range commands {


### PR DESCRIPTION
## Summary

- Automatically detects architecture mismatch between local machine and server
- Displays clear warning when deploying from ARM (Apple Silicon) to x86_64
- Interactive prompt to enable remote build with preference saved to config
- CI/CD mode fails with clear instructions

## Changes

- Added `RemoteBuild *bool` field to `ServerConfig`
- Added `GetServerArchitecture()` method to SSH client
- Added `--no-remote-build` flag to override saved preference
- Added `server set <name> <key> <value>` command
- Updated `server list` to show remote build preference
- Updated documentation

## Test plan

- [x] Deploy from Mac Silicon to x86_64 VPS → warning displayed
- [x] `server set prod remote_build true` → preference saved
- [x] Deploy again → uses remote build automatically
- [x] `--no-remote-build` flag → overrides preference
- [x] `server list` → shows Remote Build: true

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)