### PR TITLE
fix(generator): fix 10 Docker Compose generator bugs

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -31,6 +32,8 @@ func LoadProjectConfig(path string) (*ProjectConfig, error) {
 	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, fmt.Errorf("failed to parse config file: %w", err)
 	}
+
+	config.Database.Driver = NormalizeDBDriver(config.Database.Driver)
 
 	return &config, nil
 }
@@ -84,4 +87,19 @@ func FindProjectConfig() (string, error) {
 	}
 
 	return "", fmt.Errorf("no %s found in current or parent directories", ProjectConfigFile)
+}
+
+// NormalizeDBDriver normalizes database driver names to their canonical form.
+// For example, "pdo_pgsql" → "pgsql", "pdo_mysql" → "mysql", "pdo_sqlite" → "sqlite".
+func NormalizeDBDriver(driver string) string {
+	switch strings.ToLower(driver) {
+	case "pdo_pgsql", "postgresql", "postgres":
+		return "pgsql"
+	case "pdo_mysql", "mysqli":
+		return "mysql"
+	case "pdo_sqlite", "sqlite3":
+		return "sqlite"
+	default:
+		return driver
+	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -8,6 +8,7 @@ type ProjectConfig struct {
 	Database          DatabaseConfig   `yaml:"database,omitempty"`
 	Assets            AssetsConfig     `yaml:"assets,omitempty"`
 	Messenger         MessengerConfig  `yaml:"messenger,omitempty"`
+	Mailer            MailerConfig     `yaml:"mailer,omitempty"`
 	Dockerfile        DockerfileConfig `yaml:"dockerfile,omitempty"`
 	Deploy            DeployConfig     `yaml:"deploy,omitempty"`
 	Env               EnvConfig        `yaml:"env,omitempty"`
@@ -47,6 +48,11 @@ type MessengerConfig struct {
 	Enabled    bool     `yaml:"enabled,omitempty"`
 	Workers    int      `yaml:"workers,omitempty"`
 	Transports []string `yaml:"transports,omitempty"`
+}
+
+// MailerConfig holds Symfony Mailer configuration
+type MailerConfig struct {
+	Enabled bool `yaml:"enabled,omitempty"`
 }
 
 // DockerfileConfig holds Dockerfile customization options

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"embed"
 	"fmt"
+	"strings"
 	"sync"
 	"text/template"
 )
@@ -97,6 +98,10 @@ func templateFuncs() template.FuncMap {
 				return def
 			}
 			return val
+		},
+		"yamlEscape": func(s string) string {
+			replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`, "\n", `\n`, "\r", `\r`, "\t", `\t`)
+			return replacer.Replace(s)
 		},
 		"appPort":     func() string { return AppPort },
 		"metricsPort": func() string { return MetricsPort },

--- a/internal/generator/templates/compose-dev.tmpl
+++ b/internal/generator/templates/compose-dev.tmpl
@@ -24,13 +24,19 @@ services:
       APP_ENV: dev
       APP_DEBUG: "1"
 {{- if .Database.Driver }}
-      DATABASE_URL: "{{ .DatabaseURL }}"
+      DATABASE_URL: "{{ yamlEscape .DatabaseURL }}"
 {{- end }}
 {{- if .Env.Dev }}
 {{- range $key, $value := .Env.Dev }}
-      {{ $key }}: "{{ $value }}"
+      {{ $key }}: "{{ yamlEscape $value }}"
 {{- end }}
 {{- end }}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:{{ metricsPort }}/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 {{- if or (eq .Database.Driver "pgsql") (eq .Database.Driver "mysql") }}
     depends_on:
 {{- if eq .Database.Driver "pgsql" }}

--- a/internal/generator/templates/compose-prod.tmpl
+++ b/internal/generator/templates/compose-prod.tmpl
@@ -20,9 +20,12 @@ services:
       SERVER_NAME: ":{{ appPort }}"
       APP_ENV: prod
       APP_DEBUG: "0"
+{{- if .Database.Driver }}
+      # DATABASE_URL: Set via .env.local on the server
+{{- end }}
 {{- if .Env.Prod }}
 {{- range $key, $value := .Env.Prod }}
-      {{ $key }}: "{{ $value }}"
+      {{ $key }}: "{{ yamlEscape $value }}"
 {{- end }}
 {{- end }}
     healthcheck:

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -67,6 +67,9 @@ func ValidateComposeData(data ComposeData) error {
 		if _, err := GetDBDriverInfo(data.Database.Driver); err != nil {
 			return fmt.Errorf("compose data: %w", err)
 		}
+		if data.Database.Version == "" {
+			return fmt.Errorf("compose data: database version is required for driver %q", data.Database.Driver)
+		}
 	}
 
 	return nil

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -172,6 +172,11 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 		}
 	}
 
+	// Auto-fill Mailer config if detected
+	if result.HasMailer {
+		cfg.Mailer = config.MailerConfig{Enabled: true}
+	}
+
 	// Auto-fill hooks based on detected features
 	cfg.Deploy.Hooks = s.generateDefaultHooks(result)
 


### PR DESCRIPTION
## Summary

- **MailHog/RabbitMQ never rendered**: Add `MailerConfig` struct and propagate `HasMailer`/`HasMessenger` from config to compose data so dev services are actually included
- **`pdo_*` drivers not handled**: Add `NormalizeDBDriver()` to map `pdo_pgsql`→`pgsql`, `pdo_mysql`→`mysql`, `pdo_sqlite`→`sqlite` and other aliases
- **SQLite path hardcoded**: Use `Database.Path` with default `var/data.db`
- **No error on unknown driver**: `buildDatabaseURL()` now returns `(string, error)`
- **Host/Port/Name fields ignored**: Used with sensible defaults (`database`, registry port, `DefaultDevDBName`)
- **No dev health check**: Added to app service in compose-dev template
- **No YAML escaping**: Added `yamlEscape` template function for env vars and DATABASE_URL
- **Version not URL-encoded**: Applied `url.QueryEscape()` to database version
- **No DB version validation**: Added check for non-empty version on containerized drivers
- **Prod compose missing DATABASE_URL hint**: Added conditional comment

## Test plan

- [x] All 76 tests pass with `-race` (`make test`)
- [x] `go vet ./...` passes
- [x] `make build` succeeds
- [ ] Manual: `./bin/frankendeploy init` generates valid YAML with new fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)