### PR TITLE
refactor(deploy): use dbDriverRegistry in deployManagedDatabase (#24)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -17,6 +17,7 @@ import (
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
 	"github.com/yoanbernabeu/frankendeploy/internal/deploy"
+	"github.com/yoanbernabeu/frankendeploy/internal/generator"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
 )
@@ -734,6 +735,12 @@ func deployManagedDatabase(ctx context.Context, client *ssh.Client, cfg *config.
 	dbName := strings.ReplaceAll(cfg.Name, "-", "_")
 	credentialsFile := filepath.Join(appPath, "shared", ".db_credentials")
 
+	// Get driver info from registry (single source of truth)
+	info, err := generator.GetDBDriverInfo(cfg.Database.Driver)
+	if err != nil {
+		return "", fmt.Errorf("unsupported database driver for managed mode: %s", cfg.Database.Driver)
+	}
+
 	// Check if database container already exists and is running
 	checkResult, checkErr := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=%s", dbContainerName))
 	if checkErr == nil && strings.TrimSpace(checkResult.Stdout) != "" {
@@ -752,40 +759,20 @@ func deployManagedDatabase(ctx context.Context, client *ssh.Client, cfg *config.
 		return "", err
 	}
 
-	// Build DATABASE_URL based on driver
-	var databaseURL string
-	var dockerImage string
-	var dockerEnv string
-	var dockerPort string
-
-	switch cfg.Database.Driver {
-	case "pgsql":
-		version := cfg.Database.Version
-		if version == "" {
-			version = "16"
-		}
-		dockerImage = fmt.Sprintf("postgres:%s-alpine", version)
-		dockerEnv = fmt.Sprintf("-e POSTGRES_USER=%s -e POSTGRES_PASSWORD=%s -e POSTGRES_DB=%s",
-			security.ShellEscape(dbUser), security.ShellEscape(dbPassword), security.ShellEscape(dbName))
-		dockerPort = "5432"
-		databaseURL = fmt.Sprintf("postgresql://%s:%s@%s:%s/%s?serverVersion=%s&charset=utf8",
-			dbUser, dbPassword, dbContainerName, dockerPort, dbName, version)
-
-	case "mysql":
-		version := cfg.Database.Version
-		if version == "" {
-			version = "8.0"
-		}
-		dockerImage = fmt.Sprintf("mysql:%s", version)
-		dockerEnv = fmt.Sprintf("-e MYSQL_ROOT_PASSWORD=%s -e MYSQL_USER=%s -e MYSQL_PASSWORD=%s -e MYSQL_DATABASE=%s",
-			security.ShellEscape(dbPassword), security.ShellEscape(dbUser), security.ShellEscape(dbPassword), security.ShellEscape(dbName))
-		dockerPort = "3306"
-		databaseURL = fmt.Sprintf("mysql://%s:%s@%s:%s/%s?serverVersion=%s&charset=utf8mb4",
-			dbUser, dbPassword, dbContainerName, dockerPort, dbName, version)
-
-	default:
-		return "", fmt.Errorf("unsupported database driver for managed mode: %s", cfg.Database.Driver)
+	// Use configured version or registry default
+	version := cfg.Database.Version
+	if version == "" {
+		version = info.DefaultVersion
 	}
+
+	// Build database configuration from registry
+	dockerImage := info.FullImage(version)
+	dockerEnv := info.BuildEnvArgs(
+		security.ShellEscape(dbUser),
+		security.ShellEscape(dbPassword),
+		security.ShellEscape(dbName),
+	)
+	databaseURL := info.BuildDatabaseURL(dbUser, dbPassword, dbContainerName, dbName, version)
 
 	// Stop and remove existing container if exists (for recreation)
 	stopAndRemoveContainer(ctx, client, dbContainerName)
@@ -795,13 +782,13 @@ func deployManagedDatabase(ctx context.Context, client *ssh.Client, cfg *config.
 		--network %s \
 		--restart unless-stopped \
 		%s \
-		-v %s-data:/var/lib/%s \
+		-v %s-data:%s \
 		%s`,
 		dbContainerName,
 		constants.NetworkName,
 		dockerEnv,
 		dbContainerName,
-		map[string]string{"pgsql": "postgresql/data", "mysql": "mysql"}[cfg.Database.Driver],
+		info.DataVolumePath,
 		dockerImage)
 
 	result, err := client.Exec(ctx, dbRunCmd)
@@ -823,14 +810,12 @@ func deployManagedDatabase(ctx context.Context, client *ssh.Client, cfg *config.
 	// Wait for database to be ready
 	PrintVerbose("Waiting for database to be ready...")
 	for i := 0; i < 30; i++ {
-		var checkCmd string
-		if cfg.Database.Driver == "pgsql" {
-			checkCmd = fmt.Sprintf("docker exec %s pg_isready -U %s", dbContainerName, security.ShellEscape(dbUser))
-		} else {
-			checkCmd = fmt.Sprintf("docker exec %s mysqladmin ping -u%s -p%s --silent",
-				dbContainerName, security.ShellEscape(dbUser), security.ShellEscape(dbPassword))
-		}
-		checkResult, _ := client.Exec(ctx, checkCmd)
+		healthCmd := info.BuildHealthCmd(
+			dbContainerName,
+			security.ShellEscape(dbUser),
+			security.ShellEscape(dbPassword),
+		)
+		checkResult, _ := client.Exec(ctx, healthCmd)
 		if checkResult != nil && checkResult.ExitCode == 0 {
 			break
 		}

--- a/internal/generator/database.go
+++ b/internal/generator/database.go
@@ -2,38 +2,81 @@ package generator
 
 import "fmt"
 
-// DBDriverInfo holds configuration for a database driver used in Docker generation.
+// DBDriverInfo holds configuration for a database driver used in Docker generation and deployment.
 type DBDriverInfo struct {
 	DockerImage    string
 	DefaultVersion string
+	ImageSuffix    string // suffix appended after version for deploy images (e.g., "-alpine")
 	Port           string
 	URLScheme      string
 	URLCharset     string
 	HealthcheckCmd []string
 	DataVolumePath string
 	PHPExtension   string
+
+	// BuildEnvArgs returns Docker env flags (-e ...) for the database container.
+	// Arguments (user, password, dbName) should be pre-escaped for shell safety.
+	BuildEnvArgs func(user, password, dbName string) string
+
+	// BuildHealthCmd returns a command to check if the database is ready.
+	// Arguments (containerName, user, password) should be pre-escaped for shell safety.
+	BuildHealthCmd func(containerName, user, password string) string
+}
+
+// FullImage returns the Docker image reference with version and optional suffix.
+func (d DBDriverInfo) FullImage(version string) string {
+	if version == "" {
+		version = d.DefaultVersion
+	}
+	return fmt.Sprintf("%s:%s%s", d.DockerImage, version, d.ImageSuffix)
+}
+
+// BuildDatabaseURL constructs a Symfony-compatible DATABASE_URL.
+func (d DBDriverInfo) BuildDatabaseURL(user, password, host, dbName, version string) string {
+	if version == "" {
+		version = d.DefaultVersion
+	}
+	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?serverVersion=%s&charset=%s",
+		d.URLScheme, user, password, host, d.Port, dbName, version, d.URLCharset)
 }
 
 var dbDriverRegistry = map[string]DBDriverInfo{
 	"pgsql": {
 		DockerImage:    "postgres",
 		DefaultVersion: "16",
+		ImageSuffix:    "-alpine",
 		Port:           PostgresPort,
 		URLScheme:      "postgresql",
 		URLCharset:     "utf8",
 		HealthcheckCmd: []string{"CMD-SHELL", "pg_isready -U " + DefaultDevDBUser + " -d " + DefaultDevDBName},
 		DataVolumePath: "/var/lib/postgresql/data",
 		PHPExtension:   "pdo_pgsql",
+		BuildEnvArgs: func(user, password, dbName string) string {
+			return fmt.Sprintf("-e POSTGRES_USER=%s -e POSTGRES_PASSWORD=%s -e POSTGRES_DB=%s",
+				user, password, dbName)
+		},
+		BuildHealthCmd: func(containerName, user, _ string) string {
+			return fmt.Sprintf("docker exec %s pg_isready -U %s", containerName, user)
+		},
 	},
 	"mysql": {
 		DockerImage:    "mysql",
 		DefaultVersion: "8.0",
+		ImageSuffix:    "",
 		Port:           MySQLPort,
 		URLScheme:      "mysql",
 		URLCharset:     "utf8mb4",
 		HealthcheckCmd: []string{"CMD", "mysqladmin", "ping", "-h", "localhost"},
 		DataVolumePath: "/var/lib/mysql",
 		PHPExtension:   "pdo_mysql",
+		BuildEnvArgs: func(user, password, dbName string) string {
+			return fmt.Sprintf("-e MYSQL_ROOT_PASSWORD=%s -e MYSQL_USER=%s -e MYSQL_PASSWORD=%s -e MYSQL_DATABASE=%s",
+				password, user, password, dbName)
+		},
+		BuildHealthCmd: func(containerName, user, password string) string {
+			return fmt.Sprintf("docker exec %s mysqladmin ping -u%s -p%s --silent",
+				containerName, user, password)
+		},
 	},
 }
 

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -990,6 +990,135 @@ func TestIsContainerizedDriver(t *testing.T) {
 	}
 }
 
+// ─── DBDriverInfo Methods ────────────────────────────────────────────────────
+
+func TestDBDriverInfo_FullImage(t *testing.T) {
+	tests := []struct {
+		name     string
+		driver   string
+		version  string
+		expected string
+	}{
+		{"pgsql with version", "pgsql", "15", "postgres:15-alpine"},
+		{"pgsql default version", "pgsql", "", "postgres:16-alpine"},
+		{"mysql with version", "mysql", "8.1", "mysql:8.1"},
+		{"mysql default version", "mysql", "", "mysql:8.0"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := GetDBDriverInfo(tt.driver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			result := info.FullImage(tt.version)
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDBDriverInfo_BuildDatabaseURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		driver   string
+		expected string
+	}{
+		{
+			"pgsql URL",
+			"pgsql",
+			"postgresql://user:pass@myapp-db:5432/mydb?serverVersion=16&charset=utf8",
+		},
+		{
+			"mysql URL",
+			"mysql",
+			"mysql://user:pass@myapp-db:3306/mydb?serverVersion=8.0&charset=utf8mb4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := GetDBDriverInfo(tt.driver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			result := info.BuildDatabaseURL("user", "pass", "myapp-db", "mydb", "")
+			if result != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestDBDriverInfo_BuildEnvArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		driver   string
+		contains []string
+	}{
+		{
+			"pgsql env args",
+			"pgsql",
+			[]string{"POSTGRES_USER=testuser", "POSTGRES_PASSWORD=secret", "POSTGRES_DB=testdb"},
+		},
+		{
+			"mysql env args",
+			"mysql",
+			[]string{"MYSQL_ROOT_PASSWORD=secret", "MYSQL_USER=testuser", "MYSQL_PASSWORD=secret", "MYSQL_DATABASE=testdb"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := GetDBDriverInfo(tt.driver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			result := info.BuildEnvArgs("testuser", "secret", "testdb")
+			for _, c := range tt.contains {
+				if !strings.Contains(result, c) {
+					t.Errorf("expected env args to contain %q, got %q", c, result)
+				}
+			}
+		})
+	}
+}
+
+func TestDBDriverInfo_BuildHealthCmd(t *testing.T) {
+	tests := []struct {
+		name     string
+		driver   string
+		contains []string
+	}{
+		{
+			"pgsql health cmd",
+			"pgsql",
+			[]string{"docker exec", "mydb", "pg_isready", "-U testuser"},
+		},
+		{
+			"mysql health cmd",
+			"mysql",
+			[]string{"docker exec", "mydb", "mysqladmin ping", "-utestuser", "-psecret"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			info, err := GetDBDriverInfo(tt.driver)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			result := info.BuildHealthCmd("mydb", "testuser", "secret")
+			for _, c := range tt.contains {
+				if !strings.Contains(result, c) {
+					t.Errorf("expected health cmd to contain %q, got %q", c, result)
+				}
+			}
+		})
+	}
+}
+
 // ─── buildDatabaseURL ────────────────────────────────────────────────────────
 
 func TestComposeGenerator_BuildDatabaseURL(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replace duplicated switch/case in `deployManagedDatabase` with `GetDBDriverInfo()` from the generator registry
- Extend `DBDriverInfo` with deploy-specific fields: `ImageSuffix`, `BuildEnvArgs`, `BuildHealthCmd`
- Add `FullImage()` and `BuildDatabaseURL()` methods on `DBDriverInfo` for reusable image/URL construction
- The registry is now the single source of truth for all database driver metadata (images, ports, env vars, health checks, URLs, volumes)

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] New tests cover `FullImage`, `BuildDatabaseURL`, `BuildEnvArgs`, `BuildHealthCmd` for both pgsql and mysql
- [x] `go vet` clean

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)