### PR TITLE
refactor(deploy): wire HealthChecker into deploy path (#21)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -492,7 +492,8 @@ func rollbackNewContainer(ctx context.Context, client *ssh.Client, state *deploy
 	}
 }
 
-// runHealthCheckOnContainer runs a health check against a specific container name.
+// runHealthCheckOnContainer runs a health check against a specific container name
+// using the centralized HealthChecker with retries, timeout, and proper status code parsing.
 func runHealthCheckOnContainer(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, containerName string) error {
 	healthPath := cfg.Deploy.HealthcheckPath
 	if healthPath == "" {
@@ -503,20 +504,16 @@ func runHealthCheckOnContainer(ctx context.Context, client *ssh.Client, cfg *con
 		return fmt.Errorf("invalid health check path: %w", err)
 	}
 
-	// Wait for container to be ready
-	time.Sleep(5 * time.Second)
+	// Wait for container to be ready before health checks
+	time.Sleep(constants.PreHealthSleep)
 
-	// Check container is running
-	result, err := client.Exec(ctx, fmt.Sprintf("docker ps --filter name=%s --format '{{.Status}}'", containerName))
-	if err != nil || result.Stdout == "" {
-		return fmt.Errorf("container %s not running", containerName)
+	hc := deploy.NewHealthChecker(client, containerName, healthPath, constants.AppPort)
+	result, err := hc.Check(ctx)
+	if err != nil {
+		return fmt.Errorf("health check error: %w", err)
 	}
-
-	// Check health endpoint (port 8080 for non-root execution)
-	healthCmd := fmt.Sprintf("docker exec %s curl -sf http://localhost:%s%s", containerName, constants.AppPort, healthPath)
-	result, err = client.Exec(ctx, healthCmd)
-	if err != nil || result.ExitCode != 0 {
-		return fmt.Errorf("health check failed on %s", containerName)
+	if !result.Healthy {
+		return fmt.Errorf("health check failed on %s: %s (after %d attempts)", containerName, result.Message, result.Attempts)
 	}
 
 	return nil

--- a/internal/deploy/health.go
+++ b/internal/deploy/health.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/yoanbernabeu/frankendeploy/internal/constants"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
 )
 
@@ -14,20 +15,22 @@ type HealthChecker struct {
 	client      ssh.Executor
 	containerID string
 	path        string
+	port        string
 	timeout     time.Duration
 	retries     int
 	interval    time.Duration
 }
 
-// NewHealthChecker creates a new health checker
-func NewHealthChecker(client ssh.Executor, containerID, path string) *HealthChecker {
+// NewHealthChecker creates a new health checker with sensible defaults from constants.
+func NewHealthChecker(client ssh.Executor, containerID, path, port string) *HealthChecker {
 	return &HealthChecker{
 		client:      client,
 		containerID: containerID,
 		path:        path,
-		timeout:     30 * time.Second,
-		retries:     5,
-		interval:    2 * time.Second,
+		port:        port,
+		timeout:     constants.HealthCheckTimeout,
+		retries:     constants.HealthCheckRetries,
+		interval:    constants.HealthCheckInterval,
 	}
 }
 
@@ -85,21 +88,27 @@ func (h *HealthChecker) Check(ctx context.Context) (*HealthResult, error) {
 		// Check HTTP endpoint
 		start := time.Now()
 		healthCmd := fmt.Sprintf(
-			"docker exec %s curl -sf -w '%%{http_code}' -o /dev/null http://localhost%s",
-			h.containerID, h.path)
+			"docker exec %s curl -sf -w '%%{http_code}' -o /dev/null http://localhost:%s%s",
+			h.containerID, h.port, h.path)
 
 		httpCheck, err := h.client.Exec(ctx, healthCmd)
 		result.ResponseTime = time.Since(start)
 
 		if err == nil && httpCheck.ExitCode == 0 {
 			result.Healthy = true
-			result.StatusCode = 200
+			result.StatusCode = 200 // default if parsing fails
+			if httpCheck.Stdout != "" {
+				var code int
+				if n, scanErr := fmt.Sscanf(strings.TrimSpace(httpCheck.Stdout), "%d", &code); n == 1 && scanErr == nil {
+					result.StatusCode = code
+				}
+			}
 			result.Message = "healthy"
 			return result, nil
 		}
 
 		// Parse status code from output
-		if httpCheck.Stdout != "" {
+		if httpCheck != nil && httpCheck.Stdout != "" {
 			if n, scanErr := fmt.Sscanf(httpCheck.Stdout, "%d", &result.StatusCode); n == 0 || scanErr != nil {
 				result.StatusCode = 0
 			}

--- a/internal/deploy/health_test.go
+++ b/internal/deploy/health_test.go
@@ -23,7 +23,7 @@ func TestHealthChecker_Check_Healthy(t *testing.T) {
 		},
 	}
 
-	hc := NewHealthChecker(mock, "test-app", "/healthz")
+	hc := NewHealthChecker(mock, "test-app", "/healthz", "8080")
 	hc.SetTimeout(10 * time.Second)
 	hc.SetRetries(3)
 	hc.SetInterval(100 * time.Millisecond)
@@ -38,6 +38,40 @@ func TestHealthChecker_Check_Healthy(t *testing.T) {
 	if result.Attempts != 1 {
 		t.Errorf("expected 1 attempt, got %d", result.Attempts)
 	}
+	if result.StatusCode != 200 {
+		t.Errorf("expected status code 200, got %d", result.StatusCode)
+	}
+}
+
+func TestHealthChecker_Check_ParsesActualStatusCode(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
+			}
+			if strings.Contains(command, "curl") {
+				// Simulate a 204 No Content response
+				return &ssh.ExecResult{Stdout: "204", ExitCode: 0}, nil
+			}
+			return &ssh.ExecResult{}, nil
+		},
+	}
+
+	hc := NewHealthChecker(mock, "test-app", "/healthz", "8080")
+	hc.SetTimeout(10 * time.Second)
+	hc.SetRetries(3)
+	hc.SetInterval(100 * time.Millisecond)
+
+	result, err := hc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Errorf("expected healthy, got message: %s", result.Message)
+	}
+	if result.StatusCode != 204 {
+		t.Errorf("expected status code 204, got %d", result.StatusCode)
+	}
 }
 
 func TestHealthChecker_Check_ContainerNotRunning(t *testing.T) {
@@ -50,7 +84,7 @@ func TestHealthChecker_Check_ContainerNotRunning(t *testing.T) {
 		},
 	}
 
-	hc := NewHealthChecker(mock, "test-app", "/")
+	hc := NewHealthChecker(mock, "test-app", "/", "8080")
 	hc.SetTimeout(2 * time.Second)
 	hc.SetRetries(2)
 	hc.SetInterval(100 * time.Millisecond)
@@ -78,7 +112,7 @@ func TestHealthChecker_Check_Timeout(t *testing.T) {
 		},
 	}
 
-	hc := NewHealthChecker(mock, "test-app", "/")
+	hc := NewHealthChecker(mock, "test-app", "/", "8080")
 	hc.SetTimeout(500 * time.Millisecond)
 	hc.SetRetries(10)
 	hc.SetInterval(100 * time.Millisecond)
@@ -89,6 +123,33 @@ func TestHealthChecker_Check_Timeout(t *testing.T) {
 	}
 	if result.Healthy {
 		t.Error("expected unhealthy due to timeout")
+	}
+}
+
+func TestHealthChecker_Check_PortInCurlCommand(t *testing.T) {
+	var capturedCmd string
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
+			}
+			if strings.Contains(command, "curl") {
+				capturedCmd = command
+				return &ssh.ExecResult{Stdout: "200", ExitCode: 0}, nil
+			}
+			return &ssh.ExecResult{}, nil
+		},
+	}
+
+	hc := NewHealthChecker(mock, "test-app", "/health", "8080")
+	hc.SetRetries(1)
+
+	_, err := hc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(capturedCmd, "localhost:8080/health") {
+		t.Errorf("expected curl command to contain 'localhost:8080/health', got: %s", capturedCmd)
 	}
 }
 
@@ -109,7 +170,7 @@ func TestHealthChecker_CheckContainer(t *testing.T) {
 					return &ssh.ExecResult{Stdout: tt.stdout, ExitCode: 0}, nil
 				},
 			}
-			hc := NewHealthChecker(mock, "test-app", "/")
+			hc := NewHealthChecker(mock, "test-app", "/", "8080")
 			running, err := hc.CheckContainer(context.Background())
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
## Summary

- Replace duplicate health check in `deploy.go` with the centralized `HealthChecker` from `deploy/health.go`
- Add `port` parameter to `NewHealthChecker` — the old implementation was missing the port in the curl URL (would hit port 80 instead of 8080)
- Wire health check constants (`PreHealthSleep`, `HealthCheckTimeout`, `HealthCheckRetries`, `HealthCheckInterval`) as defaults
- Fix status code bug: parse actual HTTP status code from curl output instead of hardcoding 200 (a 204 response was incorrectly reported as 200)

## Test plan

- [x] All existing tests pass (`go test -race ./...`)
- [x] New test verifies actual status code parsing (204 case)
- [x] New test verifies port is correctly included in curl command
- [x] `go vet` clean

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)