### PR TITLE
refactor(deploy): accept ssh.Executor for testability (#25)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -120,7 +120,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	if deployRemoteBuild {
 		// Remote build: transfer source code and build on server
 		PrintInfo("Transferring source code to server...")
-		if err := transferSourceCode(client, serverCfg, projectCfg.Name, remoteAppPath); err != nil {
+		if err := transferSourceCode(ctx, client, serverCfg, projectCfg.Name, remoteAppPath); err != nil {
 			return fmt.Errorf("transfer failed: %w", err)
 		}
 		PrintSuccess("Source code transferred")
@@ -276,7 +276,7 @@ func buildDockerImage(imageName string) error {
 	return dockerCmd.Run()
 }
 
-func transferImage(ctx context.Context, client *ssh.Client, serverCfg *config.ServerConfig, imageName string) error {
+func transferImage(ctx context.Context, client ssh.Executor, serverCfg *config.ServerConfig, imageName string) error {
 	// Save image to tar
 	tarPath := fmt.Sprintf("/tmp/%s.tar", strings.ReplaceAll(imageName, ":", "-"))
 
@@ -318,10 +318,10 @@ func transferImage(ctx context.Context, client *ssh.Client, serverCfg *config.Se
 	return nil
 }
 
-func transferSourceCode(client *ssh.Client, serverCfg *config.ServerConfig, appName, appPath string) error {
+func transferSourceCode(ctx context.Context, client ssh.Executor, serverCfg *config.ServerConfig, appName, appPath string) error {
 	// Create build directory on server
 	buildPath := fmt.Sprintf("%s/build", appPath)
-	if _, err := client.Exec(context.Background(), fmt.Sprintf("rm -rf %s && mkdir -p %s", buildPath, buildPath)); err != nil {
+	if _, err := client.Exec(ctx, fmt.Sprintf("rm -rf %s && mkdir -p %s", buildPath, buildPath)); err != nil {
 		return fmt.Errorf("failed to create build directory: %w", err)
 	}
 
@@ -352,7 +352,7 @@ func transferSourceCode(client *ssh.Client, serverCfg *config.ServerConfig, appN
 	return nil
 }
 
-func buildDockerImageRemote(ctx context.Context, client *ssh.Client, imageName, appPath string) error {
+func buildDockerImageRemote(ctx context.Context, client ssh.Executor, imageName, appPath string) error {
 	buildPath := fmt.Sprintf("%s/build", appPath)
 
 	// Build Docker image on the server
@@ -375,7 +375,7 @@ func buildDockerImageRemote(ctx context.Context, client *ssh.Client, imageName, 
 }
 
 // prepareRelease creates the release directory, shared directories and files, and fixes permissions.
-func prepareRelease(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, appPath, tag string) error {
+func prepareRelease(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, appPath, tag string) error {
 	releasePath := filepath.Join(appPath, "releases", tag)
 	sharedPath := filepath.Join(appPath, "shared")
 
@@ -416,7 +416,7 @@ func prepareRelease(ctx context.Context, client *ssh.Client, cfg *config.Project
 
 // startNewContainer starts the new version with a temporary container name.
 // The old container remains running for zero-downtime deployment.
-func startNewContainer(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, imageName, appPath, tag, databaseURL, containerName string) error {
+func startNewContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, imageName, appPath, tag, databaseURL, containerName string) error {
 	sharedPath := filepath.Join(appPath, "shared")
 
 	sharedDirs := cfg.Deploy.EffectiveSharedDirs()
@@ -454,7 +454,7 @@ func startNewContainer(ctx context.Context, client *ssh.Client, cfg *config.Proj
 }
 
 // swapContainers performs the atomic swap: stop old container, rename new → final, update symlink.
-func swapContainers(ctx context.Context, client *ssh.Client, appName, appPath, tag, tempContainerName string) error {
+func swapContainers(ctx context.Context, client ssh.Executor, appName, appPath, tag, tempContainerName string) error {
 	releasePath := filepath.Join(appPath, "releases", tag)
 	currentPath := filepath.Join(appPath, "current")
 
@@ -470,11 +470,20 @@ func swapContainers(ctx context.Context, client *ssh.Client, appName, appPath, t
 		return fmt.Errorf("failed to rename container: %w", err)
 	}
 
-	// Update current symlink and save release info
-	if _, err := client.Exec(ctx, fmt.Sprintf("ln -sfn %s %s", releasePath, currentPath)); err != nil {
+	// Update current symlink (critical step — surface any non-zero exit code)
+	symlinkResult, err := client.Exec(ctx, fmt.Sprintf("ln -sfn %s %s", releasePath, currentPath))
+	if err != nil {
 		return fmt.Errorf("failed to update symlink: %w", err)
 	}
-	if _, err := client.Exec(ctx, fmt.Sprintf("echo '%s' > %s/release", tag, releasePath)); err != nil {
+	if err := symlinkResult.Err(); err != nil {
+		return fmt.Errorf("failed to update symlink: %w", err)
+	}
+
+	// Save release marker (best-effort)
+	releaseResult, err := client.Exec(ctx, fmt.Sprintf("echo '%s' > %s/release", tag, releasePath))
+	if err != nil {
+		PrintVerbose("Could not write release file: %v", err)
+	} else if err := releaseResult.Err(); err != nil {
 		PrintVerbose("Could not write release file: %v", err)
 	}
 
@@ -482,7 +491,7 @@ func swapContainers(ctx context.Context, client *ssh.Client, appName, appPath, t
 }
 
 // rollbackNewContainer removes the temporary new container, leaving the old one intact.
-func rollbackNewContainer(ctx context.Context, client *ssh.Client, state *deploy.DeployState) {
+func rollbackNewContainer(ctx context.Context, client ssh.Executor, state *deploy.DeployState) {
 	actions := state.RollbackActions()
 	for _, action := range actions {
 		PrintVerboseCommand(action)
@@ -494,7 +503,7 @@ func rollbackNewContainer(ctx context.Context, client *ssh.Client, state *deploy
 
 // runHealthCheckOnContainer runs a health check against a specific container name
 // using the centralized HealthChecker with retries, timeout, and proper status code parsing.
-func runHealthCheckOnContainer(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, containerName string) error {
+func runHealthCheckOnContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, containerName string) error {
 	healthPath := cfg.Deploy.HealthcheckPath
 	if healthPath == "" {
 		healthPath = "/"
@@ -544,7 +553,7 @@ func buildVolumeMounts(sharedPath string, sharedDirs, sharedFiles []string) stri
 }
 
 // fixSharedPermissions ensures shared directories and files have correct ownership for container user 1000:1000
-func fixSharedPermissions(ctx context.Context, client *ssh.Client, sharedPath string, sharedDirs, sharedFiles []string) {
+func fixSharedPermissions(ctx context.Context, client ssh.Executor, sharedPath string, sharedDirs, sharedFiles []string) {
 	// Fix ownership of shared directory itself
 	cmd := fmt.Sprintf("sudo chown %s %s 2>/dev/null || true", constants.ContainerUser, sharedPath)
 	PrintVerboseCommand(cmd)
@@ -586,7 +595,7 @@ func fixSharedPermissions(ctx context.Context, client *ssh.Client, sharedPath st
 	}
 }
 
-func updateCaddyConfig(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig) error {
+func updateCaddyConfig(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig) error {
 	domain := cfg.Deploy.Domain
 	if domain == "" {
 		fmt.Println()
@@ -629,7 +638,7 @@ func updateCaddyConfig(ctx context.Context, client *ssh.Client, cfg *config.Proj
 	return nil
 }
 
-func cleanupOldReleases(ctx context.Context, client *ssh.Client, appPath string, keepReleases int) {
+func cleanupOldReleases(ctx context.Context, client ssh.Executor, appPath string, keepReleases int) {
 	if keepReleases <= 0 {
 		keepReleases = constants.DefaultKeepReleases
 	}
@@ -645,7 +654,7 @@ func cleanupOldReleases(ctx context.Context, client *ssh.Client, appPath string,
 }
 
 // runDeployHooks executes deployment hooks inside the container
-func runDeployHooks(ctx context.Context, client *ssh.Client, containerName string, hooks []string) error {
+func runDeployHooks(ctx context.Context, client ssh.Executor, containerName string, hooks []string) error {
 	for _, hook := range hooks {
 		// Validate hook command before execution
 		if err := security.ValidateDockerCommand(hook); err != nil {
@@ -666,7 +675,7 @@ func runDeployHooks(ctx context.Context, client *ssh.Client, containerName strin
 }
 
 // deployMessengerWorkers starts Messenger worker containers
-func deployMessengerWorkers(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, imageName, appPath, databaseURL string) error {
+func deployMessengerWorkers(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, imageName, appPath, databaseURL string) error {
 	workerName := fmt.Sprintf("%s-worker", cfg.Name)
 	workers := cfg.Messenger.Workers
 	if workers <= 0 {
@@ -727,7 +736,7 @@ func deployMessengerWorkers(ctx context.Context, client *ssh.Client, cfg *config
 }
 
 // deployManagedDatabase creates and manages a database container for the app
-func deployManagedDatabase(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, appPath string) (string, error) {
+func deployManagedDatabase(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, appPath string) (string, error) {
 	dbContainerName := fmt.Sprintf("%s-db", cfg.Name)
 	dbName := strings.ReplaceAll(cfg.Name, "-", "_")
 	credentialsFile := filepath.Join(appPath, "shared", ".db_credentials")
@@ -832,7 +841,7 @@ func generateRandomPassword(length int) (string, error) {
 }
 
 // runEnvPreflightCheck verifies required environment variables before deployment
-func runEnvPreflightCheck(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, serverName string) error {
+func runEnvPreflightCheck(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, serverName string) error {
 	result, err := deploy.CheckEnvVars(ctx, client, cfg, serverName)
 	if err != nil {
 		return fmt.Errorf("failed to check environment variables: %w", err)
@@ -863,7 +872,7 @@ func runEnvPreflightCheck(ctx context.Context, client *ssh.Client, cfg *config.P
 }
 
 // handleInteractiveEnvCheck handles missing env vars in interactive mode
-func handleInteractiveEnvCheck(ctx context.Context, client *ssh.Client, cfg *config.ProjectConfig, result *deploy.EnvCheckResult, serverName string) error {
+func handleInteractiveEnvCheck(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, result *deploy.EnvCheckResult, serverName string) error {
 	// Show missing variables
 	PrintWarning("Missing required environment variables:")
 	for _, req := range result.Missing {
@@ -940,7 +949,7 @@ func handleInteractiveEnvCheck(ctx context.Context, client *ssh.Client, cfg *con
 }
 
 // checkAndWarnMigrationState checks for empty migrations and warns once per app
-func checkAndWarnMigrationState(ctx context.Context, client *ssh.Client, appName string) {
+func checkAndWarnMigrationState(ctx context.Context, client ssh.Executor, appName string) {
 	// Check migration state inside the container
 	result, err := deploy.CheckMigrationState(ctx, client, appName)
 	if err != nil {

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -1,8 +1,13 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
 )
 
 func TestBuildVolumeMounts(t *testing.T) {
@@ -66,5 +71,229 @@ func TestBuildVolumeMounts(t *testing.T) {
 				t.Errorf("buildVolumeMounts() = %q, expected empty", result)
 			}
 		})
+	}
+}
+
+// hasCommand returns true if any recorded command contains substr.
+func hasCommand(cmds []string, substr string) bool {
+	for _, c := range cmds {
+		if strings.Contains(c, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPrepareRelease_IssuesExpectedCommands(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Deploy: config.DeployConfig{
+			SharedDirs:  []string{"var/log", "var/sessions"},
+			SharedFiles: []string{".env.local"},
+		},
+	}
+
+	if err := prepareRelease(context.Background(), mock, cfg, "/opt/frankendeploy/apps/myapp", "20260420-120000"); err != nil {
+		t.Fatalf("prepareRelease() unexpected error: %v", err)
+	}
+
+	wantSubstrings := []string{
+		"mkdir -p /opt/frankendeploy/apps/myapp/releases/20260420-120000",
+		"mkdir -p /opt/frankendeploy/apps/myapp/shared",
+		"mkdir -p /opt/frankendeploy/apps/myapp/shared/var/log",
+		"mkdir -p /opt/frankendeploy/apps/myapp/shared/var/sessions",
+		"touch /opt/frankendeploy/apps/myapp/shared/.env.local",
+	}
+	for _, want := range wantSubstrings {
+		if !hasCommand(mock.Commands, want) {
+			t.Errorf("prepareRelease() missing expected command: %q\nrecorded: %v", want, mock.Commands)
+		}
+	}
+}
+
+func TestPrepareRelease_SurfacesNonZeroExit(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			return &ssh.ExecResult{ExitCode: 1, Stderr: "permission denied"}, nil
+		},
+	}
+	cfg := &config.ProjectConfig{
+		Name:   "myapp",
+		Deploy: config.DeployConfig{},
+	}
+
+	err := prepareRelease(context.Background(), mock, cfg, "/opt/frankendeploy/apps/myapp", "t1")
+	if err == nil {
+		t.Fatal("prepareRelease() expected error on non-zero exit code, got nil")
+	}
+}
+
+func TestStartNewContainer_BuildsDockerRunCommand(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Deploy: config.DeployConfig{
+			SharedDirs:  []string{"var/log"},
+			SharedFiles: []string{".env.local"},
+		},
+	}
+
+	err := startNewContainer(
+		context.Background(), mock, cfg,
+		"myapp:t1",
+		"/opt/frankendeploy/apps/myapp",
+		"t1",
+		"postgres://user:pwd@myapp-db:5432/db",
+		"myapp-new",
+	)
+	if err != nil {
+		t.Fatalf("startNewContainer() unexpected error: %v", err)
+	}
+
+	// Should force-remove any leftover temp container first
+	if !hasCommand(mock.Commands, "docker rm -f myapp-new") {
+		t.Errorf("expected force-remove of temp container, got: %v", mock.Commands)
+	}
+
+	// Should issue a docker run with the expected flags
+	wantFragments := []string{
+		"docker run -d --name myapp-new",
+		"--network frankendeploy",
+		"--restart unless-stopped",
+		"--user 1000:1000",
+		"-e SERVER_NAME=:8080",
+		"-e APP_ENV=prod",
+		"-e DATABASE_URL=",
+		"-v /opt/frankendeploy/apps/myapp/shared/var/log:/app/var/log",
+		"-v /opt/frankendeploy/apps/myapp/shared/.env.local:/app/.env.local:ro",
+		"myapp:t1",
+	}
+	for _, want := range wantFragments {
+		if !hasCommand(mock.Commands, want) {
+			t.Errorf("startNewContainer() missing fragment %q\nrecorded: %v", want, mock.Commands)
+		}
+	}
+}
+
+func TestSwapContainers_HappyPath(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+
+	err := swapContainers(
+		context.Background(), mock,
+		"myapp",
+		"/opt/frankendeploy/apps/myapp",
+		"t1",
+		"myapp-new",
+	)
+	if err != nil {
+		t.Fatalf("swapContainers() unexpected error: %v", err)
+	}
+
+	wantOrdered := []string{
+		"docker rename myapp-new myapp",
+		"ln -sfn /opt/frankendeploy/apps/myapp/releases/t1 /opt/frankendeploy/apps/myapp/current",
+	}
+	for _, want := range wantOrdered {
+		if !hasCommand(mock.Commands, want) {
+			t.Errorf("swapContainers() missing command %q\nrecorded: %v", want, mock.Commands)
+		}
+	}
+}
+
+func TestSwapContainers_SymlinkFailureSurfaces(t *testing.T) {
+	// Guards the bug fix: a non-zero exit code from `ln -sfn` must be surfaced
+	// as an error instead of being silently ignored.
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.HasPrefix(command, "ln -sfn ") {
+				return &ssh.ExecResult{ExitCode: 1, Stderr: "permission denied"}, nil
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	err := swapContainers(
+		context.Background(), mock,
+		"myapp",
+		"/opt/frankendeploy/apps/myapp",
+		"t1",
+		"myapp-new",
+	)
+	if err == nil {
+		t.Fatal("swapContainers() expected error when symlink update fails, got nil")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Errorf("expected symlink error, got: %v", err)
+	}
+}
+
+func TestCleanupOldReleases_ConstructsCorrectCommand(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+
+	cleanupOldReleases(context.Background(), mock, "/opt/frankendeploy/apps/myapp", 3)
+
+	want := "cd /opt/frankendeploy/apps/myapp/releases && ls -1t | tail -n +4 | xargs -r rm -rf"
+	if !hasCommand(mock.Commands, want) {
+		t.Errorf("cleanupOldReleases() missing expected command %q\nrecorded: %v", want, mock.Commands)
+	}
+}
+
+func TestCleanupOldReleases_DefaultKeepReleases(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+
+	cleanupOldReleases(context.Background(), mock, "/opt/frankendeploy/apps/myapp", 0)
+
+	// Default is 5, so tail -n +6
+	want := "tail -n +6"
+	if !hasCommand(mock.Commands, want) {
+		t.Errorf("cleanupOldReleases() should default to keep=5 (tail -n +6), got: %v", mock.Commands)
+	}
+}
+
+func TestTransferSourceCode_PropagatesContext(t *testing.T) {
+	// Guards the bug fix: the function must use the propagated ctx instead of context.Background().
+	type ctxKey string
+	const key ctxKey = "trace"
+	seen := ""
+
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if v, ok := ctx.Value(key).(string); ok {
+				seen = v
+			}
+			// Return an error so transferSourceCode returns before rsync runs externally.
+			return nil, fmt.Errorf("mocked failure to short-circuit rsync")
+		},
+	}
+
+	ctx := context.WithValue(context.Background(), key, "propagated")
+	_ = transferSourceCode(
+		ctx, mock,
+		&config.ServerConfig{Host: "example", User: "deploy", Port: 22},
+		"myapp",
+		"/opt/frankendeploy/apps/myapp",
+	)
+
+	if seen != "propagated" {
+		t.Errorf("transferSourceCode() did not propagate ctx to client.Exec; seen=%q", seen)
+	}
+}
+
+func TestRunHealthCheckOnContainer_RejectsInvalidHealthPath(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Deploy: config.DeployConfig{
+			HealthcheckPath: "../../etc/passwd",
+		},
+	}
+
+	err := runHealthCheckOnContainer(context.Background(), mock, cfg, "myapp-new")
+	if err == nil {
+		t.Fatal("runHealthCheckOnContainer() expected error for invalid health path, got nil")
+	}
+	if len(mock.Commands) != 0 {
+		t.Errorf("runHealthCheckOnContainer() should not execute any command on invalid path, got: %v", mock.Commands)
 	}
 }


### PR DESCRIPTION
## Summary

Migrates the remaining deploy orchestration functions in `internal/cmd/deploy.go` from `*ssh.Client` to the `ssh.Executor` interface. This is the last area of the codebase not using the Executor pattern — it was already in place in `internal/deploy` and `internal/cmd/docker_helpers.go`.

`*ssh.Client` already satisfies `ssh.Executor`, so `runDeploy` and no other caller needs changes. `checkArchitectureMismatch` keeps `*ssh.Client` because it calls `GetServerArchitecture`, which is only defined on the concrete client.

## Changes

- Migrate 8 orchestration functions + 9 coupled helpers to accept `ssh.Executor`
- **Bug fix**: `swapContainers` now checks `result.Err()` on `ln -sfn` (symlink update). Previously a non-zero exit from that critical step was silently swallowed.
- **Bug fix**: `transferSourceCode` uses the propagated `ctx` instead of `context.Background()`.
- Add 7 unit tests in `deploy_test.go` using `ssh.MockExecutor` (prepareRelease happy path + non-zero exit, startNewContainer docker-run fragments, swapContainers happy path + symlink failure guard, cleanupOldReleases command construction + default keep-releases, transferSourceCode ctx propagation guard, runHealthCheckOnContainer invalid-path guard).

## Test Plan

- [x] `make test` — all packages pass (race detector on)
- [x] `go build ./...` — compiles
- [x] `make build` + `./bin/frankendeploy --help` + `./bin/frankendeploy deploy --help` — CLI functional, signatures preserved
- [x] Lint: no new issues introduced (12 pre-existing errcheck/staticcheck issues identical on main)
- [ ] CI (GitHub Actions)

## Related Issue

Closes #25

---
🤖 Generated with [Claude Code](https://claude.ai/code)