### PR TITLE
refactor: remove dead code and fix env/key detection quirks (#26)

### DIFF
--- a/internal/caddy/config.go
+++ b/internal/caddy/config.go
@@ -24,17 +24,12 @@ type AppConfig struct {
 	Name   string
 	Domain string
 	Port   int
-	TLS    bool
 }
 
 // GenerateAppConfig generates Caddy config for an application
 func (g *ConfigGenerator) GenerateAppConfig(app AppConfig) (string, error) {
 	tmpl := `# {{ .Name }}
 {{ .Domain }} {
-{{- if not .TLS }}
-    tls internal
-{{- end }}
-
     reverse_proxy {{ .Name }}:{{ .Port }} {
         health_uri /
         health_interval 30s
@@ -105,7 +100,6 @@ func AppConfigFromProject(cfg *config.ProjectConfig, domain string) AppConfig {
 		Name:   cfg.Name,
 		Domain: domain,
 		Port:   port,
-		TLS:    true,
 	}
 }
 
@@ -115,14 +109,6 @@ func ReloadCommands() []string {
 	return []string{
 		// Reload Caddy config inside container via Admin API (zero downtime)
 		`docker exec caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile && echo "Caddy config reloaded"`,
-	}
-}
-
-// ReloadCommandsFallback returns fallback reload command if graceful reload fails
-func ReloadCommandsFallback() []string {
-	return []string{
-		// Restart container (brief downtime, last resort)
-		`docker restart caddy`,
 	}
 }
 

--- a/internal/caddy/config_test.go
+++ b/internal/caddy/config_test.go
@@ -1,0 +1,34 @@
+package caddy
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateAppConfig_DoesNotEmitTLSInternal(t *testing.T) {
+	// The `tls internal` branch was unreachable since AppConfigFromProject
+	// always left TLS as the default. The field and branch were removed —
+	// this test guards against accidental reintroduction.
+	gen := NewConfigGenerator()
+	out, err := gen.GenerateAppConfig(AppConfig{
+		Name:   "myapp",
+		Domain: "example.com",
+		Port:   8080,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAppConfig: %v", err)
+	}
+	if strings.Contains(out, "tls internal") {
+		t.Errorf("generated config should not contain 'tls internal':\n%s", out)
+	}
+	wantFragments := []string{
+		"example.com {",
+		"reverse_proxy myapp:8080",
+		"encode zstd gzip",
+	}
+	for _, want := range wantFragments {
+		if !strings.Contains(out, want) {
+			t.Errorf("generated config missing %q\n%s", want, out)
+		}
+	}
+}

--- a/internal/deploy/envcheck.go
+++ b/internal/deploy/envcheck.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
@@ -235,10 +236,18 @@ func parseEnvContent(content string) map[string]string {
 	return vars
 }
 
-// buildEnvContent builds .env file content from a map
+// buildEnvContent builds .env file content from a map.
+// Keys are sorted alphabetically so repeated writes produce stable diffs.
 func buildEnvContent(vars map[string]string) string {
-	var lines []string
-	for key, value := range vars {
+	keys := make([]string, 0, len(vars))
+	for k := range vars {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	lines := make([]string, 0, len(keys))
+	for _, key := range keys {
+		value := vars[key]
 		// Quote values with spaces or special characters
 		if strings.ContainsAny(value, " \t\n\"'") {
 			value = fmt.Sprintf("\"%s\"", value)

--- a/internal/deploy/envcheck_test.go
+++ b/internal/deploy/envcheck_test.go
@@ -284,6 +284,31 @@ func TestBuildEnvContent(t *testing.T) {
 	}
 }
 
+// TestBuildEnvContent_DeterministicOrdering guards the fix for non-deterministic
+// ordering that produced noisy diffs on every env file rewrite.
+func TestBuildEnvContent_DeterministicOrdering(t *testing.T) {
+	vars := map[string]string{
+		"ZEBRA":       "z",
+		"APP_ENV":     "prod",
+		"DATABASE_URL": "postgres://u:p@h/db",
+		"APP_SECRET":  "abc",
+	}
+
+	// Calling buildEnvContent repeatedly must produce the exact same bytes.
+	first := buildEnvContent(vars)
+	for i := 0; i < 20; i++ {
+		if got := buildEnvContent(vars); got != first {
+			t.Fatalf("buildEnvContent() is non-deterministic:\nfirst=%q\ngot  =%q", first, got)
+		}
+	}
+
+	// Keys must appear in alphabetical order.
+	want := "APP_ENV=prod\nAPP_SECRET=abc\nDATABASE_URL=postgres://u:p@h/db\nZEBRA=z\n"
+	if first != want {
+		t.Errorf("buildEnvContent() = %q, want %q", first, want)
+	}
+}
+
 // Helper function for bool pointers
 func boolPtr(b bool) *bool {
 	return &b

--- a/internal/ssh/keys.go
+++ b/internal/ssh/keys.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"bytes"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -126,28 +128,36 @@ func isPassphraseError(err error) bool {
 		strings.Contains(errStr, "ENCRYPTED")
 }
 
-// detectKeyType attempts to detect the key type from the key data
+// detectKeyType attempts to detect the key type from the key data.
+// For legacy PEM types the header is authoritative. For modern OpenSSH keys,
+// the PEM header is always "OPENSSH PRIVATE KEY" regardless of the underlying
+// algorithm, so we PEM-decode and inspect the binary blob for the key-type
+// marker (e.g. "ssh-ed25519", "ssh-rsa", "ecdsa-sha2-*", "ssh-dss").
 func detectKeyType(data []byte) string {
 	content := string(data)
 
-	if strings.Contains(content, "OPENSSH PRIVATE KEY") {
-		// Modern OpenSSH format - need to look for type hints
-		if strings.Contains(content, "ed25519") ||
-			strings.Contains(strings.ToLower(content), "ed25519") {
-			return "ed25519"
-		}
-		// For OpenSSH format, we default to ed25519 if no type hint is found
-		// as it's the modern default
-		return "ed25519"
-	}
-	if strings.Contains(content, "RSA PRIVATE KEY") {
+	switch {
+	case strings.Contains(content, "-----BEGIN RSA PRIVATE KEY-----"):
 		return "rsa"
-	}
-	if strings.Contains(content, "EC PRIVATE KEY") {
+	case strings.Contains(content, "-----BEGIN EC PRIVATE KEY-----"):
 		return "ecdsa"
-	}
-	if strings.Contains(content, "DSA PRIVATE KEY") {
+	case strings.Contains(content, "-----BEGIN DSA PRIVATE KEY-----"):
 		return "dsa"
+	case strings.Contains(content, "-----BEGIN OPENSSH PRIVATE KEY-----"):
+		if block, _ := pem.Decode(data); block != nil {
+			switch {
+			case bytes.Contains(block.Bytes, []byte("ssh-ed25519")),
+				bytes.Contains(block.Bytes, []byte("sk-ssh-ed25519")):
+				return "ed25519"
+			case bytes.Contains(block.Bytes, []byte("ssh-rsa")):
+				return "rsa"
+			case bytes.Contains(block.Bytes, []byte("ecdsa-sha2")),
+				bytes.Contains(block.Bytes, []byte("sk-ecdsa-sha2")):
+				return "ecdsa"
+			case bytes.Contains(block.Bytes, []byte("ssh-dss")):
+				return "dsa"
+			}
+		}
 	}
 
 	return "unknown"

--- a/internal/ssh/keys_test.go
+++ b/internal/ssh/keys_test.go
@@ -1,6 +1,8 @@
 package ssh
 
 import (
+	"bytes"
+	"encoding/pem"
 	"os"
 	"path/filepath"
 	"testing"
@@ -98,6 +100,42 @@ L2VqAHZG6v4r7hYWQCK1H4D8pL8f5F0c3H4B7vH8L7sFQE7dH1pQ2s8GlJ1DsB0W
 			})
 		}
 	})
+}
+
+// TestDetectKeyType_OpenSSHFormat verifies that for keys stored in the modern
+// OpenSSH format ("-----BEGIN OPENSSH PRIVATE KEY-----"), the algorithm is
+// identified from the decoded binary blob rather than defaulted to ed25519.
+// Guards against the prior bug where an RSA key in OpenSSH format would be
+// misclassified as ed25519.
+func TestDetectKeyType_OpenSSHFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		marker string
+		want   string
+	}{
+		{"RSA in OpenSSH format", "ssh-rsa", "rsa"},
+		{"ed25519 in OpenSSH format", "ssh-ed25519", "ed25519"},
+		{"ECDSA in OpenSSH format", "ecdsa-sha2-nistp256", "ecdsa"},
+		{"DSA in OpenSSH format", "ssh-dss", "dsa"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Craft a minimal OpenSSH-format PEM whose decoded blob contains the
+			// algorithm marker. The blob does not need to be a valid OpenSSH key —
+			// detectKeyType only scans the decoded bytes for the marker string.
+			body := append([]byte("openssh-key-v1\x00"), []byte(tt.marker)...)
+			block := &pem.Block{Type: "OPENSSH PRIVATE KEY", Bytes: body}
+			var buf bytes.Buffer
+			if err := pem.Encode(&buf, block); err != nil {
+				t.Fatalf("pem.Encode: %v", err)
+			}
+
+			if got := detectKeyType(buf.Bytes()); got != tt.want {
+				t.Errorf("detectKeyType(%s) = %q, want %q", tt.marker, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestValidateSSHKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses the cleanup findings from the v0.8.0 architecture audit (issue #26): removes two blocks of dead code and fixes two small correctness issues (stable `.env` diffs and accurate SSH key type detection).

## Changes

**Dead code**
- Remove `ReloadCommandsFallback` in `internal/caddy/config.go` (defined, never called).
- Remove the unreachable `{{- if not .TLS }}` branch in the inline Caddy template, along with the `AppConfig.TLS` field that only ever held the constant `true`.

**Correctness fixes**
- `buildEnvContent` now sorts keys before iterating, so rewriting `.env.local` produces stable, alphabetically ordered output instead of a fresh random ordering on each call.
- `detectKeyType` now PEM-decodes OpenSSH-format keys and inspects the binary blob for the algorithm marker (`ssh-rsa`, `ssh-ed25519`, `ecdsa-sha2-*`, `ssh-dss`). Legacy PEM types still trust the header. Previously an RSA key saved in OpenSSH new format was silently misclassified as ed25519.

## Tests

- `TestGenerateAppConfig_DoesNotEmitTLSInternal` — guards the template regression.
- `TestBuildEnvContent_DeterministicOrdering` — asserts stable, alphabetical output across 20+ calls.
- `TestDetectKeyType_OpenSSHFormat` — covers rsa, ed25519, ecdsa, dsa in the OpenSSH format (directly guards the bug).

## Test Plan

- [x] `make test` — 526 tests pass across 11 packages (race detector on)
- [x] `make build` — binary compiles
- [x] `./bin/frankendeploy --version`, `./bin/frankendeploy server --help` — CLI functional
- [x] Lint: no new issues introduced (12 pre-existing errcheck/staticcheck issues identical to main)
- [ ] CI (GitHub Actions)

## Out of scope

The issue also mentions migrating the Caddy template to `TemplateLoader` for pattern consistency. That was marked as \"consider\" and is deferred — it would invasive for negligible performance gain and can be done in a follow-up if desired.

## Related Issue

Closes #26

---
🤖 Generated with [Claude Code](https://claude.ai/code)