### PR TITLE
refactor: unify validation and remove dead code across scanner/config/generator (#29)

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -121,13 +121,15 @@ func FindProjectConfig() (string, error) {
 
 // NormalizeDBDriver normalizes database driver names to their canonical form.
 // For example, "pdo_pgsql" → "pgsql", "pdo_mysql" → "mysql", "pdo_sqlite" → "sqlite".
+// Known aliases (including already-canonical forms like "pgsql") are canonicalized
+// to lowercase; unknown driver names are returned unchanged.
 func NormalizeDBDriver(driver string) string {
 	switch strings.ToLower(driver) {
-	case "pdo_pgsql", "postgresql", "postgres":
+	case "pdo_pgsql", "postgresql", "postgres", "pgsql":
 		return "pgsql"
-	case "pdo_mysql", "mysqli":
+	case "pdo_mysql", "mysqli", "mysql":
 		return "mysql"
-	case "pdo_sqlite", "sqlite3":
+	case "pdo_sqlite", "sqlite3", "sqlite":
 		return "sqlite"
 	default:
 		return driver

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -214,6 +214,8 @@ func TestNormalizeDBDriver(t *testing.T) {
 		{"pgsql", "pgsql"},
 		{"mysql", "mysql"},
 		{"sqlite", "sqlite"},
+		{"PGSQL", "pgsql"},
+		{"MySQL", "mysql"},
 		{"unknown", "unknown"},
 	}
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -184,14 +184,19 @@ func isValidProjectName(name string) bool {
 	return matched
 }
 
+// phpVersionRegex matches PHP versions of the form "8.x" where x ≥ 1.
+// Kept forward-compatible so new PHP releases (8.10, 8.20, …) don't require
+// a config/validator update before they can be used.
+var phpVersionRegex = regexp.MustCompile(`^8\.[1-9]\d*$`)
+
+// IsValidPHPVersion reports whether the given version is an accepted PHP version.
+// This is the single source of truth used by both the config and generator layers.
+func IsValidPHPVersion(version string) bool {
+	return phpVersionRegex.MatchString(version)
+}
+
 func isValidPHPVersion(version string) bool {
-	validVersions := []string{"8.1", "8.2", "8.3", "8.4"}
-	for _, v := range validVersions {
-		if version == v {
-			return true
-		}
-	}
-	return false
+	return IsValidPHPVersion(version)
 }
 
 func isValidDatabaseDriver(driver string) bool {

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -75,24 +75,6 @@ func (l *TemplateLoader) Execute(name string, data interface{}) (string, error) 
 // templateFuncs returns custom template functions
 func templateFuncs() template.FuncMap {
 	return template.FuncMap{
-		"join": func(sep string, items []string) string {
-			result := ""
-			for i, item := range items {
-				if i > 0 {
-					result += sep
-				}
-				result += item
-			}
-			return result
-		},
-		"contains": func(slice []string, item string) bool {
-			for _, s := range slice {
-				if s == item {
-					return true
-				}
-			}
-			return false
-		},
 		"default": func(def, val interface{}) interface{} {
 			if val == nil || val == "" {
 				return def

--- a/internal/generator/templates/compose-dev.tmpl
+++ b/internal/generator/templates/compose-dev.tmpl
@@ -39,13 +39,8 @@ services:
       start_period: 30s
 {{- if or (eq .Database.Driver "pgsql") (eq .Database.Driver "mysql") }}
     depends_on:
-{{- if eq .Database.Driver "pgsql" }}
       database:
         condition: service_healthy
-{{- else if eq .Database.Driver "mysql" }}
-      database:
-        condition: service_healthy
-{{- end }}
 {{- end }}
 
 {{- if eq .Database.Driver "pgsql" }}

--- a/internal/generator/templates/dockerfile.tmpl
+++ b/internal/generator/templates/dockerfile.tmpl
@@ -31,12 +31,14 @@ WORKDIR /app
 
 VOLUME /app/var/
 
-# Install system dependencies
+# Install system dependencies (netcat-openbsd is used by docker-entrypoint for
+# the database wait loop)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     acl \
     file \
     gettext \
     git \
+    netcat-openbsd \
 {{- if .Dockerfile.ExtraPackages }}
 {{- range .Dockerfile.ExtraPackages }}
     {{ . }} \
@@ -70,9 +72,6 @@ RUN groupadd --gid ${GID} app && \
 
 # Allow Composer to run as superuser during build only
 ENV COMPOSER_ALLOW_SUPERUSER=1
-
-# Install netcat for database wait
-RUN apt-get update && apt-get install -y --no-install-recommends netcat-openbsd && rm -rf /var/lib/apt/lists/*
 
 {{- if .PHP.IniValues }}
 

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -5,11 +5,11 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 )
 
 var (
-	phpVersionRegex      = regexp.MustCompile(`^8\.[1-9]\d*$`)
 	phpExtensionRegex    = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 	extraPackageRegex    = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+-]*$`)
 	frankenPHPVersionRgx = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
@@ -28,7 +28,7 @@ var shellInjectionPatterns = []string{"$(", "`", ";", "&&", "||", "|", ">", "<",
 
 // ValidateDockerfileData validates inputs before Dockerfile generation.
 func ValidateDockerfileData(data DockerfileData) error {
-	if !phpVersionRegex.MatchString(data.PHP.Version) {
+	if !config.IsValidPHPVersion(data.PHP.Version) {
 		return fmt.Errorf("invalid PHP version %q: must be 8.x (e.g., 8.1, 8.2, 8.3, 8.4)", data.PHP.Version)
 	}
 

--- a/internal/scanner/composer.go
+++ b/internal/scanner/composer.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -77,9 +78,10 @@ func (s *Scanner) ParseComposer() (*ComposerResult, error) {
 	return result, nil
 }
 
-// extractPHPVersion extracts a clean PHP version from composer constraint
+// extractPHPVersion extracts a clean PHP version from composer constraint.
+// Compares matches numerically so "8.10" is recognised as higher than "8.9"
+// (string comparison would incorrectly rank "8.9" above "8.10").
 func extractPHPVersion(constraint string) string {
-	// Common patterns: ">=8.1", "^8.2", "~8.3", "8.2.*", ">=8.1 <8.4"
 	re := regexp.MustCompile(`8\.\d+`)
 	matches := re.FindAllString(constraint, -1)
 
@@ -87,15 +89,30 @@ func extractPHPVersion(constraint string) string {
 		return "8.3" // Default to latest stable
 	}
 
-	// Return the highest version found
 	highest := matches[0]
-	for _, m := range matches {
-		if m > highest {
+	highestMinor := phpMinor(highest)
+	for _, m := range matches[1:] {
+		if phpMinor(m) > highestMinor {
 			highest = m
+			highestMinor = phpMinor(m)
 		}
 	}
 
 	return highest
+}
+
+// phpMinor returns the minor-version component of a "8.x" string, or -1 if
+// the string does not follow that format.
+func phpMinor(v string) int {
+	parts := strings.SplitN(v, ".", 2)
+	if len(parts) != 2 {
+		return -1
+	}
+	n, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return -1
+	}
+	return n
 }
 
 // GetPackageVersion returns the version constraint for a package

--- a/internal/scanner/database.go
+++ b/internal/scanner/database.go
@@ -51,7 +51,7 @@ func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
 	// First, check doctrine.yaml for explicit driver
 	if doctrineConfig, err := s.GetDoctrineConfig(); err == nil {
 		if driver := doctrineConfig.Doctrine.DBAL.Driver; driver != "" {
-			dbConfig.Driver = normalizeDriver(driver)
+			dbConfig.Driver = config.NormalizeDBDriver(driver)
 			dbConfig.Version = getDefaultVersion(dbConfig.Driver)
 			// SQLite doesn't support managed mode (file-based database)
 			if dbConfig.Driver != "sqlite" {
@@ -137,20 +137,6 @@ func parseDBURL(url string) (string, string) {
 	}
 
 	return driver, version
-}
-
-// normalizeDriver normalizes the database driver name
-func normalizeDriver(driver string) string {
-	switch strings.ToLower(driver) {
-	case "pdo_pgsql", "postgresql", "postgres", "pgsql":
-		return "pgsql"
-	case "pdo_mysql", "mysql", "mysqli":
-		return "mysql"
-	case "pdo_sqlite", "sqlite", "sqlite3":
-		return "sqlite"
-	default:
-		return driver
-	}
 }
 
 // getDefaultVersion returns the default version for a database driver

--- a/internal/scanner/database_test.go
+++ b/internal/scanner/database_test.go
@@ -217,30 +217,5 @@ func TestDetectDatabase_NoWarningExplicit(t *testing.T) {
 	}
 }
 
-func TestNormalizeDriver(t *testing.T) {
-	tests := []struct {
-		driver   string
-		expected string
-	}{
-		{"pdo_pgsql", "pgsql"},
-		{"postgresql", "pgsql"},
-		{"postgres", "pgsql"},
-		{"pgsql", "pgsql"},
-		{"pdo_mysql", "mysql"},
-		{"mysql", "mysql"},
-		{"mysqli", "mysql"},
-		{"pdo_sqlite", "sqlite"},
-		{"sqlite", "sqlite"},
-		{"sqlite3", "sqlite"},
-		{"unknown", "unknown"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.driver, func(t *testing.T) {
-			result := normalizeDriver(tt.driver)
-			if result != tt.expected {
-				t.Errorf("normalizeDriver(%q) = %q, want %q", tt.driver, result, tt.expected)
-			}
-		})
-	}
-}
+// Driver normalization is now tested exclusively in internal/config/project_test.go
+// (TestNormalizeDBDriver). The scanner delegates to config.NormalizeDBDriver.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -125,17 +125,19 @@ func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResu
 		}
 	}
 
-	// Add database-specific extension
+	// Add database-specific extension. DetectDatabase already canonicalizes
+	// the driver via config.NormalizeDBDriver, so only the canonical forms
+	// (pgsql/mysql/sqlite) need handling here.
 	switch result.Database.Driver {
-	case "pgsql", "pdo_pgsql":
+	case "pgsql":
 		if !extMap["pdo_pgsql"] {
 			extensions = append(extensions, "pdo_pgsql")
 		}
-	case "mysql", "pdo_mysql":
+	case "mysql":
 		if !extMap["pdo_mysql"] {
 			extensions = append(extensions, "pdo_mysql")
 		}
-	case "sqlite", "pdo_sqlite":
+	case "sqlite":
 		if !extMap["pdo_sqlite"] {
 			extensions = append(extensions, "pdo_sqlite")
 		}

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -104,6 +104,11 @@ func TestExtractPHPVersion(t *testing.T) {
 		{">=8.1 <8.4", "8.4"},
 		{"^8.5", "8.5"},
 		{">=8.10", "8.10"},
+		// Guards the numeric-comparison fix: lexicographically "8.9" > "8.11"
+		// ('9' > '1' at the same position) and "8.2" > "8.10" ('2' > '1').
+		// The minor version must be compared as a number.
+		{">=8.9 <8.11", "8.11"},
+		{">=8.2 <8.10", "8.10"},
 		{">=7.4", "8.3"}, // No 8.x found, should default
 		{"", "8.3"},
 	}


### PR DESCRIPTION
## Summary

Closes the remaining consistency findings from the v0.8.0 architecture audit (issue #29). Two parallel implementations are consolidated, one latent bug is fixed before PHP 8.10 ships, and a handful of dead-code / template duplications are removed.

## Changes

**Consolidation (single source of truth)**
- **Driver normalization**: `scanner.normalizeDriver` is removed; the scanner now calls `config.NormalizeDBDriver`. The config function gains identity cases (`pgsql`/`mysql`/`sqlite`) so any case-variant of a known driver is lowercased.
- **PHP version validation**: new exported `config.IsValidPHPVersion` (regex `^8\.[1-9]\d*$`) is the single policy. `config/validation.go` calls into it instead of a hard-coded `[8.1..8.4]` allowlist, and `generator/validate.go` drops its parallel `phpVersionRegex`. Side benefit: PHP 8.10+ no longer requires a config update to be accepted.

**Correctness fix**
- `scanner.extractPHPVersion` compared PHP versions with `>` on the string. Lexicographically `"8.9" > "8.10"` because `'9' > '1'` at the same offset — so the scanner will silently pick the wrong version when PHP 8.10 arrives. Now parses the minor component as an integer. Test cases added (`">=8.9 <8.11"` → `"8.11"`, `">=8.2 <8.10"` → `"8.10"`) that fail under the old implementation.

**Dead code**
- Remove unreachable `pdo_pgsql`/`pdo_mysql`/`pdo_sqlite` arms in `enhanceExtensions` (`DetectDatabase` canonicalises the driver before this switch is reached).
- Remove `join` and `contains` template helpers — not referenced by any embedded template.
- Collapse duplicate `depends_on` branches in `compose-dev.tmpl` (pgsql/mysql emitted identical YAML).
- Fold `netcat-openbsd` install into the first `apt-get install` block in `dockerfile.tmpl`, removing a redundant second RUN layer + `apt-get update`.

## Test Plan

- [x] `make test` — 518 tests pass across 11 packages (race detector on)
- [x] `go vet ./...` — clean
- [x] `make build` — binary compiles; `--version` / `build --help` / `server --help` functional
- [x] Lint: no new issues introduced (12 pre-existing errcheck/staticcheck issues, identical to main)
- [ ] CI (GitHub Actions)

## Related Issue

Closes #29

---
🤖 Generated with [Claude Code](https://claude.ai/code)