### PR TITLE
refactor: close template data-flow gaps (#28)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -149,7 +149,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 
 	// Step 3b: Deploy managed database if configured
 	var databaseURL string
-	if projectCfg.Database.Driver != "" && projectCfg.Database.Managed != nil && *projectCfg.Database.Managed {
+	if projectCfg.Database.Driver != "" && projectCfg.Database.IsManaged() {
 		PrintInfo("Setting up managed database...")
 		var err error
 		databaseURL, err = deployManagedDatabase(ctx, client, projectCfg, remoteAppPath)
@@ -219,13 +219,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("swap failed: %w", err)
 	}
 
-	// Step 8b: Deploy Messenger workers if enabled
+	// Step 8b: Deploy Messenger worker if enabled
 	if projectCfg.Messenger.Enabled {
-		PrintInfo("Starting Messenger workers...")
+		PrintInfo("Starting Messenger worker...")
 		if err := deployMessengerWorkers(ctx, client, projectCfg, imageName, remoteAppPath, databaseURL); err != nil {
-			PrintWarning("Failed to start Messenger workers: %v", err)
+			PrintWarning("Failed to start Messenger worker: %v", err)
 		} else {
-			PrintSuccess("Messenger workers started (%d workers)", projectCfg.Messenger.Workers)
+			PrintSuccess("Messenger worker started")
 		}
 	}
 
@@ -674,13 +674,11 @@ func runDeployHooks(ctx context.Context, client ssh.Executor, containerName stri
 	return nil
 }
 
-// deployMessengerWorkers starts Messenger worker containers
+// deployMessengerWorkers starts a Messenger worker container for the app.
+// Only a single worker container is started; multi-worker scaling is not
+// currently supported.
 func deployMessengerWorkers(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, imageName, appPath, databaseURL string) error {
 	workerName := fmt.Sprintf("%s-worker", cfg.Name)
-	workers := cfg.Messenger.Workers
-	if workers <= 0 {
-		workers = 2
-	}
 
 	// Build transports argument
 	transports := cfg.Messenger.Transports
@@ -724,12 +722,6 @@ func deployMessengerWorkers(ctx context.Context, client ssh.Executor, cfg *confi
 	}
 	if err := result.Err(); err != nil {
 		return fmt.Errorf("failed to start worker: %w", err)
-	}
-
-	// If more than 1 worker requested, use docker exec to spawn additional workers
-	// Note: For true scaling, consider using docker-compose or swarm
-	if workers > 1 {
-		PrintVerbose("Note: Running %d workers via single container (use docker-compose for true scaling)", workers)
 	}
 
 	return nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -36,6 +36,11 @@ type DatabaseConfig struct {
 	Managed *bool `yaml:"managed,omitempty"`
 }
 
+// IsManaged reports whether this database config requests a managed DB container.
+func (d *DatabaseConfig) IsManaged() bool {
+	return d.Managed != nil && *d.Managed
+}
+
 // AssetsConfig holds asset build configuration
 type AssetsConfig struct {
 	BuildTool    string `yaml:"build_tool,omitempty"`
@@ -43,10 +48,12 @@ type AssetsConfig struct {
 	OutputDir    string `yaml:"output_dir,omitempty"`
 }
 
-// MessengerConfig holds Symfony Messenger worker configuration
+// MessengerConfig holds Symfony Messenger worker configuration.
+// Note: a single worker container is started per application; scaling to
+// multiple workers is not supported today. The transports slice is passed
+// directly to `messenger:consume`.
 type MessengerConfig struct {
 	Enabled    bool     `yaml:"enabled,omitempty"`
-	Workers    int      `yaml:"workers,omitempty"`
 	Transports []string `yaml:"transports,omitempty"`
 }
 

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -81,13 +81,11 @@ func ValidateProjectConfig(config *ProjectConfig) ValidationErrors {
 		}
 
 		// SQLite cannot use managed mode (file-based database, not a container)
-		if isSQLiteDriver(config.Database.Driver) {
-			if config.Database.Managed != nil && *config.Database.Managed {
-				errors = append(errors, ValidationError{
-					Field:   "database.managed",
-					Message: "SQLite does not support managed mode. SQLite is a file-based database and cannot run as a container. Remove 'managed: true' from your configuration. The SQLite database directory should be in 'deploy.shared_dirs' for persistence",
-				})
-			}
+		if isSQLiteDriver(config.Database.Driver) && config.Database.IsManaged() {
+			errors = append(errors, ValidationError{
+				Field:   "database.managed",
+				Message: "SQLite does not support managed mode. SQLite is a file-based database and cannot run as a container. Remove 'managed: true' from your configuration. The SQLite database directory should be in 'deploy.shared_dirs' for persistence",
+			})
 		}
 	}
 
@@ -114,13 +112,6 @@ func ValidateProjectConfig(config *ProjectConfig) ValidationErrors {
 				Message: err.Error(),
 			})
 		}
-	}
-
-	if config.Messenger.Enabled && config.Messenger.Workers < 1 {
-		errors = append(errors, ValidationError{
-			Field:   "messenger.workers",
-			Message: "workers must be greater than 0 when messenger is enabled",
-		})
 	}
 
 	if config.Deploy.KeepReleases < 0 {

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -276,7 +276,7 @@ func TestValidateProjectConfig(t *testing.T) {
 			wantErrors: true,
 		},
 		{
-			name: "messenger enabled with zero workers",
+			name: "messenger enabled is valid",
 			config: &ProjectConfig{
 				Name: "my-app",
 				PHP: PHPConfig{
@@ -284,35 +284,6 @@ func TestValidateProjectConfig(t *testing.T) {
 				},
 				Messenger: MessengerConfig{
 					Enabled: true,
-					Workers: 0,
-				},
-			},
-			wantErrors: true,
-		},
-		{
-			name: "messenger enabled with valid workers",
-			config: &ProjectConfig{
-				Name: "my-app",
-				PHP: PHPConfig{
-					Version: "8.3",
-				},
-				Messenger: MessengerConfig{
-					Enabled: true,
-					Workers: 2,
-				},
-			},
-			wantErrors: false,
-		},
-		{
-			name: "messenger disabled with zero workers is valid",
-			config: &ProjectConfig{
-				Name: "my-app",
-				PHP: PHPConfig{
-					Version: "8.3",
-				},
-				Messenger: MessengerConfig{
-					Enabled: false,
-					Workers: 0,
 				},
 			},
 			wantErrors: false,

--- a/internal/deploy/envcheck.go
+++ b/internal/deploy/envcheck.go
@@ -91,7 +91,7 @@ func needsDatabaseURL(cfg *config.ProjectConfig) bool {
 	}
 
 	// Managed mode: FrankenDeploy provides DATABASE_URL
-	if cfg.Database.Managed != nil && *cfg.Database.Managed {
+	if cfg.Database.IsManaged() {
 		return false
 	}
 

--- a/internal/generator/compose.go
+++ b/internal/generator/compose.go
@@ -45,6 +45,9 @@ type ComposeData struct {
 	DevDBUser     string
 	DevDBPassword string
 	DevDBName     string
+	// ManagedDatabase is true when the prod compose should emit a database
+	// service (driver is pgsql/mysql and the project opted into managed mode).
+	ManagedDatabase bool
 }
 
 // GenerateDev generates docker-compose.yaml for development
@@ -97,6 +100,10 @@ func (g *ComposeGenerator) buildComposeData(ctx composeContext) (ComposeData, er
 			}
 			data.DatabaseURL = dbURL
 		}
+	}
+
+	if ctx == composeContextProd && g.config.Database.IsManaged() && IsContainerizedDriver(g.config.Database.Driver) {
+		data.ManagedDatabase = true
 	}
 
 	return data, nil

--- a/internal/generator/dockerfile.go
+++ b/internal/generator/dockerfile.go
@@ -26,7 +26,6 @@ type DockerfileData struct {
 	Name              string
 	PHP               config.PHPConfig
 	Assets            *config.AssetsConfig
-	Deploy            config.DeployConfig
 	Dockerfile        config.DockerfileConfig
 	FrankenPHPVersion string
 }
@@ -36,13 +35,20 @@ func (g *DockerfileGenerator) Generate() (string, error) {
 	data := DockerfileData{
 		Name:              g.config.Name,
 		PHP:               g.config.PHP,
-		Deploy:            g.config.Deploy,
 		Dockerfile:        g.config.Dockerfile,
 		FrankenPHPVersion: g.config.FrankenPHPVersion,
 	}
 
 	if g.config.Assets.BuildTool != "" {
-		data.Assets = &g.config.Assets
+		assets := g.config.Assets
+		// Sensible default so a hand-written frankendeploy.yaml with a
+		// BuildTool but no output_dir still produces a valid Dockerfile.
+		// The scanner populates OutputDir, so this only kicks in for manual
+		// configs.
+		if assets.OutputDir == "" {
+			assets.OutputDir = "public/build"
+		}
+		data.Assets = &assets
 	}
 
 	if err := ValidateDockerfileData(data); err != nil {

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -439,6 +439,60 @@ func TestDockerfileGenerator_Generate_NPMVite(t *testing.T) {
 	}
 }
 
+// TestDockerfileGenerator_Generate_CustomAssetOutputDir verifies that a
+// user-provided Assets.OutputDir (e.g. "public/dist" for Vite with a custom
+// build.outDir) flows into the generated COPY line, instead of being ignored
+// with a hardcoded "public/build".
+func TestDockerfileGenerator_Generate_CustomAssetOutputDir(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "test-app",
+		PHP:  config.PHPConfig{Version: "8.3"},
+		Assets: config.AssetsConfig{
+			BuildTool:    "npm",
+			BuildCommand: "npm run build",
+			OutputDir:    "public/dist",
+		},
+	}
+	dockerfile, err := NewDockerfileGenerator(cfg).Generate()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	want := "COPY --from=node_build /app/public/dist public/dist"
+	if !strings.Contains(dockerfile, want) {
+		t.Errorf("dockerfile should contain %q:\n%s", want, dockerfile)
+	}
+	if strings.Contains(dockerfile, "/app/public/build public/build") {
+		t.Errorf("dockerfile should not contain the hardcoded public/build path:\n%s", dockerfile)
+	}
+}
+
+// TestDockerfileGenerator_Generate_RejectsUnsafeOutputDir guards the
+// sanitization of Assets.OutputDir — it flows into a Dockerfile COPY line.
+func TestDockerfileGenerator_Generate_RejectsUnsafeOutputDir(t *testing.T) {
+	for _, bad := range []string{
+		"../etc",
+		"public/../../etc",
+		"/absolute/path",
+		"public build", // space
+		`"; RUN rm -rf /; #`,
+	} {
+		t.Run(bad, func(t *testing.T) {
+			cfg := &config.ProjectConfig{
+				Name: "test-app",
+				PHP:  config.PHPConfig{Version: "8.3"},
+				Assets: config.AssetsConfig{
+					BuildTool:    "npm",
+					BuildCommand: "npm run build",
+					OutputDir:    bad,
+				},
+			}
+			if _, err := NewDockerfileGenerator(cfg).Generate(); err == nil {
+				t.Errorf("expected error for unsafe output_dir %q, got nil", bad)
+			}
+		})
+	}
+}
+
 func TestDockerfileGenerator_Generate_ExtraPackages(t *testing.T) {
 	cfg := &config.ProjectConfig{
 		Name: "test-app",
@@ -857,6 +911,64 @@ func TestComposeGenerator_GenerateProd_NoDatabaseComment(t *testing.T) {
 	}
 	if strings.Contains(compose, "DATABASE_URL") {
 		t.Error("compose-prod should not contain DATABASE_URL comment without DB config")
+	}
+}
+
+// TestComposeGenerator_GenerateProd_ManagedDatabase verifies that a managed
+// Postgres driver causes compose-prod to emit a `database:` service, a
+// depends_on reference, and a db_data volume. Guards the wiring of
+// Database.Managed into ComposeData.
+func TestComposeGenerator_GenerateProd_ManagedDatabase(t *testing.T) {
+	managed := true
+	cfg := &config.ProjectConfig{
+		Name: "test-app",
+		PHP:  config.PHPConfig{Version: "8.3"},
+		Database: config.DatabaseConfig{
+			Driver:  "pgsql",
+			Version: "16",
+			Managed: &managed,
+		},
+	}
+	gen := NewComposeGenerator(cfg)
+	compose, err := gen.GenerateProd()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	for _, want := range []string{
+		"  database:",
+		"image: postgres:16-alpine",
+		"depends_on:",
+		"db_data:/var/lib/postgresql/data",
+		"volumes:\n  db_data:",
+	} {
+		if !strings.Contains(compose, want) {
+			t.Errorf("managed compose-prod should contain %q:\n%s", want, compose)
+		}
+	}
+}
+
+// TestComposeGenerator_GenerateProd_UnmanagedDatabase verifies that without
+// Managed: true the prod compose does NOT emit a database service.
+func TestComposeGenerator_GenerateProd_UnmanagedDatabase(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "test-app",
+		PHP:  config.PHPConfig{Version: "8.3"},
+		Database: config.DatabaseConfig{
+			Driver:  "pgsql",
+			Version: "16",
+			// Managed unset → external DB
+		},
+	}
+	gen := NewComposeGenerator(cfg)
+	compose, err := gen.GenerateProd()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	if strings.Contains(compose, "  database:") {
+		t.Errorf("unmanaged compose-prod should NOT emit a database service:\n%s", compose)
+	}
+	if strings.Contains(compose, "db_data:") {
+		t.Errorf("unmanaged compose-prod should NOT declare db_data volume:\n%s", compose)
 	}
 }
 

--- a/internal/generator/templates/compose-prod.tmpl
+++ b/internal/generator/templates/compose-prod.tmpl
@@ -42,6 +42,50 @@ services:
 {{- end }}
     networks:
       - {{ networkName }}
+{{- if .ManagedDatabase }}
+    depends_on:
+      database:
+        condition: service_healthy
+
+  database:
+{{- if eq .Database.Driver "pgsql" }}
+    image: postgres:{{ .Database.Version }}-alpine
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-{{ .Name }}}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:?DATABASE_PASSWORD is required}
+      POSTGRES_DB: ${DATABASE_NAME:-{{ .Name }}}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER:-{{ .Name }}} -d ${DATABASE_NAME:-{{ .Name }}}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+{{- else if eq .Database.Driver "mysql" }}
+    image: mysql:{{ .Database.Version }}
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DATABASE_PASSWORD:?DATABASE_PASSWORD is required}
+      MYSQL_USER: ${DATABASE_USER:-{{ .Name }}}
+      MYSQL_PASSWORD: ${DATABASE_PASSWORD}
+      MYSQL_DATABASE: ${DATABASE_NAME:-{{ .Name }}}
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+{{- end }}
+    restart: unless-stopped
+    networks:
+      - {{ networkName }}
+{{- end }}
+
+{{- if .ManagedDatabase }}
+
+volumes:
+  db_data:
+{{- end }}
 
 networks:
   {{ networkName }}:

--- a/internal/generator/templates/dockerfile.tmpl
+++ b/internal/generator/templates/dockerfile.tmpl
@@ -152,7 +152,7 @@ RUN set -eux; \
     php bin/console asset-map:compile --no-interaction
 {{- else }}
 # Webpack/Vite: copy pre-built assets from node_build stage
-COPY --from=node_build /app/public/build public/build
+COPY --from=node_build /app/{{ .Assets.OutputDir }} {{ .Assets.OutputDir }}
 {{- end }}
 {{- end }}
 

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -14,6 +14,9 @@ var (
 	extraPackageRegex    = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._+-]*$`)
 	frankenPHPVersionRgx = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 	dbVersionTagRegex    = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	// assetOutputDirRegex: relative path, no traversal, safe chars only.
+	// Flows into a Dockerfile COPY line so must be sanitized.
+	assetOutputDirRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
 )
 
 // dockerfileInstructions are the valid Dockerfile instruction keywords
@@ -41,6 +44,15 @@ func ValidateDockerfileData(data DockerfileData) error {
 	if data.Assets != nil && data.Assets.BuildCommand != "" {
 		if err := security.ValidateDockerCommand(data.Assets.BuildCommand); err != nil {
 			return fmt.Errorf("invalid build command: %w", err)
+		}
+	}
+
+	if data.Assets != nil && data.Assets.OutputDir != "" {
+		if strings.Contains(data.Assets.OutputDir, "..") {
+			return fmt.Errorf("invalid asset output_dir %q: must not contain path traversal", data.Assets.OutputDir)
+		}
+		if !assetOutputDirRegex.MatchString(data.Assets.OutputDir) {
+			return fmt.Errorf("invalid asset output_dir %q: only alphanumeric, dots, underscores, slashes, and hyphens allowed (no leading slash)", data.Assets.OutputDir)
 		}
 	}
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -182,7 +182,6 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 	if result.HasMessenger {
 		cfg.Messenger = config.MessengerConfig{
 			Enabled:    true,
-			Workers:    2,
 			Transports: []string{"async"},
 		}
 	}


### PR DESCRIPTION
## Summary

Resolves the four findings from the v0.8.0 audit where scanner/config fields were accepted but never reached the generator or the runtime. The fixes split cleanly into **wire** (make the field actually do something) and **remove** (drop the field so it can't mislead).

## Changes

### Wire

**1. `Assets.OutputDir`** — `dockerfile.tmpl` hardcoded `public/build`. The value was only ever honoured because the scanner always produced it; any user override (e.g. Vite with `build.outDir: 'dist'`) silently broke the COPY instruction. The template now uses `{{ .Assets.OutputDir }}`, with `public/build` as default for hand-written configs. `ValidateDockerfileData` now sanitises the value (no traversal, no metacharacters) because it flows into a Dockerfile COPY line.

**2. `Database.Managed`** — `compose.prod.yaml` never emitted a database service regardless of the flag; a user running `docker compose -f compose.prod.yaml up` got no DB even with `managed: true`. `ComposeData` gains a `ManagedDatabase` boolean and the prod template now renders a pgsql or mysql service (with `depends_on` and a `db_data` volume) when set. Credentials are parametrised via `DATABASE_USER`/`DATABASE_PASSWORD`/`DATABASE_NAME`. Added `DatabaseConfig.IsManaged()` helper; existing callers (validation, envcheck, deploy) route through it.

### Remove

**3. `Messenger.Workers`** — The scanner seeded `Workers: 2` and `deployMessengerWorkers` only ever started a single container, emitting a verbose log that the value was ignored. Rather than keep a misleading knob, the field is removed. `Transports` (which is properly wired) stays.

**4. `DockerfileData.Deploy`** — The whole `DeployConfig` was passed into the Dockerfile template but none of its fields were referenced. Dropped. `ComposeData.Deploy` stays because the compose templates do read `Deploy.Domain`.

## Tests

- `TestDockerfileGenerator_Generate_CustomAssetOutputDir` — `public/dist` lands in the COPY line, hardcoded path is gone.
- `TestDockerfileGenerator_Generate_RejectsUnsafeOutputDir` — traversal, absolute paths, shell metacharacters rejected.
- `TestComposeGenerator_GenerateProd_ManagedDatabase` — managed flag → service + depends_on + db_data volume.
- `TestComposeGenerator_GenerateProd_UnmanagedDatabase` — no service without the flag.
- Messenger validation test simplified to match the new schema.

## Test Plan

- [x] `make test` — 525 tests pass across 11 packages (race detector on)
- [x] `make build` — binary compiles; CLI help commands functional
- [x] Lint: no new issues (12 pre-existing errcheck/staticcheck issues, same as `main`)
- [ ] CI (GitHub Actions)

## Related Issue

Closes #28

---
🤖 Generated with [Claude Code](https://claude.ai/code)