### PR TITLE
fix(scanner): panic on projects without package.json (#39)

### DIFF
--- a/internal/scanner/assets.go
+++ b/internal/scanner/assets.go
@@ -31,7 +31,7 @@ func (s *Scanner) DetectAssets() (*config.AssetsConfig, error) {
 	packageJSON, err := s.parsePackageJSON()
 	if err != nil {
 		// No package.json, no frontend build
-		return nil, nil
+		return assetsConfig, nil
 	}
 
 	// Detect build tool
@@ -57,7 +57,8 @@ func (s *Scanner) DetectAssets() (*config.AssetsConfig, error) {
 		return assetsConfig, nil
 	}
 
-	return nil, nil
+	// package.json exists but has no build script: no frontend build
+	return assetsConfig, nil
 }
 
 // parsePackageJSON parses the package.json file

--- a/internal/scanner/scan_integration_test.go
+++ b/internal/scanner/scan_integration_test.go
@@ -1,0 +1,153 @@
+package scanner
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeProjectFile writes a file inside the temp project, creating parent directories.
+func writeProjectFile(t *testing.T, root, relPath, content string) {
+	t.Helper()
+	fullPath := filepath.Join(root, relPath)
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		t.Fatalf("failed to create dir for %s: %v", relPath, err)
+	}
+	if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+		t.Fatalf("failed to write %s: %v", relPath, err)
+	}
+}
+
+// TestScanner_Scan_APIPlatformWithoutPackageJSON reproduces the panic reported in #39:
+// a pure API Platform project (no package.json, no AssetMapper) must scan successfully.
+func TestScanner_Scan_APIPlatformWithoutPackageJSON(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeProjectFile(t, tempDir, "composer.json", `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^7.0",
+			"api-platform/core": "^3.2",
+			"doctrine/orm": "^2.17"
+		}
+	}`)
+	writeProjectFile(t, tempDir, ".env", "DATABASE_URL=postgresql://app:pass@127.0.0.1:5432/app?serverVersion=16\n")
+	writeProjectFile(t, tempDir, "config/packages/doctrine.yaml", "doctrine:\n  dbal:\n    url: '%env(resolve:DATABASE_URL)%'\n")
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+
+	if !result.IsSymfony {
+		t.Error("expected IsSymfony to be true")
+	}
+	if result.Assets.BuildTool != "" {
+		t.Errorf("expected no asset build tool, got %q", result.Assets.BuildTool)
+	}
+	if !result.HasDoctrine {
+		t.Error("expected HasDoctrine to be true")
+	}
+	if result.Database.Driver != "pgsql" {
+		t.Errorf("expected pgsql database driver, got %q", result.Database.Driver)
+	}
+}
+
+// TestScanner_Scan_PackageJSONWithoutBuildScript covers the second nil-return path of
+// DetectAssets: a package.json that has no build script must not break Scan.
+func TestScanner_Scan_PackageJSONWithoutBuildScript(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeProjectFile(t, tempDir, "composer.json", `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^7.0"
+		}
+	}`)
+	writeProjectFile(t, tempDir, "package.json", `{
+		"name": "app",
+		"scripts": {"lint": "eslint ."}
+	}`)
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+	if result.Assets.BuildTool != "" {
+		t.Errorf("expected no asset build tool, got %q", result.Assets.BuildTool)
+	}
+}
+
+// TestScanner_Scan_AssetMapper covers the AssetMapper path end to end.
+func TestScanner_Scan_AssetMapper(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeProjectFile(t, tempDir, "composer.json", `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^7.0",
+			"symfony/asset-mapper": "^7.0"
+		}
+	}`)
+	writeProjectFile(t, tempDir, "importmap.php", "<?php return [];\n")
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+	if result.Assets.BuildTool != "assetmapper" {
+		t.Errorf("expected assetmapper build tool, got %q", result.Assets.BuildTool)
+	}
+}
+
+// TestScanner_Scan_WebpackEncore covers a classic webapp with a frontend build.
+func TestScanner_Scan_WebpackEncore(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeProjectFile(t, tempDir, "composer.json", `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^6.4"
+		}
+	}`)
+	writeProjectFile(t, tempDir, "package.json", `{
+		"name": "app",
+		"devDependencies": {"@symfony/webpack-encore": "^4.0"},
+		"scripts": {"build": "encore production"}
+	}`)
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+	if result.Assets.BuildTool != "npm" {
+		t.Errorf("expected npm build tool, got %q", result.Assets.BuildTool)
+	}
+	if result.Assets.BuildCommand == "" {
+		t.Error("expected a build command for Webpack Encore project")
+	}
+}
+
+// TestScanner_DetectAssets_NeverReturnsNilConfig locks the contract relied on by Scan().
+func TestScanner_DetectAssets_NeverReturnsNilConfig(t *testing.T) {
+	// Case 1: empty project (no package.json at all)
+	s := New(t.TempDir())
+	cfg, err := s.DetectAssets()
+	if err != nil {
+		t.Fatalf("DetectAssets() failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("DetectAssets() returned nil config for project without package.json")
+	}
+
+	// Case 2: package.json without build script
+	tempDir := t.TempDir()
+	writeProjectFile(t, tempDir, "package.json", `{"name": "app", "scripts": {}}`)
+	cfg, err = New(tempDir).DetectAssets()
+	if err != nil {
+		t.Fatalf("DetectAssets() failed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("DetectAssets() returned nil config for package.json without build script")
+	}
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -52,7 +52,7 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 
 	// Detect assets
 	assetsConfig, err := s.DetectAssets()
-	if err == nil {
+	if err == nil && assetsConfig != nil {
 		result.Assets = *assetsConfig
 	}
 


### PR DESCRIPTION
## Summary

Fixes the SIGSEGV in `frankendeploy init` on projects without `package.json` (e.g. a pure API Platform skeleton).

Closes #39

## Root cause

`DetectAssets()` returned `(nil, nil)` in two paths (no `package.json`; `package.json` without a build script) and `Scan()` dereferenced the nil pointer (`internal/scanner/scanner.go:56`).

## Changes

- `DetectAssets()` now always returns a non-nil `AssetsConfig` (empty struct = no frontend build — identical semantics for consumers, since `result.Assets` stayed at its zero value anyway).
- Defensive `assetsConfig != nil` check in `Scan()` to lock the contract.
- New `Scan()` integration tests (`scan_integration_test.go`) — the missing coverage that let this slip through — with fixtures for: pure API Platform (reproduces the panic), Webpack Encore webapp, AssetMapper, and `package.json` without build script.

## Verification

- New test reproduced the panic before the fix; all pass after.
- Full suite: 530 tests green with `-race`.
- `go vet`, `gofmt`, `golangci-lint`: clean.
- End-to-end: built binary, ran `frankendeploy init --domain test.example.com` on a synthetic API Platform skeleton (composer.json + `.env` + doctrine.yaml, no package.json) → previously SIGSEGV, now generates a correct config (PHP 8.2, pgsql 16, `pdo_pgsql`, no assets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
