### PR TITLE
fix(scanner): floor PHP version to 8.2 with explicit warning (#40)

### DIFF
--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -61,7 +61,7 @@ func ValidateProjectConfig(config *ProjectConfig) ValidationErrors {
 	} else if !isValidPHPVersion(config.PHP.Version) {
 		errors = append(errors, ValidationError{
 			Field:   "php.version",
-			Message: "invalid PHP version (must be 8.1, 8.2, 8.3, or 8.4)",
+			Message: "invalid PHP version (must be 8.2 or higher — FrankenPHP requires PHP >= 8.2)",
 		})
 	}
 
@@ -175,10 +175,12 @@ func isValidProjectName(name string) bool {
 	return matched
 }
 
-// phpVersionRegex matches PHP versions of the form "8.x" where x ≥ 1.
+// phpVersionRegex matches PHP versions of the form "8.x" where x ≥ 2, the
+// minimum version with an official FrankenPHP image (dunglas/frankenphp
+// requires PHP >= 8.2 — there is no php8.1 tag).
 // Kept forward-compatible so new PHP releases (8.10, 8.20, …) don't require
 // a config/validator update before they can be used.
-var phpVersionRegex = regexp.MustCompile(`^8\.[1-9]\d*$`)
+var phpVersionRegex = regexp.MustCompile(`^8\.([2-9]|[1-9]\d)$`)
 
 // IsValidPHPVersion reports whether the given version is an accepted PHP version.
 // This is the single source of truth used by both the config and generator layers.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -20,7 +20,7 @@ func TestValidateDockerfileData_ValidMinimal(t *testing.T) {
 }
 
 func TestValidateDockerfileData_InvalidPHPVersion(t *testing.T) {
-	for _, v := range []string{"7.4", "8.0", "9.0", "abc", ""} {
+	for _, v := range []string{"7.4", "8.0", "8.1", "9.0", "abc", ""} {
 		data := DockerfileData{PHP: config.PHPConfig{Version: v}}
 		if err := ValidateDockerfileData(data); err == nil {
 			t.Errorf("expected error for PHP version %q", v)
@@ -29,7 +29,7 @@ func TestValidateDockerfileData_InvalidPHPVersion(t *testing.T) {
 }
 
 func TestValidateDockerfileData_ValidPHPVersions(t *testing.T) {
-	for _, v := range []string{"8.1", "8.2", "8.3", "8.4", "8.5"} {
+	for _, v := range []string{"8.2", "8.3", "8.4", "8.5", "8.10"} {
 		data := DockerfileData{PHP: config.PHPConfig{Version: v}}
 		if err := ValidateDockerfileData(data); err != nil {
 			t.Errorf("unexpected error for PHP version %q: %v", v, err)
@@ -277,7 +277,7 @@ func TestValidateComposeData_InvalidEnvKey(t *testing.T) {
 		Name: "my-app",
 		Env: config.EnvConfig{
 			Dev: map[string]string{
-				"VALID_KEY":  "ok",
+				"VALID_KEY":   "ok",
 				"invalid:key": "bad",
 			},
 		},

--- a/internal/scanner/composer.go
+++ b/internal/scanner/composer.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,9 +21,12 @@ type ComposerJSON struct {
 type ComposerResult struct {
 	Name       string
 	PHPVersion string
-	Extensions []string
-	HasSymfony bool
-	Packages   map[string]string
+	// PHPVersionWarning is set when the detected version had to be adjusted
+	// (e.g. floored to the minimum version supported by FrankenPHP).
+	PHPVersionWarning string
+	Extensions        []string
+	HasSymfony        bool
+	Packages          map[string]string
 }
 
 // ParseComposer parses the composer.json file
@@ -54,9 +58,9 @@ func (s *Scanner) ParseComposer() (*ComposerResult, error) {
 
 	// Extract PHP version
 	if phpVersion, ok := composer.Require["php"]; ok {
-		result.PHPVersion = extractPHPVersion(phpVersion)
+		result.PHPVersion, result.PHPVersionWarning = extractPHPVersion(phpVersion)
 	} else {
-		result.PHPVersion = "8.3" // Default
+		result.PHPVersion = defaultPHPVersion
 	}
 
 	// Check for Symfony
@@ -78,41 +82,58 @@ func (s *Scanner) ParseComposer() (*ComposerResult, error) {
 	return result, nil
 }
 
-// extractPHPVersion extracts a clean PHP version from composer constraint.
-// Compares matches numerically so "8.10" is recognised as higher than "8.9"
-// (string comparison would incorrectly rank "8.9" above "8.10").
-func extractPHPVersion(constraint string) string {
-	re := regexp.MustCompile(`8\.\d+`)
-	matches := re.FindAllString(constraint, -1)
+const (
+	// defaultPHPVersion is used when no usable PHP 8.x version is found.
+	defaultPHPVersion = "8.3"
+	// minPHPMinor is the minimum 8.x minor with an official FrankenPHP image
+	// (dunglas/frankenphp requires PHP >= 8.2).
+	minPHPMinor = 2
+)
+
+// phpConstraintRegex captures an optional comparison operator and the minor
+// component of each "8.x" version in a composer constraint.
+var phpConstraintRegex = regexp.MustCompile(`(>=|<=|<|>|\^|~)?\s*8\.(\d+)`)
+
+// extractPHPVersion extracts the highest PHP 8.x version allowed by the
+// composer constraint. An exclusive upper bound ("<8.4") contributes the
+// version just below it ("8.3"). Minors are compared numerically so "8.10"
+// ranks above "8.9". The result is floored at 8.2 (the minimum version with
+// a FrankenPHP image); a non-empty warning is returned when the constraint
+// had to be adjusted or could not be interpreted.
+func extractPHPVersion(constraint string) (string, string) {
+	matches := phpConstraintRegex.FindAllStringSubmatch(constraint, -1)
 
 	if len(matches) == 0 {
-		return "8.3" // Default to latest stable
+		if strings.TrimSpace(constraint) == "" {
+			return defaultPHPVersion, ""
+		}
+		return defaultPHPVersion, fmt.Sprintf(
+			"no PHP 8.x version found in composer constraint %q, using PHP %s",
+			constraint, defaultPHPVersion)
 	}
 
-	highest := matches[0]
-	highestMinor := phpMinor(highest)
-	for _, m := range matches[1:] {
-		if phpMinor(m) > highestMinor {
-			highest = m
-			highestMinor = phpMinor(m)
+	highestMinor := -1
+	for _, m := range matches {
+		minor, err := strconv.Atoi(m[2])
+		if err != nil {
+			continue
+		}
+		if m[1] == "<" {
+			// Exclusive upper bound: the highest allowed minor is one below.
+			minor--
+		}
+		if minor > highestMinor {
+			highestMinor = minor
 		}
 	}
 
-	return highest
-}
+	if highestMinor < minPHPMinor {
+		return defaultPHPVersion, fmt.Sprintf(
+			"composer constraint %q allows PHP 8.%d but FrankenPHP requires PHP >= 8.2, using PHP %s (set php.version in frankendeploy.yaml to override)",
+			constraint, highestMinor, defaultPHPVersion)
+	}
 
-// phpMinor returns the minor-version component of a "8.x" string, or -1 if
-// the string does not follow that format.
-func phpMinor(v string) int {
-	parts := strings.SplitN(v, ".", 2)
-	if len(parts) != 2 {
-		return -1
-	}
-	n, err := strconv.Atoi(parts[1])
-	if err != nil {
-		return -1
-	}
-	return n
+	return fmt.Sprintf("8.%d", highestMinor), ""
 }
 
 // GetPackageVersion returns the version constraint for a package

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -40,6 +40,9 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	result.PHPVersion = composer.PHPVersion
 	result.PHPExtensions = composer.Extensions
 	result.Framework = "symfony"
+	if composer.PHPVersionWarning != "" {
+		result.Warnings = append(result.Warnings, composer.PHPVersionWarning)
+	}
 
 	// Detect database
 	dbConfig, dbWarning, err := s.DetectDatabase()

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
@@ -94,32 +95,75 @@ func TestEnhanceExtensions_Dedup(t *testing.T) {
 
 func TestExtractPHPVersion(t *testing.T) {
 	tests := []struct {
-		constraint string
-		expected   string
+		constraint  string
+		expected    string
+		wantWarning bool
 	}{
-		{">=8.1", "8.1"},
-		{"^8.2", "8.2"},
-		{"~8.3", "8.3"},
-		{"8.2.*", "8.2"},
-		{">=8.1 <8.4", "8.4"},
-		{"^8.5", "8.5"},
-		{">=8.10", "8.10"},
+		// FrankenPHP requires PHP >= 8.2: versions below are floored to the
+		// default with a warning (a stock Symfony 6.4 skeleton declares >=8.1).
+		{">=8.1", "8.3", true},
+		{"^8.0", "8.3", true},
+		{"^8.2", "8.2", false},
+		{"~8.3", "8.3", false},
+		{"8.2.*", "8.2", false},
+		// "<8.4" is an exclusive upper bound: the highest allowed version is 8.3.
+		{">=8.1 <8.4", "8.3", false},
+		{"^8.5", "8.5", false},
+		{">=8.10", "8.10", false},
 		// Guards the numeric-comparison fix: lexicographically "8.9" > "8.11"
 		// ('9' > '1' at the same position) and "8.2" > "8.10" ('2' > '1').
 		// The minor version must be compared as a number.
-		{">=8.9 <8.11", "8.11"},
-		{">=8.2 <8.10", "8.10"},
-		{">=7.4", "8.3"}, // No 8.x found, should default
-		{"", "8.3"},
+		{">=8.9 <8.11", "8.10", false},
+		{">=8.2 <8.10", "8.9", false},
+		{">=7.4", "8.3", true}, // No 8.x found, defaults with a warning
+		{"", "8.3", false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.constraint, func(t *testing.T) {
-			result := extractPHPVersion(tt.constraint)
+			result, warning := extractPHPVersion(tt.constraint)
 			if result != tt.expected {
 				t.Errorf("extractPHPVersion(%q) = %q, want %q", tt.constraint, result, tt.expected)
 			}
+			if tt.wantWarning && warning == "" {
+				t.Errorf("extractPHPVersion(%q): expected a warning, got none", tt.constraint)
+			}
+			if !tt.wantWarning && warning != "" {
+				t.Errorf("extractPHPVersion(%q): unexpected warning %q", tt.constraint, warning)
+			}
 		})
+	}
+}
+
+// TestScanner_Scan_PHPVersionFloorWarning verifies that the floor warning
+// reaches ScanResult.Warnings (what `frankendeploy init` displays).
+func TestScanner_Scan_PHPVersionFloorWarning(t *testing.T) {
+	tempDir := t.TempDir()
+	composerContent := `{
+		"require": {
+			"php": ">=8.1",
+			"symfony/framework-bundle": "^6.4"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tempDir, "composer.json"), []byte(composerContent), 0644); err != nil {
+		t.Fatalf("failed to create composer.json: %v", err)
+	}
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+	if result.PHPVersion != "8.3" {
+		t.Errorf("expected PHP version floored to 8.3, got %q", result.PHPVersion)
+	}
+	found := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "FrankenPHP requires PHP >= 8.2") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a floor warning in ScanResult.Warnings, got %v", result.Warnings)
 	}
 }
 


### PR DESCRIPTION
## Summary

A stock Symfony 6.4 skeleton (`"php": ">=8.1"`) resolved to PHP 8.1, generating `FROM dunglas/frankenphp:1-php8.1` — an image that does not exist (FrankenPHP requires PHP >= 8.2). Every unmodified Symfony 6.4 project failed at Docker build with a cryptic pull error.

Closes #40

## Changes

- **Floor at 8.2**: `extractPHPVersion` now floors the detected version at 8.2 (minimum with an official FrankenPHP image) and returns a warning, surfaced by `init` through the existing `ScanResult.Warnings` mechanism, with a hint to override `php.version` in frankendeploy.yaml.
- **Exclusive upper bounds respected**: `>=8.1 <8.4` previously yielded **8.4** — the version the composer.json explicitly excludes. It now yields 8.3. (The old test enshrined the bug as expected behavior; updated.)
- **Validation aligned**: regex went from `^8\.[1-9]\d*$` (accepted 8.1) to `^8\.([2-9]|[1-9]\d)$` (8.2+ including 8.10+, still forward-compatible), and the error message now matches the behavior: "must be 8.2 or higher — FrankenPHP requires PHP >= 8.2". Single source of truth (`config.IsValidPHPVersion`) used by both config and generator layers.
- Drive-by: gofmt fix of a pre-existing alignment issue in `generator_test.go` (file already touched by this PR).

## Verification

- 532 tests green with `-race`; `go vet`, `gofmt`, `golangci-lint` clean.
- New/updated tests: `TestExtractPHPVersion` covers floor, warnings and exclusive bounds; new `Scan()` integration test asserts the warning reaches `ScanResult.Warnings`; `8.1` moved to the invalid list in generator validation tests.
- End-to-end with the built binary:
  - `init` on a Symfony 6.4 skeleton (`>=8.1`) → warning printed, YAML generated with `version: "8.3"`.
  - `build` → `FROM dunglas/frankenphp:1-php8.3` (existing image).
  - YAML hand-edited to `8.1` → clear validation error instead of a broken build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
