### PR TITLE
feat(scanner): auto-detect API Platform and default healthcheck to /api (#41)

### DIFF
--- a/internal/cmd/init.go
+++ b/internal/cmd/init.go
@@ -129,6 +129,10 @@ func printInitSummary(result *config.ScanResult, cfg *config.ProjectConfig) {
 		fmt.Printf("   Domain:      %s\n", cfg.Deploy.Domain)
 	}
 
+	if result.HasAPIPlatform {
+		fmt.Printf("   Healthcheck: %s (API Platform detected)\n", cfg.Deploy.HealthcheckPath)
+	}
+
 	fmt.Println()
 	fmt.Println("Next steps:")
 	fmt.Println("  1. Review frankendeploy.yaml and adjust if needed")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -143,16 +143,17 @@ type AppConfig struct {
 
 // ScanResult holds the result of project scanning
 type ScanResult struct {
-	IsSymfony     bool
-	PHPVersion    string
-	PHPExtensions []string
-	Database      DatabaseConfig
-	Assets        AssetsConfig
-	HasDoctrine   bool
-	HasMessenger  bool
-	HasMailer     bool
-	Framework     string
-	Warnings      []string
+	IsSymfony      bool
+	PHPVersion     string
+	PHPExtensions  []string
+	Database       DatabaseConfig
+	Assets         AssetsConfig
+	HasDoctrine    bool
+	HasMessenger   bool
+	HasMailer      bool
+	HasAPIPlatform bool
+	Framework      string
+	Warnings       []string
 }
 
 // DefaultProjectConfig returns a default project configuration

--- a/internal/scanner/scan_integration_test.go
+++ b/internal/scanner/scan_integration_test.go
@@ -51,6 +51,40 @@ func TestScanner_Scan_APIPlatformWithoutPackageJSON(t *testing.T) {
 	if result.Database.Driver != "pgsql" {
 		t.Errorf("expected pgsql database driver, got %q", result.Database.Driver)
 	}
+	if !result.HasAPIPlatform {
+		t.Error("expected HasAPIPlatform to be true")
+	}
+
+	cfg := New(tempDir).ToProjectConfig(result, "apiproject")
+	if cfg.Deploy.HealthcheckPath != "/api" {
+		t.Errorf("expected healthcheck path /api for API Platform project, got %q", cfg.Deploy.HealthcheckPath)
+	}
+}
+
+// TestScanner_Scan_APIPlatform4SymfonyPackage covers the API Platform 4 split
+// packages, where Symfony projects require api-platform/symfony instead of
+// api-platform/core.
+func TestScanner_Scan_APIPlatform4SymfonyPackage(t *testing.T) {
+	tempDir := t.TempDir()
+
+	writeProjectFile(t, tempDir, "composer.json", `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^7.1",
+			"api-platform/symfony": "^4.0"
+		}
+	}`)
+
+	result, err := New(tempDir).Scan()
+	if err != nil {
+		t.Fatalf("Scan() failed: %v", err)
+	}
+	if !result.HasAPIPlatform {
+		t.Error("expected HasAPIPlatform to be true for api-platform/symfony")
+	}
+	if cfg := New(tempDir).ToProjectConfig(result, "app"); cfg.Deploy.HealthcheckPath != "/api" {
+		t.Errorf("expected healthcheck path /api, got %q", cfg.Deploy.HealthcheckPath)
+	}
 }
 
 // TestScanner_Scan_PackageJSONWithoutBuildScript covers the second nil-return path of
@@ -75,6 +109,13 @@ func TestScanner_Scan_PackageJSONWithoutBuildScript(t *testing.T) {
 	}
 	if result.Assets.BuildTool != "" {
 		t.Errorf("expected no asset build tool, got %q", result.Assets.BuildTool)
+	}
+	if result.HasAPIPlatform {
+		t.Error("expected HasAPIPlatform to be false without api-platform packages")
+	}
+	// Non-API Platform projects keep the default healthcheck path
+	if cfg := New(tempDir).ToProjectConfig(result, "app"); cfg.Deploy.HealthcheckPath != "/" {
+		t.Errorf("expected default healthcheck path /, got %q", cfg.Deploy.HealthcheckPath)
 	}
 }
 

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -63,6 +63,8 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	result.HasDoctrine = s.HasDoctrine()
 	result.HasMessenger = s.HasMessenger()
 	result.HasMailer = s.HasMailer()
+	// api-platform/core (v2/v3) or api-platform/symfony (v4 split packages)
+	result.HasAPIPlatform = composer.HasAnyPackage("api-platform/core", "api-platform/symfony")
 
 	// Add required extensions based on detected features
 	result.PHPExtensions = s.enhanceExtensions(result.PHPExtensions, result)
@@ -172,6 +174,12 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 	cfg.PHP.Extensions = result.PHPExtensions
 	cfg.Database = result.Database
 	cfg.Assets = result.Assets
+
+	// A pure API Platform app typically returns 404 on "/" in prod, which
+	// would fail the deploy health check: default to the API entrypoint.
+	if result.HasAPIPlatform {
+		cfg.Deploy.HealthcheckPath = "/api"
+	}
 
 	// For SQLite, add the database directory to shared_dirs for persistence
 	if result.Database.Driver == "sqlite" && result.Database.Path != "" {


### PR DESCRIPTION
## Summary

A pure API Platform app serves `/api` and returns 404 on `/` in prod. With the default `healthcheck_path: /` and a health check using `curl -sf` (fails on HTTP >= 400), every deploy of a pure API Platform project built everything, started everything… then failed the health check and rolled back a perfectly healthy deployment.

Closes #41

## Changes

- `Scan()` detects API Platform from composer.json: `api-platform/core` (v2/v3) **and** `api-platform/symfony` (API Platform 4 split packages).
- `ToProjectConfig` defaults `healthcheck_path` to `/api` when API Platform is detected; other projects keep `/`.
- The `init` summary makes the decision visible: `Healthcheck: /api (API Platform detected)`.

## Verification

- 533 tests green with `-race`; `go vet`, `gofmt` clean. (golangci-lint reports 5 pre-existing errcheck issues in `internal/cmd` files untouched by this PR.)
- New tests: API Platform v3 fixture → `/api`; API Platform 4 (`api-platform/symfony`) fixture → `/api`; project without API Platform → `/` kept.
- End-to-end with the built binary: `init` on a synthetic API Platform skeleton → summary shows the Healthcheck line, generated YAML contains `healthcheck_path: /api`.

Combined with #63 and #64, the core conference demo scenario ("API Platform skeleton → init → deploy") is now unblocked on the scanner side: no panic, an existing PHP image, and a health check that will pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
