### PR TITLE
fix(server): allow the actual SSH ports in UFW instead of hardcoded 22 (#45)

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -287,6 +287,27 @@ func autoTryKeys(serverCfg *config.ServerConfig, keys []ssh.SSHKeyInfo) *ssh.SSH
 	return nil
 }
 
+// buildFirewallCommands returns the UFW commands for server setup. Every SSH
+// port is allowed before ufw is enabled: never enable the firewall without
+// having allowed the port(s) SSH is reachable on, or the user gets locked
+// out of their own server. Invalid ports (<= 0) are filtered out.
+func buildFirewallCommands(sshPorts []int) []string {
+	cmds := make([]string, 0, len(sshPorts)+3)
+	seen := make(map[int]bool)
+	for _, port := range sshPorts {
+		if port > 0 && !seen[port] {
+			seen[port] = true
+			cmds = append(cmds, fmt.Sprintf("sudo ufw allow %d/tcp || true", port))
+		}
+	}
+	cmds = append(cmds,
+		"sudo ufw allow 80/tcp || true",
+		"sudo ufw allow 443/tcp || true",
+		"sudo ufw --force enable || true",
+	)
+	return cmds
+}
+
 func runServerSetup(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	name := args[0]
@@ -397,14 +418,16 @@ CADDYEOF`, constants.CaddyDir, mainConfig)
 
 	// Step 5: Configure firewall and start Caddy container
 	PrintInfo("[5/5] Configuring firewall and starting Caddy...")
-	firewallCommands := []string{
-		// Configure UFW firewall
-		"sudo ufw allow 22/tcp || true",
-		"sudo ufw allow 80/tcp || true",
-		"sudo ufw allow 443/tcp || true",
-		"sudo ufw --force enable || true",
+	sshPorts := []int{conn.Server.Port}
+	// Behind a gateway/NAT, sshd may receive connections on a different port
+	// than the client-side one: also allow the port of the current session
+	// ($SSH_CONNECTION is "client_ip client_port server_ip server_port").
+	if result, err := client.Exec(ctx, `echo "${SSH_CONNECTION##* }"`); err == nil && result != nil {
+		if port, convErr := strconv.Atoi(strings.TrimSpace(result.Stdout)); convErr == nil {
+			sshPorts = append(sshPorts, port)
+		}
 	}
-	if err := runCommandsWithProgress(ctx, client, firewallCommands); err != nil {
+	if err := runCommandsWithProgress(ctx, client, buildFirewallCommands(sshPorts)); err != nil {
 		return err
 	}
 
@@ -447,7 +470,16 @@ CADDYEOF`, constants.CaddyDir, mainConfig)
 	fmt.Printf("  Email:    %s (for Let's Encrypt)\n", setupEmail)
 	fmt.Println("  Caddy:    Docker container with Admin API")
 	fmt.Println("  Docker:   Installed with 'frankendeploy' network")
-	fmt.Println("  Firewall: Ports 22, 80, 443 open")
+	openPorts := make([]string, 0, len(sshPorts)+2)
+	seenPort := make(map[int]bool)
+	for _, port := range sshPorts {
+		if port > 0 && !seenPort[port] {
+			seenPort[port] = true
+			openPorts = append(openPorts, strconv.Itoa(port))
+		}
+	}
+	openPorts = append(openPorts, "80", "443")
+	fmt.Printf("  Firewall: Ports %s open\n", strings.Join(openPorts, ", "))
 	fmt.Println("  Fail2ban: SSH protection enabled (5 retries, 1h ban)")
 	fmt.Println()
 	fmt.Println("Next step:")

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -1,0 +1,67 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildFirewallCommands_CustomSSHPort(t *testing.T) {
+	cmds := buildFirewallCommands([]int{3022})
+
+	joined := strings.Join(cmds, "\n")
+	if !strings.Contains(joined, "sudo ufw allow 3022/tcp") {
+		t.Errorf("expected the configured SSH port 3022 to be allowed, got:\n%s", joined)
+	}
+	if strings.Contains(joined, "allow 22/tcp") {
+		t.Errorf("port 22 must not be hardcoded when SSH uses another port, got:\n%s", joined)
+	}
+}
+
+func TestBuildFirewallCommands_MultiplePortsDeduplicated(t *testing.T) {
+	// Configured port + server-side detected port (gateway/NAT case), with a duplicate
+	cmds := buildFirewallCommands([]int{3022, 22, 3022})
+
+	joined := strings.Join(cmds, "\n")
+	if !strings.Contains(joined, "allow 3022/tcp") || !strings.Contains(joined, "allow 22/tcp") {
+		t.Errorf("expected both SSH ports to be allowed, got:\n%s", joined)
+	}
+	count := strings.Count(joined, "allow 3022/tcp")
+	if count != 1 {
+		t.Errorf("expected port 3022 to be allowed exactly once, got %d times", count)
+	}
+}
+
+func TestBuildFirewallCommands_HTTPPortsAndEnableLast(t *testing.T) {
+	cmds := buildFirewallCommands([]int{22})
+
+	joined := strings.Join(cmds, "\n")
+	for _, want := range []string{"allow 80/tcp", "allow 443/tcp"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected %q in firewall commands, got:\n%s", want, joined)
+		}
+	}
+	// The enable must come last: every allow runs before the firewall goes up.
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "ufw --force enable") {
+		t.Errorf("expected 'ufw --force enable' to be the last command, got %q", last)
+	}
+	for _, cmd := range cmds[:len(cmds)-1] {
+		if strings.Contains(cmd, "enable") {
+			t.Errorf("enable found before the last position: %q", cmd)
+		}
+	}
+}
+
+func TestBuildFirewallCommands_InvalidPortsFiltered(t *testing.T) {
+	// A failed detection (0) must not produce an 'allow 0/tcp' rule, and at
+	// least the valid port must still be allowed before enabling.
+	cmds := buildFirewallCommands([]int{0, -1, 2222})
+
+	joined := strings.Join(cmds, "\n")
+	if strings.Contains(joined, "allow 0/tcp") || strings.Contains(joined, "allow -1/tcp") {
+		t.Errorf("invalid ports must be filtered, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "allow 2222/tcp") {
+		t.Errorf("expected valid port 2222 to be allowed, got:\n%s", joined)
+	}
+}


### PR DESCRIPTION
## Summary

`server setup` ran `sudo ufw allow 22/tcp` (hardcoded) then `ufw --force enable`, regardless of the configured SSH port. With `--port 2222` — a flag `server add` explicitly offers — the firewall blocked the SSH port actually in use: **the user got locked out of their own VPS**. For the novice audience this is the worst possible failure mode.

Closes #45

## Changes

- `buildFirewallCommands(sshPorts)`: every SSH port is allowed **before** `ufw enable` (never the other way around); invalid ports (<= 0) filtered; duplicates removed; 80/443 then enable last.
- **Two ports covered**: the configured client-side port (`conn.Server.Port`) AND the port sshd actually received the session on, detected via `$SSH_CONNECTION` — they differ behind a gateway/NAT.
- The setup summary now prints the real opened ports instead of hardcoded "22, 80, 443".

## Verification

- 4 new unit tests on the helper (custom port without hardcoded 22, multi-port dedup, enable strictly last, invalid-port filtering); 572 tests green with `-race`; vet/gofmt clean; no new lint issues.
- **Validated live** on a pristine Ubuntu 24.04 VPS behind an SSH gateway (client port 3022 → internal sshd port 22): full `server add` + `server setup` succeeded (Docker installed, Caddy container up, `frankendeploy` network created, Fail2ban active) and the SSH session survived. The live run confirmed the gateway scenario: `$SSH_CONNECTION` shows internal port 22 while the client connects on 3022 — allowing only the configured port would itself have caused a lockout, hence the two-port design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
