### PR TITLE
fix(caddy): use configured healthcheck path as active health check URI (refs #42)

### DIFF
--- a/internal/caddy/config.go
+++ b/internal/caddy/config.go
@@ -24,14 +24,26 @@ type AppConfig struct {
 	Name   string
 	Domain string
 	Port   int
+	// HealthPath is the URL probed by Caddy's active health check.
+	// It must match the application's healthcheck path: an API-only app
+	// returns 404 on "/", which would mark the upstream unhealthy and
+	// turn every request into a 503.
+	HealthPath string
 }
 
 // GenerateAppConfig generates Caddy config for an application
 func (g *ConfigGenerator) GenerateAppConfig(app AppConfig) (string, error) {
+	if err := security.ValidateHealthPath(app.HealthPath); err != nil {
+		return "", fmt.Errorf("invalid health path: %w", err)
+	}
+	if app.HealthPath == "" {
+		app.HealthPath = "/"
+	}
+
 	tmpl := `# {{ .Name }}
 {{ .Domain }} {
     reverse_proxy {{ .Name }}:{{ .Port }} {
-        health_uri /
+        health_uri {{ .HealthPath }}
         health_interval 30s
         health_timeout 5s
     }
@@ -97,9 +109,10 @@ import /config/apps/*.caddy
 func AppConfigFromProject(cfg *config.ProjectConfig, domain string) AppConfig {
 	port, _ := strconv.Atoi(constants.AppPort)
 	return AppConfig{
-		Name:   cfg.Name,
-		Domain: domain,
-		Port:   port,
+		Name:       cfg.Name,
+		Domain:     domain,
+		Port:       port,
+		HealthPath: cfg.Deploy.HealthcheckPath,
 	}
 }
 

--- a/internal/caddy/config_test.go
+++ b/internal/caddy/config_test.go
@@ -3,6 +3,8 @@ package caddy
 import (
 	"strings"
 	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
 )
 
 func TestGenerateAppConfig_DoesNotEmitTLSInternal(t *testing.T) {
@@ -30,5 +32,65 @@ func TestGenerateAppConfig_DoesNotEmitTLSInternal(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("generated config missing %q\n%s", want, out)
 		}
+	}
+}
+
+// TestGenerateAppConfig_UsesConfiguredHealthPath guards against the live 503
+// found in production: Caddy's active health check probed a hardcoded "/",
+// got 404 from an API-only app, marked the upstream unhealthy, and every
+// request failed with "no upstreams available".
+func TestGenerateAppConfig_UsesConfiguredHealthPath(t *testing.T) {
+	gen := NewConfigGenerator()
+	out, err := gen.GenerateAppConfig(AppConfig{
+		Name:       "myapp",
+		Domain:     "example.com",
+		Port:       8080,
+		HealthPath: "/api",
+	})
+	if err != nil {
+		t.Fatalf("GenerateAppConfig: %v", err)
+	}
+	if !strings.Contains(out, "health_uri /api") {
+		t.Errorf("expected 'health_uri /api' in generated config:\n%s", out)
+	}
+}
+
+func TestGenerateAppConfig_DefaultsHealthPathToRoot(t *testing.T) {
+	gen := NewConfigGenerator()
+	out, err := gen.GenerateAppConfig(AppConfig{
+		Name:   "myapp",
+		Domain: "example.com",
+		Port:   8080,
+	})
+	if err != nil {
+		t.Fatalf("GenerateAppConfig: %v", err)
+	}
+	if !strings.Contains(out, "health_uri /") {
+		t.Errorf("expected 'health_uri /' as default:\n%s", out)
+	}
+}
+
+func TestGenerateAppConfig_RejectsInvalidHealthPath(t *testing.T) {
+	gen := NewConfigGenerator()
+	for _, path := range []string{"no-leading-slash", "/api\nmalicious {", "/api/../../etc"} {
+		_, err := gen.GenerateAppConfig(AppConfig{
+			Name:       "myapp",
+			Domain:     "example.com",
+			Port:       8080,
+			HealthPath: path,
+		})
+		if err == nil {
+			t.Errorf("expected error for invalid health path %q", path)
+		}
+	}
+}
+
+func TestAppConfigFromProject_CopiesHealthcheckPath(t *testing.T) {
+	cfg := &config.ProjectConfig{Name: "myapp"}
+	cfg.Deploy.HealthcheckPath = "/api"
+
+	app := AppConfigFromProject(cfg, "example.com")
+	if app.HealthPath != "/api" {
+		t.Errorf("expected HealthPath /api, got %q", app.HealthPath)
 	}
 }


### PR DESCRIPTION
## Summary

The generated Caddy app config hardcoded `health_uri /`. For an API-only app that returns 404 on `/`, Caddy's active health check marked the upstream unhealthy and **every request failed with 503 "no upstreams available"** — while the app container itself was perfectly healthy.

**Observed live** on a real deployment (API Platform app): the smoking gun in Caddy's logs was
```
health_checker.active: status code out of tolerances, status_code=404, host=demo-api:8080
```

Refs #42 (this is the "align Caddy health check with the configured healthcheck path" part of that issue; the atomic-swap part remains).

## Changes

- `caddy.AppConfig` gains `HealthPath`, wired from `deploy.healthcheck_path` in `AppConfigFromProject`.
- `GenerateAppConfig` validates it with `security.ValidateHealthPath` (defense against Caddyfile injection through a hand-edited YAML) and defaults to `/`.

## Verification

- 4 new tests (configured path used, default `/`, invalid paths rejected, project wiring); 576 tests green with `-race`; vet/gofmt clean.
- **Validated live**: redeploying the same image with the fixed binary turned the public HTTPS 503 into **200** (valid Let's Encrypt certificate), app untouched. Generated config on the server now shows `health_uri /api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
