### PR TITLE
fix(rollback): bring rollback and env reload to parity with deploy (#44)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -416,32 +416,48 @@ func prepareRelease(ctx context.Context, client ssh.Executor, cfg *config.Projec
 	return nil
 }
 
-// startNewContainer starts the new version with a temporary container name.
-// The old container remains running for zero-downtime deployment.
-func startNewContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, imageName, appPath, tag, databaseURL, containerName string) error {
+// buildAppRunCommand builds the docker run command for the application
+// container. It is the single source of truth shared by deploy, rollback and
+// env reload: same volume mounts, env vars, non-root user and restart policy.
+func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseURL, containerName string) string {
 	sharedPath := filepath.Join(appPath, "shared")
 
-	sharedDirs := cfg.Deploy.EffectiveSharedDirs()
-	sharedFiles := cfg.Deploy.EffectiveSharedFiles()
-
-	volumeMounts := buildVolumeMounts(sharedPath, sharedDirs, sharedFiles)
+	volumeMounts := buildVolumeMounts(sharedPath, cfg.Deploy.EffectiveSharedDirs(), cfg.Deploy.EffectiveSharedFiles())
 
 	envVars := fmt.Sprintf("-e SERVER_NAME=:%s -e APP_ENV=prod -e APP_DEBUG=0", constants.AppPort)
 	if databaseURL != "" {
 		envVars += fmt.Sprintf(" -e DATABASE_URL=%s", security.ShellEscape(databaseURL))
 	}
 
-	// Remove any leftover temp container from a previous failed deploy
-	forceRemoveContainer(ctx, client, containerName)
-
 	// SECURITY: Run as non-root user with non-privileged port
-	dockerRunCmd := fmt.Sprintf(`docker run -d --name %s \
+	return fmt.Sprintf(`docker run -d --name %s \
 		--network %s \
 		--restart unless-stopped \
 		--user %s \
 		%s \
 		%s \
 		%s`, containerName, constants.NetworkName, constants.ContainerUser, envVars, volumeMounts, imageName)
+}
+
+// readSavedDatabaseURL reads the DATABASE_URL persisted by a managed-database
+// deploy (shared/.db_credentials). Returns "" when no managed database is
+// configured or the file cannot be read.
+func readSavedDatabaseURL(ctx context.Context, client ssh.Executor, appPath string) string {
+	credentialsFile := filepath.Join(appPath, "shared", ".db_credentials")
+	result, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", credentialsFile))
+	if err != nil || result == nil || result.ExitCode != 0 {
+		return ""
+	}
+	return strings.TrimSpace(result.Stdout)
+}
+
+// startNewContainer starts the new version with a temporary container name.
+// The old container remains running for zero-downtime deployment.
+func startNewContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, imageName, appPath, tag, databaseURL, containerName string) error {
+	// Remove any leftover temp container from a previous failed deploy
+	forceRemoveContainer(ctx, client, containerName)
+
+	dockerRunCmd := buildAppRunCommand(cfg, imageName, appPath, databaseURL, containerName)
 
 	PrintVerboseCommand(dockerRunCmd)
 	result, err := client.Exec(ctx, dockerRunCmd)
@@ -463,6 +479,37 @@ func startNewContainer(ctx context.Context, client ssh.Executor, cfg *config.Pro
 func swapContainers(ctx context.Context, client ssh.Executor, appName, appPath, tag, tempContainerName string, oldExists bool) error {
 	releasePath := filepath.Join(appPath, "releases", tag)
 	currentPath := filepath.Join(appPath, "current")
+
+	if err := swapContainerNames(ctx, client, appName, tempContainerName, oldExists); err != nil {
+		return err
+	}
+
+	// Update current symlink (critical step — surface any non-zero exit code)
+	symlinkResult, err := client.Exec(ctx, fmt.Sprintf("ln -sfn %s %s", releasePath, currentPath))
+	if err != nil {
+		return fmt.Errorf("failed to update symlink: %w", err)
+	}
+	if err := symlinkResult.Err(); err != nil {
+		return fmt.Errorf("failed to update symlink: %w", err)
+	}
+
+	// Save release marker (best-effort)
+	releaseResult, err := client.Exec(ctx, fmt.Sprintf("echo '%s' > %s/release", tag, releasePath))
+	if err != nil {
+		PrintVerbose("Could not write release file: %v", err)
+	} else if err := releaseResult.Err(); err != nil {
+		PrintVerbose("Could not write release file: %v", err)
+	}
+
+	return nil
+}
+
+// swapContainerNames hands the app name over from the old container to the
+// new one without downtime: the old container is renamed away while still
+// running, the new one takes the name (two instant renames), and only then is
+// the old one stopped. If taking over the name fails, the old container is
+// renamed back so the site keeps being served.
+func swapContainerNames(ctx context.Context, client ssh.Executor, appName, tempContainerName string, oldExists bool) error {
 	oldName := appName + "-old"
 
 	// Remove any stale -old leftover from a previously interrupted swap
@@ -504,23 +551,6 @@ func swapContainers(ctx context.Context, client ssh.Executor, appName, appPath, 
 	// Stopping the old one is best-effort cleanup.
 	if oldExists {
 		stopAndRemoveContainer(ctx, client, oldName)
-	}
-
-	// Update current symlink (critical step — surface any non-zero exit code)
-	symlinkResult, err := client.Exec(ctx, fmt.Sprintf("ln -sfn %s %s", releasePath, currentPath))
-	if err != nil {
-		return fmt.Errorf("failed to update symlink: %w", err)
-	}
-	if err := symlinkResult.Err(); err != nil {
-		return fmt.Errorf("failed to update symlink: %w", err)
-	}
-
-	// Save release marker (best-effort)
-	releaseResult, err := client.Exec(ctx, fmt.Sprintf("echo '%s' > %s/release", tag, releasePath))
-	if err != nil {
-		PrintVerbose("Could not write release file: %v", err)
-	} else if err := releaseResult.Err(); err != nil {
-		PrintVerbose("Could not write release file: %v", err)
 	}
 
 	return nil

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
@@ -165,7 +166,7 @@ func runEnvSet(cmd *cobra.Command, args []string) error {
 
 	// Reload container if requested
 	if envSetReload {
-		if err := reloadContainer(ctx, conn.Client, conn.Project.Name); err != nil {
+		if err := reloadContainer(ctx, conn.Client, conn.Project); err != nil {
 			PrintWarning("Failed to reload: %v", err)
 			PrintInfo("Changes will take effect on next deployment")
 		} else {
@@ -351,7 +352,7 @@ func runEnvPush(cmd *cobra.Command, args []string) error {
 
 	// Reload container if requested
 	if envPushReload {
-		if err := reloadContainer(ctx, conn.Client, conn.Project.Name); err != nil {
+		if err := reloadContainer(ctx, conn.Client, conn.Project); err != nil {
 			PrintWarning("Failed to reload: %v", err)
 			PrintInfo("Changes will take effect on next deployment")
 		} else {
@@ -431,13 +432,16 @@ func buildEnvContent(vars map[string]string) string {
 	return strings.Join(lines, "\n") + "\n"
 }
 
-// reloadContainer performs a rolling restart to apply env changes with minimal downtime
-func reloadContainer(ctx context.Context, client *ssh.Client, appName string) error {
+// reloadContainer performs a rolling restart to apply env changes without
+// downtime. It reuses the deploy primitives: same docker run command (mounts,
+// managed DATABASE_URL, restart policy) and the same rename-based swap.
+func reloadContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig) error {
+	appName := cfg.Name
 	PrintInfo("Reloading container...")
 
 	// Get current container info
 	result, err := client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.Config.Image}}'", appName))
-	if err != nil || result.ExitCode != 0 {
+	if err != nil || result == nil || result.ExitCode != 0 {
 		return fmt.Errorf("container not running")
 	}
 	imageName := strings.TrimSpace(result.Stdout)
@@ -445,37 +449,24 @@ func reloadContainer(ctx context.Context, client *ssh.Client, appName string) er
 	appPath := constants.AppBasePath(appName)
 	tempName := appName + "-new"
 
-	// Start new container with updated env
-	startCmd := fmt.Sprintf(`docker run -d --name %s \
-		--network %s \
-		--user %s \
-		-e SERVER_NAME=:%s \
-		-e APP_ENV=prod \
-		-e APP_DEBUG=0 \
-		-v %s/shared/.env.local:/app/.env.local:ro \
-		%s`, tempName, constants.NetworkName, constants.ContainerUser, constants.AppPort, appPath, imageName)
-
-	result, err = client.Exec(ctx, startCmd)
-	if err != nil {
-		return fmt.Errorf("failed to start new container: %w", err)
-	}
-	if err := result.Err(); err != nil {
-		return fmt.Errorf("failed to start new container: %w", err)
+	// Start new container with updated env (same command as deploy/rollback)
+	databaseURL := readSavedDatabaseURL(ctx, client, appPath)
+	if err := startNewContainer(ctx, client, cfg, imageName, appPath, "", databaseURL, tempName); err != nil {
+		return err
 	}
 
 	// Wait for new container to be healthy
 	PrintInfo("Waiting for new container to be ready...")
 	for i := 0; i < 30; i++ {
-		result, _ := client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.Health.Status}}' 2>/dev/null || echo 'starting'", tempName))
-		status := strings.TrimSpace(result.Stdout)
+		status := "starting"
+		if result, err := client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.Health.Status}}' 2>/dev/null || echo 'starting'", tempName)); err == nil && result != nil {
+			status = strings.TrimSpace(result.Stdout)
+		}
 		if status == "healthy" {
 			break
 		}
 		if i == 29 {
-			// Cleanup and fail
-			if _, err := client.Exec(ctx, fmt.Sprintf("docker rm -f %s", tempName)); err != nil {
-				PrintWarning("Failed to cleanup temporary container: %v", err)
-			}
+			forceRemoveContainer(ctx, client, tempName)
 			return fmt.Errorf("new container failed health check")
 		}
 		if _, err := client.Exec(ctx, "sleep 2"); err != nil {
@@ -483,15 +474,10 @@ func reloadContainer(ctx context.Context, client *ssh.Client, appName string) er
 		}
 	}
 
-	// Stop old container and rename new one
-	if _, err := client.Exec(ctx, fmt.Sprintf("docker stop %s", appName)); err != nil {
-		PrintWarning("Failed to stop old container: %v", err)
-	}
-	if _, err := client.Exec(ctx, fmt.Sprintf("docker rm %s", appName)); err != nil {
-		PrintWarning("Failed to remove old container: %v", err)
-	}
-	if _, err := client.Exec(ctx, fmt.Sprintf("docker rename %s %s", tempName, appName)); err != nil {
-		PrintWarning("Failed to rename container: %v", err)
+	// Zero-downtime name handover with restore on failure (same as deploy)
+	if err := swapContainerNames(ctx, client, appName, tempName, true); err != nil {
+		forceRemoveContainer(ctx, client, tempName)
+		return err
 	}
 
 	return nil

--- a/internal/cmd/rollback.go
+++ b/internal/cmd/rollback.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -16,6 +17,11 @@ var rollbackCmd = &cobra.Command{
 
 If no release is specified, rolls back to the immediately previous release.
 
+The rollback uses the same pipeline as a deployment: the target release is
+started with the same mounts and environment (including the managed database
+URL), health checked, and swapped in without downtime. If the health check
+fails, the current version keeps running.
+
 Example:
   frankendeploy rollback production           # Rollback to previous
   frankendeploy rollback production 20240115  # Rollback to specific release`,
@@ -25,6 +31,45 @@ Example:
 
 func init() {
 	rootCmd.AddCommand(rollbackCmd)
+}
+
+// findPreviousRelease returns the release that precedes current in reverse
+// lexicographic order (release tags default to sortable timestamps). It
+// ignores the current release itself and returns an error when there is
+// nothing to roll back to.
+func findPreviousRelease(releases []string, current string) (string, error) {
+	sorted := make([]string, 0, len(releases))
+	for _, r := range releases {
+		if r != "" {
+			sorted = append(sorted, r)
+		}
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(sorted)))
+
+	currentKnown := false
+	for _, r := range sorted {
+		if r == current {
+			currentKnown = true
+			break
+		}
+	}
+
+	if currentKnown {
+		// Newest release strictly older than the current one — a second
+		// rollback must not bounce forward to a newer release.
+		for _, r := range sorted {
+			if r < current {
+				return r, nil
+			}
+		}
+		return "", fmt.Errorf("no previous release available")
+	}
+
+	// Current release unknown (broken symlink?): newest available release.
+	if len(sorted) > 0 {
+		return sorted[0], nil
+	}
+	return "", fmt.Errorf("no previous release available")
 }
 
 func runRollback(cmd *cobra.Command, args []string) error {
@@ -47,72 +92,86 @@ func runRollback(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	defer conn.Client.Close()
-
-	appPath := constants.AppBasePath(conn.Project.Name)
+	client := conn.Client
+	cfg := conn.Project
+	appName := cfg.Name
+	appPath := constants.AppBasePath(appName)
 
 	PrintInfo("Connecting to %s...", conn.Server.Host)
 
 	// Get current release
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("readlink %s/current | xargs basename", appPath))
-	currentRelease := strings.TrimSpace(result.Stdout)
+	currentRelease := ""
+	if result, err := client.Exec(ctx, fmt.Sprintf("readlink %s/current | xargs basename", appPath)); err == nil && result != nil {
+		currentRelease = strings.TrimSpace(result.Stdout)
+	}
 
 	if targetRelease == "" {
-		// Get previous release
-		result, err := conn.Client.Exec(ctx, fmt.Sprintf("ls -1t %s/releases | head -2 | tail -1", appPath))
+		listResult, err := client.Exec(ctx, fmt.Sprintf("ls -1 %s/releases", appPath))
 		if err != nil {
-			return fmt.Errorf("failed to get releases: %w", err)
+			return fmt.Errorf("failed to list releases: %w", err)
 		}
-		targetRelease = strings.TrimSpace(result.Stdout)
-
-		if targetRelease == "" || targetRelease == currentRelease {
-			return fmt.Errorf("no previous release available")
+		if err := listResult.Err(); err != nil {
+			return fmt.Errorf("failed to list releases: %w", err)
+		}
+		targetRelease, err = findPreviousRelease(strings.Fields(listResult.Stdout), currentRelease)
+		if err != nil {
+			return err
 		}
 	}
 
 	// Verify target release exists
-	releasePath := constants.AppReleasePath(conn.Project.Name, targetRelease)
-	result, _ = conn.Client.Exec(ctx, fmt.Sprintf("test -d %s && echo 'exists'", releasePath))
-	if !strings.Contains(result.Stdout, "exists") {
-		// List available releases
-		result, _ = conn.Client.Exec(ctx, fmt.Sprintf("ls -1t %s/releases", appPath))
-		return fmt.Errorf("release '%s' not found. Available releases:\n%s", targetRelease, result.Stdout)
+	releasePath := constants.AppReleasePath(appName, targetRelease)
+	existsResult, err := client.Exec(ctx, fmt.Sprintf("test -d %s && echo 'exists'", releasePath))
+	if err != nil || existsResult == nil || !strings.Contains(existsResult.Stdout, "exists") {
+		available := ""
+		if listResult, listErr := client.Exec(ctx, fmt.Sprintf("ls -1t %s/releases", appPath)); listErr == nil && listResult != nil {
+			available = listResult.Stdout
+		}
+		return fmt.Errorf("release '%s' not found. Available releases:\n%s", targetRelease, available)
+	}
+
+	// Verify the release image still exists on the server
+	imageName := fmt.Sprintf("%s:%s", appName, targetRelease)
+	imageResult, err := client.Exec(ctx, fmt.Sprintf("docker image inspect %s --format ok 2>/dev/null", imageName))
+	if err != nil || imageResult == nil || !strings.Contains(imageResult.Stdout, "ok") {
+		return fmt.Errorf("image %s no longer exists on the server — cannot roll back to this release", imageName)
 	}
 
 	PrintInfo("Rolling back from %s to %s...", currentRelease, targetRelease)
 
-	// Blue-green rollback: start new container first, then stop old
-	imageName := fmt.Sprintf("%s:%s", conn.Project.Name, targetRelease)
-	tempName := conn.Project.Name + "-rollback"
+	// Same pipeline as deploy: managed database URL, mounts, restart policy
+	databaseURL := readSavedDatabaseURL(ctx, client, appPath)
+	tempName := appName + "-rollback"
 
-	// Start the target release container with a temporary name
-	startCmd := fmt.Sprintf(`docker run -d --name %s \
-		--network %s \
-		--restart unless-stopped \
-		--user %s \
-		-e SERVER_NAME=:%s \
-		-e APP_ENV=prod \
-		-e APP_DEBUG=0 \
-		-v %s/shared/.env.local:/app/.env.local:ro \
-		%s`, tempName, constants.NetworkName, constants.ContainerUser, constants.AppPort, appPath, imageName)
-
-	result, err = conn.Client.Exec(ctx, startCmd)
-	if err != nil {
-		return fmt.Errorf("failed to start container: %w", err)
-	}
-	if err := result.Err(); err != nil {
-		return fmt.Errorf("failed to start container: %w", err)
+	if err := startNewContainer(ctx, client, cfg, imageName, appPath, targetRelease, databaseURL, tempName); err != nil {
+		return err
 	}
 
-	// Stop old container and rename new one
-	stopAndRemoveContainer(ctx, conn.Client, conn.Project.Name)
-	if _, err := conn.Client.Exec(ctx, fmt.Sprintf("docker rename %s %s", tempName, conn.Project.Name)); err != nil {
-		PrintWarning("Failed to rename container: %v", err)
+	// Health check the rollback container before touching the live one
+	PrintInfo("Running health check...")
+	if err := runHealthCheckOnContainer(ctx, client, cfg, tempName); err != nil {
+		forceRemoveContainer(ctx, client, tempName)
+		return fmt.Errorf("rollback aborted, current version untouched: %w", err)
+	}
+	PrintSuccess("Health check passed")
+
+	// Zero-downtime swap with restore on failure (same as deploy)
+	oldExists := false
+	if psResult, psErr := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=^%s$", appName)); psErr == nil && psResult != nil {
+		oldExists = strings.TrimSpace(psResult.Stdout) != ""
+	}
+	PrintInfo("Swapping containers...")
+	if err := swapContainers(ctx, client, appName, appPath, targetRelease, tempName, oldExists); err != nil {
+		forceRemoveContainer(ctx, client, tempName)
+		return fmt.Errorf("swap failed: %w", err)
 	}
 
-	// Update current symlink
-	currentPath := constants.AppCurrentPath(conn.Project.Name)
-	if _, err := conn.Client.Exec(ctx, fmt.Sprintf("ln -sfn %s %s", releasePath, currentPath)); err != nil {
-		PrintWarning("Failed to update symlink: %v", err)
+	// Roll back the Messenger worker to the same image
+	if cfg.Messenger.Enabled {
+		PrintInfo("Rolling back Messenger worker...")
+		if err := deployMessengerWorkers(ctx, client, cfg, imageName, appPath, databaseURL); err != nil {
+			PrintWarning("Failed to roll back Messenger worker: %v", err)
+		}
 	}
 
 	PrintSuccess("Rolled back to release %s", targetRelease)

--- a/internal/cmd/rollback_test.go
+++ b/internal/cmd/rollback_test.go
@@ -1,0 +1,170 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func TestFindPreviousRelease(t *testing.T) {
+	tests := []struct {
+		name     string
+		releases []string
+		current  string
+		want     string
+		wantErr  bool
+	}{
+		{
+			// Guards the mtime-based bug: `ls -1t | head -2 | tail -1` could
+			// return a release NEWER than the current one after a rollback.
+			name:     "previous of newest",
+			releases: []string{"20260101-1000", "20260102-1000", "20260103-1000"},
+			current:  "20260103-1000",
+			want:     "20260102-1000",
+		},
+		{
+			name:     "second rollback must not bounce forward",
+			releases: []string{"20260101-1000", "20260102-1000", "20260103-1000"},
+			current:  "20260101-1000",
+			wantErr:  true,
+		},
+		{
+			name:     "rollback from middle release",
+			releases: []string{"20260101-1000", "20260102-1000", "20260103-1000"},
+			current:  "20260102-1000",
+			want:     "20260101-1000",
+		},
+		{
+			name:     "unknown current falls back to newest",
+			releases: []string{"20260101-1000", "20260102-1000"},
+			current:  "",
+			want:     "20260102-1000",
+		},
+		{
+			name:     "single release",
+			releases: []string{"20260101-1000"},
+			current:  "20260101-1000",
+			wantErr:  true,
+		},
+		{
+			name:     "no releases",
+			releases: []string{},
+			current:  "x",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findPreviousRelease(tt.releases, tt.current)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("findPreviousRelease() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("findPreviousRelease() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildAppRunCommand_SharedByDeployAndRollback(t *testing.T) {
+	// Guards #44: rollback and reload must start the container with the SAME
+	// mounts, env and restart policy as deploy — previously rollback only
+	// mounted .env.local and lost the managed DATABASE_URL and shared dirs.
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Deploy: config.DeployConfig{
+			SharedDirs:  []string{"var/log"},
+			SharedFiles: []string{".env.local"},
+		},
+	}
+
+	cmd := buildAppRunCommand(cfg, "myapp:t1", "/opt/frankendeploy/apps/myapp", "postgres://u:p@myapp-db:5432/db", "myapp-rollback")
+
+	for _, want := range []string{
+		"docker run -d --name myapp-rollback",
+		"--restart unless-stopped",
+		"--user 1000:1000",
+		"-e DATABASE_URL=",
+		"-v /opt/frankendeploy/apps/myapp/shared/var/log:/app/var/log",
+		"-v /opt/frankendeploy/apps/myapp/shared/.env.local:/app/.env.local:ro",
+		"myapp:t1",
+	} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("buildAppRunCommand() missing %q\ngot: %s", want, cmd)
+		}
+	}
+}
+
+func TestReadSavedDatabaseURL(t *testing.T) {
+	t.Run("returns trimmed content", func(t *testing.T) {
+		mock := &ssh.MockExecutor{
+			ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+				if strings.Contains(command, ".db_credentials") {
+					return &ssh.ExecResult{ExitCode: 0, Stdout: "postgres://u:p@db:5432/app\n"}, nil
+				}
+				return &ssh.ExecResult{ExitCode: 0}, nil
+			},
+		}
+		got := readSavedDatabaseURL(context.Background(), mock, "/opt/frankendeploy/apps/myapp")
+		if got != "postgres://u:p@db:5432/app" {
+			t.Errorf("readSavedDatabaseURL() = %q", got)
+		}
+	})
+
+	t.Run("empty when file missing", func(t *testing.T) {
+		mock := &ssh.MockExecutor{
+			ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+				return &ssh.ExecResult{ExitCode: 1}, nil
+			},
+		}
+		if got := readSavedDatabaseURL(context.Background(), mock, "/x"); got != "" {
+			t.Errorf("expected empty URL, got %q", got)
+		}
+	})
+}
+
+func TestReloadContainer_UsesDeployPrimitives(t *testing.T) {
+	// Guards #44: reload previously omitted --restart unless-stopped (container
+	// lost on VPS reboot), shared dirs and the managed DATABASE_URL.
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			switch {
+			case strings.Contains(command, "{{.Config.Image}}"):
+				return &ssh.ExecResult{ExitCode: 0, Stdout: "myapp:t1\n"}, nil
+			case strings.Contains(command, ".db_credentials"):
+				return &ssh.ExecResult{ExitCode: 0, Stdout: "postgres://u:p@myapp-db:5432/app\n"}, nil
+			case strings.Contains(command, "{{.State.Health.Status}}"):
+				return &ssh.ExecResult{ExitCode: 0, Stdout: "healthy\n"}, nil
+			default:
+				return &ssh.ExecResult{ExitCode: 0}, nil
+			}
+		},
+	}
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Deploy: config.DeployConfig{
+			SharedDirs:  []string{"var/log"},
+			SharedFiles: []string{".env.local"},
+		},
+	}
+
+	if err := reloadContainer(context.Background(), mock, cfg); err != nil {
+		t.Fatalf("reloadContainer() unexpected error: %v", err)
+	}
+
+	for _, want := range []string{
+		"--restart unless-stopped",
+		"-e DATABASE_URL=",
+		"/shared/var/log:/app/var/log",
+		"docker rename myapp myapp-old",
+		"docker rename myapp-new myapp",
+	} {
+		if !hasCommand(mock.Commands, want) {
+			t.Errorf("reloadContainer() missing %q\nrecorded: %v", want, mock.Commands)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

`rollback` was a degraded, silently-breakable version of the deploy path:

- Only `.env.local` was mounted: shared dirs (var/log, sessions, uploads…) were lost, and the **managed `DATABASE_URL`** (injected via `-e` at deploy time, persisted in `shared/.db_credentials`) was absent — **any app with a managed database was broken after rollback**.
- `docker rename` / `ln -sfn` errors were swallowed (`result.Err()` never checked): a failed rename left the site down while the CLI printed "Rolled back to release X".
- No health check before stopping the live container; the Messenger worker was never rolled back.
- "Previous release" was picked by mtime (`ls -1t | head -2 | tail -1`): after a first rollback it could select a release **newer** than the current one.
- `env --reload` had the same class of bugs: no `--restart unless-stopped` (container lost on VPS reboot), no shared dirs, no `DATABASE_URL`.

Closes #44

## Changes

- **`buildAppRunCommand`**: single `docker run` builder (mounts, env, managed `DATABASE_URL` via new `readSavedDatabaseURL`, non-root user, restart policy) shared by deploy, rollback and env reload.
- **Rollback = deploy pipeline**: `startNewContainer` → health check (current version untouched on failure) → zero-downtime `swapContainers` with restore-on-failure → worker rollback.
- **`findPreviousRelease`**: deterministic reverse-lexicographic selection; a second rollback errors with "no previous release available" instead of bouncing forward.
- Release image existence checked upfront with a clear error.
- `env --reload` reuses the same primitives and the rename-based name handover (`swapContainerNames`, extracted from `swapContainers`).
- Nil-dereference fixes on all SSH results in the rollback path.

## Verification

- 10 new tests (`findPreviousRelease` table incl. the bounce-forward guard, `buildAppRunCommand` parity, `readSavedDatabaseURL`, `reloadContainer` primitives); `rollback.go` previously had **zero tests**. 593 tests green with `-race`; vet/gofmt clean; no new lint issues.
- **Validated live** on a production VPS (managed PostgreSQL app):
  - Zero-downtime rollback: **0 non-200 over 61 requests** probing the public HTTPS endpoint every ~150ms during the rollback.
  - `DATABASE_URL` present in the rolled-back container; symlink updated to the target release; container healthy; public `/api` → 200.
  - Second rollback fails cleanly with `no previous release available`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
