### PR TITLE
fix(deploy): generate missing Docker artifacts automatically (#70)

### DIFF
--- a/internal/cmd/artifacts.go
+++ b/internal/cmd/artifacts.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/generator"
+)
+
+// ensureDockerArtifacts generates the Docker build artifacts (Dockerfile,
+// docker-entrypoint.sh, .dockerignore) if they are missing, so that
+// `deploy` works right after `init` without requiring a manual `build`.
+// Existing files are never overwritten: users may have customized them.
+func ensureDockerArtifacts(cfg *config.ProjectConfig) error {
+	type artifact struct {
+		path  string
+		write func(*generator.DockerfileGenerator) error
+	}
+
+	artifacts := []artifact{
+		{"Dockerfile", func(g *generator.DockerfileGenerator) error { return g.WriteDockerfile("") }},
+		{"docker-entrypoint.sh", func(g *generator.DockerfileGenerator) error { return g.WriteEntrypoint("") }},
+		{".dockerignore", func(g *generator.DockerfileGenerator) error { return g.WriteDockerignore("") }},
+	}
+
+	var missing []artifact
+	for _, a := range artifacts {
+		if _, err := os.Stat(a.path); os.IsNotExist(err) {
+			missing = append(missing, a)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	PrintInfo("Docker artifacts missing — generating them (equivalent to 'frankendeploy build')")
+	gen := generator.NewDockerfileGenerator(cfg)
+	for _, a := range missing {
+		if err := a.write(gen); err != nil {
+			return fmt.Errorf("failed to generate %s: %w", a.path, err)
+		}
+		PrintSuccess("Generated %s", a.path)
+	}
+
+	return nil
+}

--- a/internal/cmd/artifacts_test.go
+++ b/internal/cmd/artifacts_test.go
@@ -1,0 +1,100 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+)
+
+func artifactsTestConfig() *config.ProjectConfig {
+	return &config.ProjectConfig{
+		Name: "test-app",
+		PHP: config.PHPConfig{
+			Version:    "8.3",
+			Extensions: []string{"intl", "opcache"},
+		},
+	}
+}
+
+func TestEnsureDockerArtifacts_GeneratesAllWhenMissing(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := ensureDockerArtifacts(artifactsTestConfig()); err != nil {
+		t.Fatalf("ensureDockerArtifacts failed: %v", err)
+	}
+
+	for _, f := range []string{"Dockerfile", "docker-entrypoint.sh", ".dockerignore"} {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Fatalf("%s should have been generated: %v", f, err)
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s should not be empty", f)
+		}
+	}
+
+	info, err := os.Stat("docker-entrypoint.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode()&0111 == 0 {
+		t.Error("docker-entrypoint.sh should be executable")
+	}
+}
+
+func TestEnsureDockerArtifacts_NeverOverwritesExisting(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	custom := "# customized by user — must not be overwritten\n"
+	for _, f := range []string{"Dockerfile", "docker-entrypoint.sh", ".dockerignore"} {
+		if err := os.WriteFile(f, []byte(custom), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := ensureDockerArtifacts(artifactsTestConfig()); err != nil {
+		t.Fatalf("ensureDockerArtifacts failed: %v", err)
+	}
+
+	for _, f := range []string{"Dockerfile", "docker-entrypoint.sh", ".dockerignore"} {
+		content, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(content) != custom {
+			t.Errorf("%s was overwritten, user content lost", f)
+		}
+	}
+}
+
+func TestEnsureDockerArtifacts_GeneratesOnlyMissing(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	custom := "# my hand-tuned Dockerfile\n"
+	if err := os.WriteFile("Dockerfile", []byte(custom), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ensureDockerArtifacts(artifactsTestConfig()); err != nil {
+		t.Fatalf("ensureDockerArtifacts failed: %v", err)
+	}
+
+	content, err := os.ReadFile("Dockerfile")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != custom {
+		t.Error("existing Dockerfile was overwritten")
+	}
+
+	for _, f := range []string{"docker-entrypoint.sh", ".dockerignore"} {
+		info, err := os.Stat(f)
+		if err != nil {
+			t.Fatalf("%s should have been generated: %v", f, err)
+		}
+		if info.Size() == 0 {
+			t.Errorf("%s should not be empty", f)
+		}
+	}
+}

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -117,6 +117,13 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		PrintSuccess("Pre-flight checks passed")
 	}
 
+	// Step 2: Ensure Docker artifacts exist (novice flow: init → deploy without build)
+	if deployRemoteBuild || !deployNoBuild {
+		if err := ensureDockerArtifacts(projectCfg); err != nil {
+			return err
+		}
+	}
+
 	if deployRemoteBuild {
 		// Remote build: transfer source code and build on server
 		PrintInfo("Transferring source code to server...")


### PR DESCRIPTION
## Summary

Fixes #70 — `deploy` is now self-sufficient: it no longer requires a manual `frankendeploy build` first.

The natural novice flow `init` → `deploy` failed deep into the pipeline (after SSH connect, preflight and source transfer) with a raw Docker error:

```
ERROR: failed to build: failed to solve: failed to read dockerfile: open Dockerfile: no such file or directory
```

## Changes

- New `ensureDockerArtifacts()` in `internal/cmd/artifacts.go`: before building (local or remote), checks that `Dockerfile`, `docker-entrypoint.sh` and `.dockerignore` exist and generates **only the missing ones**, reusing the same generator code path as `frankendeploy build`.
- **Never overwrites existing files** — customized Dockerfiles are preserved.
- Wired into `runDeploy` before both build paths (remote build transfers the sources, so the check runs before the transfer). Skipped with `--no-build` on a local build, where no Dockerfile is needed.
- Info message when generating: `Docker artifacts missing — generating them (equivalent to 'frankendeploy build')`.

## Tests

- 3 new unit tests (`artifacts_test.go`): all missing → all generated (entrypoint executable); all present → byte-for-byte untouched; partial → only missing generated.
- Full suite: **596 tests green with `-race`**.

## Live validation

Deleted the three artifacts from the demo API Platform app and ran `deploy hidora` directly (remote build, managed PostgreSQL):

```
✅ Pre-flight checks passed
ℹ️  Docker artifacts missing — generating them (equivalent to 'frankendeploy build')
✅ Generated Dockerfile
✅ Generated docker-entrypoint.sh
✅ Generated .dockerignore
...
✅ Deployment complete!
```

https://demo-api.193-17-33-83.nip.io/api → HTTP 200 after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
