### PR TITLE
docs: sync static site with v0.9.0 behavior

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -77,18 +77,14 @@ Update comparison links at bottom:
 [X.Y.Z]: https://github.com/yoanbernabeu/FrankenDeploy/compare/vPREVIOUS...vX.Y.Z
 ```
 
-#### 4.2 Documentation Hero
+#### 4.2 Documentation
 
-Update version in `docs/src/components/homepage/HeroAnimated.astro` line 6:
-
-```astro
-const { version = "X.Y.Z" } = Astro.props;
-```
+Check whether `docs/src/content/docs/installation.md` pins a version in the manual download examples (`VERSION=X.Y.Z`) and update it to the new version.
 
 ### Step 5: Commit and Push
 
 ```bash
-git add CHANGELOG.md docs/src/components/homepage/HeroAnimated.astro
+git add CHANGELOG.md docs/src/content/docs/installation.md
 git commit -m "chore(release): bump version to X.Y.Z
 
 Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
@@ -129,7 +125,7 @@ GitHub `--generate-notes` automatically credits contributors in release notes.
 - [ ] Version type matches changes (major/minor/patch)
 - [ ] CHANGELOG.md updated with all PRs
 - [ ] All contributors credited with @username
-- [ ] Hero version updated in docs
+- [ ] Pinned version in installation.md updated
 - [ ] CI passed after version commit
 - [ ] GitHub release created
 

--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -17,7 +17,7 @@ name: my-app
 
 # PHP Configuration
 php:
-  # PHP version: 8.1, 8.2, 8.3, or 8.4
+  # PHP version: 8.2, 8.3, or 8.4 (FrankenPHP requires PHP >= 8.2)
   version: "8.3"
 
   # PHP extensions to install
@@ -89,7 +89,7 @@ deploy:
   # Domain for HTTPS (required for production)
   domain: my-app.com
 
-  # Health check endpoint (default: /)
+  # Health check endpoint (default: /, or /api when API Platform is detected)
   healthcheck_path: /health
 
   # Number of releases to keep (default: 5)
@@ -143,10 +143,11 @@ name: my-app
 ### `php.version`
 
 Supported versions:
-- `8.1`
 - `8.2`
 - `8.3`
 - `8.4`
+
+FrankenPHP requires PHP >= 8.2. If your `composer.json` allows older versions (e.g. `>=8.1`), `init` floors the detected version at 8.2 and warns you.
 
 ### `php.extensions`
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -23,16 +23,19 @@ FrankenDeploy wraps all this power into simple commands.
 
 ### Auto-detection
 FrankenDeploy analyzes your Symfony project and automatically detects:
-- PHP version from `composer.json`
+- PHP version from `composer.json` (8.2 minimum, required by FrankenPHP)
 - Required PHP extensions
 - Database driver (PostgreSQL, MySQL, SQLite)
 - Asset build tools (Webpack Encore, Vite, AssetMapper)
+- API Platform (sets the health check path to `/api`)
 
 ### Docker Generation
 Generates optimized Docker configuration:
 - Multi-stage Dockerfile with FrankenPHP
-- docker-compose.yaml for local development
+- compose.yaml for local development
 - Production-ready configuration
+
+Missing files are generated automatically at deploy time — customized files are never overwritten.
 
 ### One-Command Deployment
 ```bash
@@ -55,7 +58,7 @@ cd my-symfony-app
 # Initialize FrankenDeploy (with optional domain)
 frankendeploy init --domain my-app.com
 
-# Generate Docker files
+# Generate Docker files (optional — deploy does it for you)
 frankendeploy build
 
 # Start local development
@@ -66,7 +69,8 @@ frankendeploy server add production deploy@my-vps.com
 frankendeploy server setup production --email admin@example.com
 
 # Set environment variables for this app
-frankendeploy env set production DATABASE_URL="postgresql://..."
+# (DATABASE_URL is injected automatically with a managed database)
+frankendeploy env set production APP_SECRET="your-secret"
 
 # Deploy!
 frankendeploy deploy production --remote-build

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -72,7 +72,7 @@ PHP configuration for your application.
 
 ```yaml
 php:
-  version: "8.3"      # PHP version (8.1, 8.2, 8.3, 8.4)
+  version: "8.3"      # PHP version (8.2 minimum — required by FrankenPHP)
   extensions:         # PHP extensions to install
     - pdo_pgsql
     - intl
@@ -169,10 +169,11 @@ When you run `frankendeploy init`, it automatically detects:
 
 | Feature | Detection Method |
 |---------|------------------|
-| PHP version | `composer.json` require.php constraint |
+| PHP version | `composer.json` require.php constraint (floored at 8.2) |
 | PHP extensions | `composer.json` ext-* requirements |
 | Database | `doctrine.yaml`, `.env` DATABASE_URL |
 | Assets | `package.json`, `vite.config.js`, `importmap.php` |
+| API Platform | `composer.json` (`api-platform/*`) — sets `healthcheck_path: /api` |
 
 ### Init Options
 

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -9,14 +9,17 @@ description: Deploy your Symfony application to production
 frankendeploy deploy production
 ```
 
-This command performs a complete deployment:
-1. Builds Docker image locally
-2. Transfers image to server
-3. Stops old container
-4. Starts new container
-5. Runs health checks
-6. Updates Caddy configuration
-7. Cleans up old releases
+This command performs a complete blue-green deployment:
+1. Generates missing Docker artifacts (`Dockerfile`, `docker-entrypoint.sh`, `.dockerignore`) — no need to run `build` first, and customized files are never overwritten
+2. Builds the Docker image (locally, or on the server with remote build)
+3. Transfers it to the server
+4. Sets up the managed database container if configured (`DATABASE_URL` is injected automatically)
+5. Starts the **new** container alongside the old one and runs pre-deploy hooks
+6. Runs health checks on the new container
+7. Swaps traffic to the new container (zero downtime), then stops the old one
+8. Updates Caddy configuration and cleans up old releases
+
+If any step fails before the swap, the old container keeps serving traffic untouched.
 
 ## Deployment Options
 
@@ -95,6 +98,8 @@ deploy:
   healthcheck_path: /health
 ```
 
+The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used by Caddy's active health checks on the running container.
+
 Create a health endpoint in your Symfony app:
 
 ```php
@@ -106,7 +111,7 @@ public function health(): Response
 }
 ```
 
-If the health check fails, FrankenDeploy automatically rolls back.
+If the health check fails, the new container is removed and the old one keeps serving traffic — a failed deployment never takes your site down.
 
 ## Deployment Hooks
 
@@ -202,10 +207,14 @@ FrankenDeploy ensures zero downtime:
 
 1. New container starts alongside old one
 2. Health checks verify new container
-3. Caddy switches traffic to new container
+3. Traffic switches to the new container via a rename-based swap (Docker's embedded DNS follows the container name, so no request is dropped)
 4. Old container is stopped
 
-If anything fails, traffic stays on the old container.
+If anything fails — including the swap itself — traffic stays on the old container.
+
+## Managed Database
+
+With `database.managed: true` (the default for PostgreSQL/MySQL), each deployment ensures the database container is running and injects the generated `DATABASE_URL` into your application automatically. Credentials are created once and persist across deployments — you never have to set `DATABASE_URL` yourself.
 
 ## Monitoring Deployments
 

--- a/docs/src/content/docs/guides/environment-variables.md
+++ b/docs/src/content/docs/guides/environment-variables.md
@@ -88,7 +88,7 @@ For Symfony applications, you typically need:
 |----------|-------------|
 | `APP_SECRET` | Symfony secret key (required) |
 | `APP_ENV` | Environment (auto-set to `prod`) |
-| `DATABASE_URL` | Database connection string |
+| `DATABASE_URL` | Database connection string — **injected automatically** with a managed database (`database.managed: true`); only set it for an external database |
 | `MAILER_DSN` | Email transport (optional) |
 
 ## Security Notes

--- a/docs/src/content/docs/guides/rollback.md
+++ b/docs/src/content/docs/guides/rollback.md
@@ -11,7 +11,11 @@ Roll back to the previous release:
 frankendeploy rollback production
 ```
 
-This instantly switches traffic to the previous version.
+This switches traffic back to the previous release with the **same guarantees as a deployment**:
+- The rollback container gets the same shared directories, environment and managed `DATABASE_URL` as a regular deploy
+- A health check runs **before** the swap — if the old release is unhealthy, the rollback aborts and the current version keeps running
+- The swap itself is zero-downtime (same rename-based mechanism as deploy)
+- Messenger workers are rolled back to the same release
 
 ## Rollback to Specific Release
 
@@ -43,16 +47,16 @@ frankendeploy rollback production 20240114-180000
 
 ## Automatic Rollback
 
-FrankenDeploy automatically rolls back if:
+During a deployment, FrankenDeploy protects the running version if:
 
 1. **Health check fails** - The new container doesn't respond correctly
 2. **Container won't start** - Docker fails to start the container
 3. **Pre-deploy hooks fail** - Migration or other commands fail
 
-You'll see:
+In all these cases the new container is removed and the **old container keeps serving traffic untouched** — there is nothing to restore because traffic never left the working version:
+
 ```
-⚠️ Health check failed, rolling back...
-✅ Rolled back to release 20240115-120000
+⚠️  Health check failed, rolling back...
 ```
 
 ## Managing Releases

--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -72,7 +72,7 @@ The `--email` flag is **required** for Let's Encrypt certificate registration.
 
 This command:
 1. Installs Docker if not present
-2. Configures UFW firewall (ports 22, 80, 443)
+2. Configures UFW firewall (HTTP/HTTPS + SSH — both your configured SSH port and the port the SSH daemon actually uses are allowed before the firewall is enabled, so a custom port or gateway setup can never lock you out)
 3. Installs and configures Fail2ban (SSH brute-force protection)
 4. Creates the FrankenDeploy directory structure
 5. Sets up the `frankendeploy` Docker network
@@ -231,7 +231,7 @@ This ensures **zero downtime** for existing apps during deployments.
 
 FrankenDeploy automatically configures:
 
-1. **UFW Firewall** - Only ports 22, 80, 443 open
+1. **UFW Firewall** - Only SSH (your actual SSH ports, not just 22), 80 and 443 open
 2. **Fail2ban** - SSH brute-force protection (automatic)
 
 ### Additional Recommendations

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -15,7 +15,7 @@ This script automatically detects your OS and architecture and installs the late
 
 ## Using Go
 
-If you have Go 1.21+ installed:
+If you have Go 1.24+ installed:
 
 ```bash
 go install github.com/yoanbernabeu/frankendeploy/cmd/frankendeploy@latest
@@ -30,24 +30,26 @@ brew install frankendeploy
 
 ## Manual Download
 
-Download the binary for your platform from the [GitHub Releases](https://github.com/yoanbernabeu/frankendeploy/releases) page.
+Download the binary for your platform from the [GitHub Releases](https://github.com/yoanbernabeu/frankendeploy/releases) page. Archive names include the version number, e.g. `frankendeploy_0.9.0_linux_amd64.tar.gz`.
 
 ### Linux (amd64)
 ```bash
-curl -LO https://github.com/yoanbernabeu/frankendeploy/releases/latest/download/frankendeploy_linux_amd64.tar.gz
-tar -xzf frankendeploy_linux_amd64.tar.gz
+VERSION=0.9.0  # See https://github.com/yoanbernabeu/frankendeploy/releases/latest
+curl -LO https://github.com/yoanbernabeu/frankendeploy/releases/download/v${VERSION}/frankendeploy_${VERSION}_linux_amd64.tar.gz
+tar -xzf frankendeploy_${VERSION}_linux_amd64.tar.gz
 sudo mv frankendeploy /usr/local/bin/
 ```
 
 ### macOS (Apple Silicon)
 ```bash
-curl -LO https://github.com/yoanbernabeu/frankendeploy/releases/latest/download/frankendeploy_darwin_arm64.tar.gz
-tar -xzf frankendeploy_darwin_arm64.tar.gz
+VERSION=0.9.0  # See https://github.com/yoanbernabeu/frankendeploy/releases/latest
+curl -LO https://github.com/yoanbernabeu/frankendeploy/releases/download/v${VERSION}/frankendeploy_${VERSION}_darwin_arm64.tar.gz
+tar -xzf frankendeploy_${VERSION}_darwin_arm64.tar.gz
 sudo mv frankendeploy /usr/local/bin/
 ```
 
 ### Windows
-Download `frankendeploy_windows_amd64.zip` and add it to your PATH.
+Download `frankendeploy_<version>_windows_amd64.zip` and add it to your PATH.
 
 ## Verify Installation
 

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -29,10 +29,11 @@ FrankenDeploy will:
 - Identify required extensions
 - Find your database configuration
 - Detect your asset build system
+- Detect API Platform and set the health check path to `/api` automatically
 
 This creates a `frankendeploy.yaml` configuration file.
 
-## Step 2: Generate Docker Files
+## Step 2: Generate Docker Files (optional)
 
 ```bash
 frankendeploy build
@@ -40,9 +41,12 @@ frankendeploy build
 
 This generates:
 - `Dockerfile` - Multi-stage build with FrankenPHP
-- `docker-compose.yaml` - Development environment
-- `docker-compose.prod.yaml` - Production template
+- `docker-entrypoint.sh` - Startup script (waits for DB, runs migrations)
+- `compose.yaml` - Development environment
+- `compose.prod.yaml` - Production template
 - `.dockerignore` - Optimized ignore patterns
+
+This step is optional before deploying: `frankendeploy deploy` generates any missing Docker artifacts automatically (and never overwrites files you have customized). Run `build` explicitly when you want to inspect or customize the generated files, or to use the local dev environment.
 
 ## Step 3: Start Local Development
 
@@ -87,8 +91,13 @@ The `--email` is required for Let's Encrypt SSL certificates.
 Set your production secrets for this application (run from your project directory):
 
 ```bash
-frankendeploy env set production DATABASE_URL="postgresql://user:pass@host/db"
 frankendeploy env set production APP_SECRET="your-secret-key"
+```
+
+**No `DATABASE_URL` needed with a managed database**: if your `frankendeploy.yaml` has `database.managed: true` (the default for PostgreSQL/MySQL), FrankenDeploy creates the database container and injects `DATABASE_URL` automatically. Only set it yourself when using an external database:
+
+```bash
+frankendeploy env set production DATABASE_URL="postgresql://user:pass@host/db"
 ```
 
 Or push a local `.env.prod` file:
@@ -103,12 +112,12 @@ frankendeploy env push production .env.prod
 frankendeploy deploy production --remote-build
 ```
 
-The `--remote-build` flag builds the Docker image directly on the server (recommended for Apple Silicon Macs).
+The `--remote-build` flag builds the Docker image directly on the server (recommended for Apple Silicon Macs). FrankenDeploy also detects architecture mismatches automatically and offers to enable remote build for you.
 
 That's it! Your Symfony app is now live with:
-- FrankenPHP worker mode for performance
+- FrankenPHP as the application server
 - Automatic HTTPS via Caddy
-- Health checks and rollback support
+- Zero-downtime blue-green deployments with health checks and rollback
 
 ## Common Operations
 


### PR DESCRIPTION
## Summary

The static docs site had not been touched since v0.6.0. This PR syncs every page with the actual v0.9.0 behavior, fixes factually wrong content, and repairs broken download links.

## Factual fixes

- **Deployment guide**: the pipeline description still documented the pre-blue-green flow ("stops old container, starts new container"). Now documents the real sequence: new container starts alongside the old one, health check, zero-downtime rename-based swap, and the guarantee that a failed deploy never takes the site down.
- **`build` is now optional** (#70/#73): quickstart, getting-started and deployment explain that `deploy` generates missing Docker artifacts automatically and never overwrites customized files.
- **PHP 8.1 removed** from supported versions in both config references (FrankenPHP requires >= 8.2; detection floors at 8.2 with a warning) — matches #64.
- **API Platform auto-detection** documented (healthcheck_path defaults to `/api`) — matches #65/#69.
- **Managed database**: examples no longer tell users to set `DATABASE_URL` by hand; it is injected automatically with `database.managed: true`.
- **UFW/firewall**: docs claimed hardcoded ports 22/80/443; now describes the real behavior (configured SSH port + actual sshd session port) — matches #68.
- **Rollback guide** rewritten for the deploy-parity rollback (#72): health check before swap, shared dirs and managed `DATABASE_URL` preserved, zero-downtime swap, Messenger worker rollback. Clarified that a failed deployment leaves the old container running (nothing is "restored").
- **Broken download links**: `releases/latest/download/frankendeploy_linux_amd64.tar.gz` returns **404** (assets are versioned). Manual download examples now use the versioned URLs.
- Corrected generated filenames (`compose.yaml` / `compose.prod.yaml`, `docker-entrypoint.sh`), removed the untrue "FrankenPHP worker mode" claim from quickstart, Go 1.21 → 1.24.
- **Release skill**: removed the step referencing `docs/src/components/homepage/HeroAnimated.astro`, which no longer exists; replaced with the installation.md version pin check.

## Verification

- `go run cmd/gendocs/main.go` + `npm run build` (Astro + pagefind): site builds, 42 pages indexed.
- Command reference pages are regenerated by CI (`docs.yml`) — nothing to commit there.
- No hardcoded version on the homepage (checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
