### PR TITLE
fix(deploy): use detected server architecture for docker build --platform (#54)

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -140,8 +140,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	} else {
 		// Local build: build locally and transfer image
 		if !deployNoBuild {
-			PrintInfo("Building Docker image locally...")
-			if err := buildDockerImage(imageName); err != nil {
+			platform := buildPlatformForServer(ctx, client)
+			PrintInfo("Building Docker image locally (%s)...", platform)
+			if err := buildDockerImage(imageName, platform); err != nil {
 				return fmt.Errorf("build failed: %w", err)
 			}
 			PrintSuccess("Image built: %s", imageName)
@@ -272,10 +273,31 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func buildDockerImage(imageName string) error {
-	// Use buildx to cross-compile for linux/amd64 (VPS architecture)
+// buildPlatformForServer returns the docker --platform value matching the
+// server's CPU architecture, so a local build always produces an image the
+// server can run (e.g. arm64 Mac → arm64 VPS must NOT build amd64).
+// Falls back to linux/amd64 when detection fails.
+func buildPlatformForServer(ctx context.Context, client ssh.Executor) string {
+	result, err := client.Exec(ctx, "uname -m")
+	if err != nil || result == nil || result.Err() != nil {
+		PrintWarning("Could not detect server architecture, building for linux/amd64")
+		return "linux/amd64"
+	}
+
+	arch := normalizeArch(result.Stdout)
+	switch arch {
+	case "amd64", "arm64":
+		return "linux/" + arch
+	default:
+		PrintWarning("Unknown server architecture %q, building for linux/amd64", arch)
+		return "linux/amd64"
+	}
+}
+
+func buildDockerImage(imageName, platform string) error {
+	// Use buildx to cross-compile for the server's architecture
 	dockerCmd := exec.Command("docker", "buildx", "build",
-		"--platform", "linux/amd64",
+		"--platform", platform,
 		"--target", "frankenphp_prod",
 		"--load",
 		"-t", imageName,

--- a/internal/cmd/platform_test.go
+++ b/internal/cmd/platform_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func TestBuildPlatformForServer(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdout   string
+		exitCode int
+		execErr  error
+		want     string
+	}{
+		{name: "x86_64 server", stdout: "x86_64\n", want: "linux/amd64"},
+		{name: "aarch64 server", stdout: "aarch64\n", want: "linux/arm64"},
+		{name: "arm64 server", stdout: "arm64\n", want: "linux/arm64"},
+		{name: "amd64 server", stdout: "amd64\n", want: "linux/amd64"},
+		{name: "exec error falls back to amd64", execErr: errors.New("connection lost"), want: "linux/amd64"},
+		{name: "non-zero exit falls back to amd64", stdout: "", exitCode: 127, want: "linux/amd64"},
+		{name: "unknown arch falls back to amd64", stdout: "riscv64\n", want: "linux/amd64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &ssh.MockExecutor{
+				ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+					if tt.execErr != nil {
+						return nil, tt.execErr
+					}
+					return &ssh.ExecResult{Stdout: tt.stdout, ExitCode: tt.exitCode}, nil
+				},
+			}
+			got := buildPlatformForServer(context.Background(), mock)
+			if got != tt.want {
+				t.Errorf("buildPlatformForServer() = %q, want %q", got, tt.want)
+			}
+			if len(mock.Commands) != 1 || mock.Commands[0] != "uname -m" {
+				t.Errorf("expected a single 'uname -m' command, got %v", mock.Commands)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #54 — the local Docker build hardcoded `--platform linux/amd64`.

The silent trap: an Apple Silicon Mac deploying to an **ARM VPS** (Hetzner CAX, AWS Graviton) passes the architecture-mismatch check (same arch → local build) but produced an **amd64** image the server cannot run. The result was `exec format error` inside the container, surfacing to the user as an unexplained "health check failed" with no hint of the real cause.

## Changes

- New `buildPlatformForServer(ctx, client)`: asks the server (`uname -m`, via the mockable `ssh.Executor` interface), normalizes (`x86_64`/`amd64` → `linux/amd64`, `aarch64`/`arm64` → `linux/arm64`), and falls back to `linux/amd64` with a warning when detection fails or returns an unknown architecture.
- `buildDockerImage(imageName, platform)` now receives the platform instead of hardcoding it.
- The build message shows the chosen platform: `Building Docker image locally (linux/amd64)...`

## Tests

- 7 new table-driven tests for `buildPlatformForServer` (x86_64, aarch64, arm64, amd64, exec error, non-zero exit, unknown arch) asserting both the result and the single `uname -m` call.
- Full suite: **604 tests green with `-race`**.

## Live validation

`deploy hidora --no-remote-build` from an arm64 Mac against the x86_64 VPS:

```
✅ Pre-flight checks passed
ℹ️  Building Docker image locally (linux/amd64)...
```

The platform now comes from server detection over SSH instead of the hardcoded constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
