### PR TITLE
fix(deploy): health check UX — container logs on failure, tunable window, honest flags (#51)

### DIFF
--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -92,6 +92,11 @@ deploy:
   # Health check endpoint (default: /, or /api when API Platform is detected)
   healthcheck_path: /health
 
+  # Health check tuning (optional, 0 or omitted = defaults)
+  healthcheck_timeout: 90    # overall window in seconds (default: 90)
+  healthcheck_retries: 30    # max attempts (default: 30)
+  healthcheck_interval: 3    # seconds between attempts (default: 3)
+
   # Number of releases to keep (default: 5)
   keep_releases: 5
 

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -82,8 +82,17 @@ If you've already built the image:
 frankendeploy deploy production --no-build
 ```
 
+### Skip Individual Checks
+```bash
+# Skip the pre-flight environment variables check
+frankendeploy deploy production --skip-env-check
+
+# Skip the health check entirely (traffic switches unverified)
+frankendeploy deploy production --skip-healthcheck
+```
+
 ### Force Deploy
-Skip health check failures:
+`--force` skips the env pre-flight and continues even when pre-deploy hooks (e.g. migrations) or the health check fail — use with care:
 ```bash
 frankendeploy deploy production --force
 ```
@@ -99,6 +108,17 @@ deploy:
 ```
 
 The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used by Caddy's active health checks on the running container.
+
+The check window is generous by default (90 seconds — a cold Symfony container needs time for opcache warmup and database wait) and tunable:
+
+```yaml
+deploy:
+  healthcheck_timeout: 90    # overall window in seconds
+  healthcheck_retries: 30    # max attempts
+  healthcheck_interval: 3    # seconds between attempts
+```
+
+When the health check fails, FrankenDeploy prints the **last 50 log lines of the failing container** before removing it, so you immediately see the real cause (missing env variable, failed migration, PHP fatal…).
 
 Create a health endpoint in your Symfony app:
 

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -98,15 +98,19 @@ func runAppList(cmd *cobra.Command, args []string) error {
 		}
 
 		// Get container status
-		statusResult, _ := conn.Client.Exec(ctx, fmt.Sprintf("docker ps --filter name=%s --format '{{.Status}}' 2>/dev/null", app))
-		status := strings.TrimSpace(statusResult.Stdout)
+		status := ""
+		if statusResult, err := conn.Client.Exec(ctx, fmt.Sprintf("docker ps --filter name=%s --format '{{.Status}}' 2>/dev/null", app)); err == nil && statusResult != nil {
+			status = strings.TrimSpace(statusResult.Stdout)
+		}
 		if status == "" {
 			status = "stopped"
 		}
 
 		// Get current release
-		releaseResult, _ := conn.Client.Exec(ctx, fmt.Sprintf("readlink %s/current 2>/dev/null | xargs basename", constants.AppBasePath(app)))
-		release := strings.TrimSpace(releaseResult.Stdout)
+		release := ""
+		if releaseResult, err := conn.Client.Exec(ctx, fmt.Sprintf("readlink %s/current 2>/dev/null | xargs basename", constants.AppBasePath(app))); err == nil && releaseResult != nil {
+			release = strings.TrimSpace(releaseResult.Stdout)
+		}
 		if release == "" {
 			release = "-"
 		}
@@ -238,32 +242,38 @@ func runAppStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Server:      %s\n\n", serverName)
 
 	// Container status
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.Status}}' 2>/dev/null", appName))
-	status := strings.TrimSpace(result.Stdout)
+	status := ""
+	if result, err := conn.Client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.Status}}' 2>/dev/null", appName)); err == nil && result != nil {
+		status = strings.TrimSpace(result.Stdout)
+	}
 	if status == "" {
 		status = "not deployed"
 	}
 	fmt.Printf("Status:      %s\n", status)
 
 	// Current release
-	result, _ = conn.Client.Exec(ctx, fmt.Sprintf("readlink %s/current 2>/dev/null | xargs basename", appPath))
-	release := strings.TrimSpace(result.Stdout)
+	release := ""
+	if result, err := conn.Client.Exec(ctx, fmt.Sprintf("readlink %s/current 2>/dev/null | xargs basename", appPath)); err == nil && result != nil {
+		release = strings.TrimSpace(result.Stdout)
+	}
 	if release != "" {
 		fmt.Printf("Release:     %s\n", release)
 	}
 
 	// Uptime
 	if status == "running" {
-		result, _ = conn.Client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.StartedAt}}' 2>/dev/null", appName))
-		startedAt := strings.TrimSpace(result.Stdout)
-		if startedAt != "" {
-			fmt.Printf("Started:     %s\n", startedAt)
+		if result, err := conn.Client.Exec(ctx, fmt.Sprintf("docker inspect %s --format '{{.State.StartedAt}}' 2>/dev/null", appName)); err == nil && result != nil {
+			if startedAt := strings.TrimSpace(result.Stdout); startedAt != "" {
+				fmt.Printf("Started:     %s\n", startedAt)
+			}
 		}
 	}
 
 	// Available releases
-	result, _ = conn.Client.Exec(ctx, fmt.Sprintf("ls -1t %s/releases 2>/dev/null | head -5", appPath))
-	releases := strings.TrimSpace(result.Stdout)
+	releases := ""
+	if result, err := conn.Client.Exec(ctx, fmt.Sprintf("ls -1t %s/releases 2>/dev/null | head -5", appPath)); err == nil && result != nil {
+		releases = strings.TrimSpace(result.Stdout)
+	}
 	if releases != "" {
 		fmt.Println("\nRecent releases:")
 		for _, r := range strings.Split(releases, "\n") {

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -41,17 +41,21 @@ CI/CD: If no server is specified, FRANKENDEPLOY_SERVER environment variable is u
 }
 
 var (
-	deployTag           string
-	deployForce         bool
-	deployNoBuild       bool
-	deployRemoteBuild   bool
-	deployNoRemoteBuild bool
+	deployTag             string
+	deployForce           bool
+	deployNoBuild         bool
+	deployRemoteBuild     bool
+	deployNoRemoteBuild   bool
+	deploySkipEnvCheck    bool
+	deploySkipHealthcheck bool
 )
 
 func init() {
 	rootCmd.AddCommand(deployCmd)
 	deployCmd.Flags().StringVarP(&deployTag, "tag", "t", "", "Image tag (default: timestamp)")
-	deployCmd.Flags().BoolVarP(&deployForce, "force", "f", false, "Force deployment even if checks fail")
+	deployCmd.Flags().BoolVarP(&deployForce, "force", "f", false, "Skip env pre-flight and continue on hook or health check failures")
+	deployCmd.Flags().BoolVar(&deploySkipEnvCheck, "skip-env-check", false, "Skip the pre-flight environment variables check")
+	deployCmd.Flags().BoolVar(&deploySkipHealthcheck, "skip-healthcheck", false, "Skip the health check on the new container (traffic switches unverified)")
 	deployCmd.Flags().BoolVar(&deployNoBuild, "no-build", false, "Skip image build (use existing image)")
 	deployCmd.Flags().BoolVar(&deployRemoteBuild, "remote-build", false, "Build image on the server (recommended for cross-architecture)")
 	deployCmd.Flags().BoolVar(&deployNoRemoteBuild, "no-remote-build", false, "Force local build (ignore saved preference)")
@@ -109,7 +113,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 1b: Pre-flight environment check
-	if !deployForce {
+	if deployForce || deploySkipEnvCheck {
+		PrintWarning("Pre-flight environment check skipped (%s)", skipFlagName(deploySkipEnvCheck, "--skip-env-check"))
+	} else {
 		PrintInfo("Running pre-flight checks...")
 		if err := runEnvPreflightCheck(ctx, client, projectCfg, serverName); err != nil {
 			return err
@@ -209,17 +215,23 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 7: Health check on the NEW container (old still running = zero downtime)
-	PrintInfo("Running health check...")
-	state.Phase = deploy.PhaseHealthCheck
-	if err := runHealthCheckOnContainer(ctx, client, projectCfg, state.TempContainerName); err != nil {
-		if !deployForce {
-			PrintWarning("Health check failed, rolling back...")
-			rollbackNewContainer(ctx, client, state)
-			return fmt.Errorf("deployment failed health check: %w", err)
+	if deploySkipHealthcheck {
+		PrintWarning("Health check skipped (--skip-healthcheck)")
+	} else {
+		PrintInfo("Running health check...")
+		state.Phase = deploy.PhaseHealthCheck
+		if err := runHealthCheckOnContainer(ctx, client, projectCfg, state.TempContainerName); err != nil {
+			showContainerLogs(ctx, client, state.TempContainerName)
+			if !deployForce {
+				PrintWarning("Health check failed, rolling back...")
+				rollbackNewContainer(ctx, client, state)
+				return fmt.Errorf("deployment failed health check: %w", err)
+			}
+			PrintWarning("Health check failed but continuing (--force)")
+		} else {
+			PrintSuccess("Health check passed")
 		}
-		PrintWarning("Health check failed but continuing (--force)")
 	}
-	PrintSuccess("Health check passed")
 
 	// Step 8: Swap containers (rename old away, rename new → final, stop old, update symlink)
 	PrintInfo("Swapping containers...")
@@ -596,6 +608,37 @@ func rollbackNewContainer(ctx context.Context, client ssh.Executor, state *deplo
 	}
 }
 
+// containerLogTailLines is how many log lines are shown when a health check fails.
+const containerLogTailLines = 50
+
+// preHealthDelay is a variable so tests can skip the wait.
+var preHealthDelay = constants.PreHealthSleep
+
+// skipFlagName returns the flag responsible for skipping a check, for honest messages.
+func skipFlagName(skipFlagSet bool, skipFlag string) string {
+	if skipFlagSet {
+		return skipFlag
+	}
+	return "--force"
+}
+
+// showContainerLogs prints the last log lines of a container so the user can
+// see why a health check failed before the container is removed by rollback.
+func showContainerLogs(ctx context.Context, client ssh.Executor, containerName string) {
+	logs, err := deploy.ContainerLogs(ctx, client, containerName, containerLogTailLines)
+	if err != nil {
+		PrintWarning("Could not retrieve container logs: %v", err)
+		return
+	}
+	if strings.TrimSpace(logs) == "" {
+		PrintWarning("Container %s produced no logs", containerName)
+		return
+	}
+	fmt.Println()
+	PrintInfo("Last %d log lines from %s:", containerLogTailLines, containerName)
+	fmt.Println(logs)
+}
+
 // runHealthCheckOnContainer runs a health check against a specific container name
 // using the centralized HealthChecker with retries, timeout, and proper status code parsing.
 func runHealthCheckOnContainer(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, containerName string) error {
@@ -609,9 +652,19 @@ func runHealthCheckOnContainer(ctx context.Context, client ssh.Executor, cfg *co
 	}
 
 	// Wait for container to be ready before health checks
-	time.Sleep(constants.PreHealthSleep)
+	time.Sleep(preHealthDelay)
 
 	hc := deploy.NewHealthChecker(client, containerName, healthPath, constants.AppPort)
+	if cfg.Deploy.HealthcheckTimeout > 0 {
+		hc.SetTimeout(time.Duration(cfg.Deploy.HealthcheckTimeout) * time.Second)
+	}
+	if cfg.Deploy.HealthcheckRetries > 0 {
+		hc.SetRetries(cfg.Deploy.HealthcheckRetries)
+	}
+	if cfg.Deploy.HealthcheckInterval > 0 {
+		hc.SetInterval(time.Duration(cfg.Deploy.HealthcheckInterval) * time.Second)
+	}
+
 	result, err := hc.Check(ctx)
 	if err != nil {
 		return fmt.Errorf("health check error: %w", err)

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -400,3 +400,40 @@ func TestRunHealthCheckOnContainer_RejectsInvalidHealthPath(t *testing.T) {
 		t.Errorf("runHealthCheckOnContainer() should not execute any command on invalid path, got: %v", mock.Commands)
 	}
 }
+
+func TestRunHealthCheckOnContainer_UsesConfiguredRetries(t *testing.T) {
+	oldDelay := preHealthDelay
+	preHealthDelay = 0
+	defer func() { preHealthDelay = oldDelay }()
+
+	curlAttempts := 0
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
+			}
+			if strings.Contains(command, "curl") {
+				curlAttempts++
+				return &ssh.ExecResult{Stdout: "500", ExitCode: 1}, nil
+			}
+			return &ssh.ExecResult{}, nil
+		},
+	}
+
+	cfg := &config.ProjectConfig{
+		Name: "test-app",
+		Deploy: config.DeployConfig{
+			HealthcheckRetries:  2,
+			HealthcheckInterval: 1,
+			HealthcheckTimeout:  30,
+		},
+	}
+
+	err := runHealthCheckOnContainer(context.Background(), mock, cfg, "test-app-new")
+	if err == nil {
+		t.Fatal("expected health check failure")
+	}
+	if curlAttempts != 2 {
+		t.Errorf("expected 2 attempts from config, got %d", curlAttempts)
+	}
+}

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -142,7 +142,10 @@ func runEnvSet(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read existing env file
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	if err != nil {
+		return fmt.Errorf("failed to read env file: %w", err)
+	}
 	existingContent := result.Stdout
 
 	// Parse existing variables
@@ -230,7 +233,10 @@ func runEnvGet(cmd *cobra.Command, args []string) error {
 
 	envFile := constants.AppEnvFilePath(conn.Project.Name)
 
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", envFile))
+	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", envFile))
+	if err != nil {
+		return fmt.Errorf("failed to read env file: %w", err)
+	}
 	envVars := parseEnvContent(result.Stdout)
 
 	if value, ok := envVars[key]; ok {
@@ -260,7 +266,10 @@ func runEnvRemove(cmd *cobra.Command, args []string) error {
 
 	envFile := constants.AppEnvFilePath(conn.Project.Name)
 
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", envFile))
+	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", envFile))
+	if err != nil {
+		return fmt.Errorf("failed to read env file: %w", err)
+	}
 	envVars := parseEnvContent(result.Stdout)
 
 	if _, ok := envVars[key]; !ok {
@@ -328,7 +337,10 @@ func runEnvPush(cmd *cobra.Command, args []string) error {
 	}
 
 	// Read existing and merge
-	result, _ := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	if err != nil {
+		return fmt.Errorf("failed to read env file: %w", err)
+	}
 	existingVars := parseEnvContent(result.Stdout)
 	newVars := parseEnvContent(string(content))
 

--- a/internal/cmd/logs.go
+++ b/internal/cmd/logs.go
@@ -96,7 +96,10 @@ func runLogs(cmd *cobra.Command, args []string) error {
 			if logsSince != "" {
 				logsCommand += fmt.Sprintf(" --since %s", logsSince)
 			}
-			result, _ := conn.Client.Exec(ctx, logsCommand)
+			result, err := conn.Client.Exec(ctx, logsCommand)
+			if err != nil {
+				return fmt.Errorf("failed to read logs: %w", err)
+			}
 			fmt.Print(result.Stdout)
 			if result.Stderr != "" {
 				fmt.Print(result.Stderr)

--- a/internal/cmd/rollback.go
+++ b/internal/cmd/rollback.go
@@ -150,6 +150,7 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	// Health check the rollback container before touching the live one
 	PrintInfo("Running health check...")
 	if err := runHealthCheckOnContainer(ctx, client, cfg, tempName); err != nil {
+		showContainerLogs(ctx, client, tempName)
 		forceRemoveContainer(ctx, client, tempName)
 		return fmt.Errorf("rollback aborted, current version untouched: %w", err)
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -73,10 +73,16 @@ type DeployConfig struct {
 	Domain          string   `yaml:"domain,omitempty"`
 	HealthcheckPath string   `yaml:"healthcheck_path,omitempty"`
 	HealthcheckHost string   `yaml:"healthcheck_host,omitempty"`
-	KeepReleases    int      `yaml:"keep_releases,omitempty"`
-	SharedFiles     []string `yaml:"shared_files,omitempty"`
-	SharedDirs      []string `yaml:"shared_dirs,omitempty"`
-	Hooks           Hooks    `yaml:"hooks,omitempty"`
+	// HealthcheckTimeout is the overall health check window in seconds (0 = default).
+	HealthcheckTimeout int `yaml:"healthcheck_timeout,omitempty"`
+	// HealthcheckRetries is the maximum number of attempts (0 = default).
+	HealthcheckRetries int `yaml:"healthcheck_retries,omitempty"`
+	// HealthcheckInterval is the wait between attempts in seconds (0 = default).
+	HealthcheckInterval int      `yaml:"healthcheck_interval,omitempty"`
+	KeepReleases        int      `yaml:"keep_releases,omitempty"`
+	SharedFiles         []string `yaml:"shared_files,omitempty"`
+	SharedDirs          []string `yaml:"shared_dirs,omitempty"`
+	Hooks               Hooks    `yaml:"hooks,omitempty"`
 }
 
 // Hooks holds deployment hook commands

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -121,6 +121,24 @@ func ValidateProjectConfig(config *ProjectConfig) ValidationErrors {
 		})
 	}
 
+	healthcheckBounds := []struct {
+		field string
+		value int
+		max   int
+	}{
+		{"deploy.healthcheck_timeout", config.Deploy.HealthcheckTimeout, 3600},
+		{"deploy.healthcheck_retries", config.Deploy.HealthcheckRetries, 1000},
+		{"deploy.healthcheck_interval", config.Deploy.HealthcheckInterval, 300},
+	}
+	for _, b := range healthcheckBounds {
+		if b.value < 0 || b.value > b.max {
+			errors = append(errors, ValidationError{
+				Field:   b.field,
+				Message: fmt.Sprintf("must be between 0 (default) and %d", b.max),
+			})
+		}
+	}
+
 	for key := range config.Env.Dev {
 		if err := security.ValidateEnvKey(key); err != nil {
 			errors = append(errors, ValidationError{

--- a/internal/config/validation_test.go
+++ b/internal/config/validation_test.go
@@ -62,6 +62,37 @@ func TestValidateProjectConfig(t *testing.T) {
 			wantErrors: true,
 		},
 		{
+			name: "valid healthcheck tuning",
+			config: &ProjectConfig{
+				Name: "my-app",
+				PHP:  PHPConfig{Version: "8.3"},
+				Deploy: DeployConfig{
+					HealthcheckTimeout:  120,
+					HealthcheckRetries:  40,
+					HealthcheckInterval: 5,
+				},
+			},
+			wantErrors: false,
+		},
+		{
+			name: "negative healthcheck timeout",
+			config: &ProjectConfig{
+				Name:   "my-app",
+				PHP:    PHPConfig{Version: "8.3"},
+				Deploy: DeployConfig{HealthcheckTimeout: -1},
+			},
+			wantErrors: true,
+		},
+		{
+			name: "healthcheck interval above bound",
+			config: &ProjectConfig{
+				Name:   "my-app",
+				PHP:    PHPConfig{Version: "8.3"},
+				Deploy: DeployConfig{HealthcheckInterval: 999},
+			},
+			wantErrors: true,
+		},
+		{
 			name: "invalid database driver",
 			config: &ProjectConfig{
 				Name: "my-app",

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -25,10 +25,13 @@ const (
 
 // Health check defaults
 const (
-	PreHealthSleep     = 5 * time.Second
-	HealthCheckTimeout = 30 * time.Second
-	HealthCheckRetries = 5
-	HealthCheckInterval = 2 * time.Second
+	// The generated Dockerfile declares HEALTHCHECK --start-period=60s: a cold
+	// Symfony container (opcache warmup, DB wait, first-request compile) can
+	// legitimately need that long, so the deploy-side window must cover it.
+	PreHealthSleep      = 5 * time.Second
+	HealthCheckTimeout  = 90 * time.Second
+	HealthCheckRetries  = 30
+	HealthCheckInterval = 3 * time.Second
 )
 
 // Deployment defaults

--- a/internal/deploy/envcheck.go
+++ b/internal/deploy/envcheck.go
@@ -49,7 +49,10 @@ func CheckEnvVars(ctx context.Context, client ssh.Executor, cfg *config.ProjectC
 	envFile := constants.AppEnvFilePath(cfg.Name)
 
 	// Read existing env variables
-	execResult, _ := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	execResult, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read env file: %w", err)
+	}
 	existingVars := parseEnvContent(execResult.Stdout)
 
 	// Get framework requirements (default to Symfony)
@@ -150,7 +153,10 @@ func SaveGeneratedSecrets(ctx context.Context, client ssh.Executor, appName stri
 	}
 
 	// Read existing env file
-	result, _ := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	result, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	if err != nil {
+		return fmt.Errorf("failed to read env file: %w", err)
+	}
 	existingVars := parseEnvContent(result.Stdout)
 
 	// Merge new secrets

--- a/internal/deploy/health.go
+++ b/internal/deploy/health.go
@@ -74,14 +74,24 @@ func (h *HealthChecker) Check(ctx context.Context) (*HealthResult, error) {
 			return result, nil
 		}
 
-		// Check if container is running
-		containerCheck, _ := h.client.Exec(ctx, fmt.Sprintf(
+		// Check if container is running. A transient SSH error counts as a
+		// failed attempt (the connection may recover), never as a panic.
+		containerCheck, err := h.client.Exec(ctx, fmt.Sprintf(
 			"docker inspect %s --format '{{.State.Status}}'", h.containerID))
+		if err != nil || containerCheck == nil {
+			result.Message = fmt.Sprintf("container status check failed: %v", err)
+			if err := h.sleepBetweenAttempts(ctx, attempt, result); err != nil {
+				return result, err
+			}
+			continue
+		}
 
 		containerStatus := strings.TrimSpace(containerCheck.Stdout)
 		if containerStatus != "running" {
 			result.Message = fmt.Sprintf("container not running (status: %s)", containerStatus)
-			time.Sleep(h.interval)
+			if err := h.sleepBetweenAttempts(ctx, attempt, result); err != nil {
+				return result, err
+			}
 			continue
 		}
 
@@ -94,7 +104,7 @@ func (h *HealthChecker) Check(ctx context.Context) (*HealthResult, error) {
 		httpCheck, err := h.client.Exec(ctx, healthCmd)
 		result.ResponseTime = time.Since(start)
 
-		if err == nil && httpCheck.ExitCode == 0 {
+		if err == nil && httpCheck != nil && httpCheck.ExitCode == 0 {
 			result.Healthy = true
 			result.StatusCode = 200 // default if parsing fails
 			if httpCheck.Stdout != "" {
@@ -108,6 +118,7 @@ func (h *HealthChecker) Check(ctx context.Context) (*HealthResult, error) {
 		}
 
 		// Parse status code from output
+		result.StatusCode = 0
 		if httpCheck != nil && httpCheck.Stdout != "" {
 			if n, scanErr := fmt.Sscanf(httpCheck.Stdout, "%d", &result.StatusCode); n == 0 || scanErr != nil {
 				result.StatusCode = 0
@@ -115,54 +126,40 @@ func (h *HealthChecker) Check(ctx context.Context) (*HealthResult, error) {
 		}
 
 		result.Message = fmt.Sprintf("HTTP check failed (status: %d)", result.StatusCode)
-		time.Sleep(h.interval)
+		if err := h.sleepBetweenAttempts(ctx, attempt, result); err != nil {
+			return result, err
+		}
 	}
 
 	return result, nil
 }
 
-// CheckContainer verifies if a container is running
-func (h *HealthChecker) CheckContainer(ctx context.Context) (bool, error) {
-	result, err := h.client.Exec(ctx, fmt.Sprintf(
-		"docker ps --filter name=%s --format '{{.Status}}'", h.containerID))
-
-	if err != nil {
-		return false, err
+// sleepBetweenAttempts waits for the retry interval, honoring context
+// cancellation, and skips the pointless sleep after the last attempt.
+func (h *HealthChecker) sleepBetweenAttempts(ctx context.Context, attempt int, result *HealthResult) error {
+	if attempt >= h.retries {
+		return nil
 	}
-
-	return result.Stdout != "", nil
+	select {
+	case <-ctx.Done():
+		result.Message = "health check cancelled"
+		return ctx.Err()
+	case <-time.After(h.interval):
+		return nil
+	}
 }
 
-// GetContainerLogs retrieves recent container logs
-func (h *HealthChecker) GetContainerLogs(ctx context.Context, lines int) (string, error) {
-	result, err := h.client.Exec(ctx, fmt.Sprintf(
-		"docker logs %s --tail %d 2>&1", h.containerID, lines))
+// ContainerLogs retrieves recent container logs (stdout and stderr merged)
+func ContainerLogs(ctx context.Context, client ssh.Executor, containerID string, lines int) (string, error) {
+	result, err := client.Exec(ctx, fmt.Sprintf(
+		"docker logs %s --tail %d 2>&1", containerID, lines))
 
 	if err != nil {
 		return "", err
 	}
+	if result == nil {
+		return "", fmt.Errorf("no output from docker logs")
+	}
 
 	return result.Stdout, nil
-}
-
-// WaitForContainer waits for a container to be in running state
-func (h *HealthChecker) WaitForContainer(ctx context.Context, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-
-	for {
-		if time.Now().After(deadline) {
-			return fmt.Errorf("timeout waiting for container to start")
-		}
-
-		running, err := h.CheckContainer(ctx)
-		if err != nil {
-			return err
-		}
-
-		if running {
-			return nil
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
 }

--- a/internal/deploy/health_test.go
+++ b/internal/deploy/health_test.go
@@ -153,31 +153,113 @@ func TestHealthChecker_Check_PortInCurlCommand(t *testing.T) {
 	}
 }
 
-func TestHealthChecker_CheckContainer(t *testing.T) {
-	tests := []struct {
-		name     string
-		stdout   string
-		expected bool
-	}{
-		{"running container", "Up 5 minutes", true},
-		{"stopped container", "", false},
+func TestContainerLogs(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if !strings.Contains(command, "docker logs test-app --tail 50") {
+				t.Errorf("unexpected command: %s", command)
+			}
+			return &ssh.ExecResult{Stdout: "line1\nline2\n", ExitCode: 0}, nil
+		},
+	}
+	logs, err := ContainerLogs(context.Background(), mock, "test-app", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if logs != "line1\nline2\n" {
+		t.Errorf("unexpected logs: %q", logs)
+	}
+}
+
+func TestHealthChecker_Check_SurvivesSSHDrop(t *testing.T) {
+	// Exec returning (nil, err) must not panic: treated as a failed attempt.
+	calls := 0
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			calls++
+			if calls == 1 {
+				return nil, fmt.Errorf("ssh connection dropped")
+			}
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
+			}
+			return &ssh.ExecResult{Stdout: "200", ExitCode: 0}, nil
+		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mock := &ssh.MockExecutor{
-				ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
-					return &ssh.ExecResult{Stdout: tt.stdout, ExitCode: 0}, nil
-				},
+	hc := NewHealthChecker(mock, "test-app", "/", "8080")
+	hc.SetTimeout(5 * time.Second)
+	hc.SetRetries(3)
+	hc.SetInterval(50 * time.Millisecond)
+
+	result, err := hc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Healthy {
+		t.Errorf("expected healthy after SSH recovery, got: %s", result.Message)
+	}
+}
+
+func TestHealthChecker_Check_ContextCancelled(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
 			}
-			hc := NewHealthChecker(mock, "test-app", "/", "8080")
-			running, err := hc.CheckContainer(context.Background())
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
+			return &ssh.ExecResult{Stdout: "503", ExitCode: 1}, nil
+		},
+	}
+
+	hc := NewHealthChecker(mock, "test-app", "/", "8080")
+	hc.SetTimeout(30 * time.Second)
+	hc.SetRetries(100)
+	hc.SetInterval(10 * time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+
+	start := time.Now()
+	result, err := hc.Check(ctx)
+	if err == nil {
+		t.Fatal("expected context cancellation error")
+	}
+	if result.Healthy {
+		t.Error("expected unhealthy on cancellation")
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Errorf("Check did not return promptly on cancellation (took %v)", elapsed)
+	}
+}
+
+func TestHealthChecker_Check_NoSleepAfterLastAttempt(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect") {
+				return &ssh.ExecResult{Stdout: "running", ExitCode: 0}, nil
 			}
-			if running != tt.expected {
-				t.Errorf("expected running=%v, got %v", tt.expected, running)
-			}
-		})
+			return &ssh.ExecResult{Stdout: "500", ExitCode: 1}, nil
+		},
+	}
+
+	hc := NewHealthChecker(mock, "test-app", "/", "8080")
+	hc.SetTimeout(30 * time.Second)
+	hc.SetRetries(3)
+	hc.SetInterval(200 * time.Millisecond)
+
+	start := time.Now()
+	result, err := hc.Check(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Healthy {
+		t.Error("expected unhealthy")
+	}
+	// 3 attempts with only 2 sleeps: well under 3 full intervals.
+	if elapsed := time.Since(start); elapsed >= 600*time.Millisecond {
+		t.Errorf("expected no sleep after last attempt, took %v", elapsed)
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #51 — the single biggest UX win of the audit: when a health check fails, the user now **sees why**.

## Changes

### Container logs on failure
The last 50 log lines of the failing container are printed **before** rollback removes it, on both the deploy and rollback paths. Previously the container was destroyed and the user was left with `HTTP check failed (status: 500)` and no way to investigate.

### Realistic, tunable window
- Defaults raised from ~15s (5 retries × 2s + 5s warmup) to **90s** (30 × 3s + 5s): a cold Symfony container legitimately needs opcache warmup, DB wait and first-request compile — the generated Dockerfile itself declares `HEALTHCHECK --start-period=60s`.
- New YAML settings (validated, `0`/omitted = default):
```yaml
deploy:
  healthcheck_timeout: 90
  healthcheck_retries: 30
  healthcheck_interval: 3
```

### Honest flags
- New `--skip-env-check` and `--skip-healthcheck` for granular control.
- `--force` keeps its behavior (skip env preflight + continue on hook/health failures) but **no longer prints "Health check passed" after a failure**, and skip messages name the responsible flag.

### HealthChecker hardening
- An SSH error during a check attempt is a failed attempt, not a nil-pointer **panic**.
- Sleeps honor context cancellation; no pointless sleep after the last attempt.
- Removed dead `CheckContainer`/`WaitForContainer` (unused; substring-match bug where `myapp` matched `myapp-db`).
- Fixed the remaining ignored-`Exec`-error nil-derefs on SSH drop in `envcheck.go`, `env.go`, `app.go`, `logs.go`.

## Tests

- New: SSH-drop survival (red test panicked exactly like production would), context cancellation (prompt return), no-sleep-after-last-attempt (timing), `ContainerLogs`, config wiring through `runHealthCheckOnContainer` (retry count), validation bounds for the three new fields.
- Full suite: **609 tests green with `-race`** (was 604).

## Live validation (Hidora VPS)

Deployed the demo API Platform app with a deliberately broken `healthcheck_path: /nope` and `retries: 4, interval: 2`:

```
ℹ️  Running health check...

ℹ️  Last 50 log lines from demo-api-new:
[FrankenDeploy] Starting in PRODUCTION mode
[FrankenDeploy] Waiting for database at demo-api-db:5432...
[FrankenDeploy] Database is ready!
[FrankenDeploy] Starting FrankenPHP...
...
⚠️  Health check failed, rolling back...
Error: deployment failed health check: ... HTTP check failed (status: 404) (after 4 attempts)
```

- Logs shown ✔ — configured retry count respected ("after 4 attempts") ✔ — no lying "Health check passed" ✔ — exit code 1 ✔ — **live site still 200 during and after the failed deploy** ✔
- Then restored the config and redeployed successfully.

Docs updated (deployment guide + project config reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
