### PR TITLE
fix(deploy): Caddy configuration failure blocks first public exposure (#52)

### DIFF
--- a/internal/caddy/config_test.go
+++ b/internal/caddy/config_test.go
@@ -94,3 +94,58 @@ func TestAppConfigFromProject_CopiesHealthcheckPath(t *testing.T) {
 		t.Errorf("expected HealthPath /api, got %q", app.HealthPath)
 	}
 }
+
+func TestReloadCommands(t *testing.T) {
+	cmds := ReloadCommands()
+	if len(cmds) != 1 {
+		t.Fatalf("expected 1 command, got %d", len(cmds))
+	}
+	if !strings.Contains(cmds[0], "docker exec caddy caddy reload") {
+		t.Errorf("expected caddy reload command, got: %s", cmds[0])
+	}
+	if !strings.Contains(cmds[0], "--config /etc/caddy/Caddyfile") {
+		t.Errorf("reload must target the main Caddyfile, got: %s", cmds[0])
+	}
+}
+
+func TestWriteAppConfigCommands(t *testing.T) {
+	content := "example.com {\n    reverse_proxy myapp:80\n}\n"
+	cmds, err := WriteAppConfigCommands("myapp", content)
+	if err != nil {
+		t.Fatalf("WriteAppConfigCommands: %v", err)
+	}
+	if len(cmds) != 3 {
+		t.Fatalf("expected 3 commands (mkdir, write, reload), got %d", len(cmds))
+	}
+	if !strings.HasPrefix(cmds[0], "mkdir -p ") {
+		t.Errorf("first command should create the apps dir, got: %s", cmds[0])
+	}
+	if !strings.Contains(cmds[1], "myapp.caddy") || !strings.Contains(cmds[1], content) {
+		t.Errorf("second command should write the app config content, got: %s", cmds[1])
+	}
+	if !strings.Contains(cmds[2], "caddy reload") {
+		t.Errorf("third command should reload Caddy, got: %s", cmds[2])
+	}
+
+	// Heredoc delimiter must be random: two calls must differ
+	cmds2, err := WriteAppConfigCommands("myapp", content)
+	if err != nil {
+		t.Fatalf("WriteAppConfigCommands: %v", err)
+	}
+	if cmds[1] == cmds2[1] {
+		t.Error("heredoc delimiter should be randomized between calls")
+	}
+}
+
+func TestRemoveAppConfigCommands(t *testing.T) {
+	cmds := RemoveAppConfigCommands("myapp")
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands (rm, reload), got %d", len(cmds))
+	}
+	if !strings.Contains(cmds[0], "rm -f") || !strings.Contains(cmds[0], "myapp.caddy") {
+		t.Errorf("first command should remove the app config, got: %s", cmds[0])
+	}
+	if !strings.Contains(cmds[1], "caddy reload") {
+		t.Errorf("second command should reload Caddy, got: %s", cmds[1])
+	}
+}

--- a/internal/cmd/caddy_test.go
+++ b/internal/cmd/caddy_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func TestCaddyAppConfigExists(t *testing.T) {
+	tests := []struct {
+		name   string
+		stdout string
+		want   bool
+	}{
+		{"config present", "yes\n", true},
+		{"config absent", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := &ssh.MockExecutor{
+				ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+					if !strings.Contains(command, "my-app.caddy") {
+						t.Errorf("expected check on my-app.caddy, got: %s", command)
+					}
+					return &ssh.ExecResult{Stdout: tt.stdout, ExitCode: 0}, nil
+				},
+			}
+			if got := caddyAppConfigExists(context.Background(), mock, "my-app"); got != tt.want {
+				t.Errorf("caddyAppConfigExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateCaddyConfig_FailsWhenCaddyNotRunning(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "docker inspect caddy") {
+				return &ssh.ExecResult{Stdout: "exited\n", ExitCode: 0}, nil
+			}
+			t.Errorf("no command should run after the caddy status check, got: %s", command)
+			return &ssh.ExecResult{}, nil
+		},
+	}
+	cfg := &config.ProjectConfig{
+		Name:   "my-app",
+		Deploy: config.DeployConfig{Domain: "example.com"},
+	}
+	err := updateCaddyConfig(context.Background(), mock, cfg)
+	if err == nil {
+		t.Fatal("expected error when caddy container is not running")
+	}
+	if !strings.Contains(err.Error(), "server setup") {
+		t.Errorf("error should point the user to 'server setup', got: %v", err)
+	}
+}
+
+func TestUpdateCaddyConfig_SucceedsWhenCaddyRunning(t *testing.T) {
+	var commands []string
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			commands = append(commands, command)
+			if strings.Contains(command, "docker inspect caddy") {
+				return &ssh.ExecResult{Stdout: "running\n", ExitCode: 0}, nil
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+	cfg := &config.ProjectConfig{
+		Name:   "my-app",
+		Deploy: config.DeployConfig{Domain: "example.com", HealthcheckPath: "/api"},
+	}
+	if err := updateCaddyConfig(context.Background(), mock, cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(commands, "\n")
+	if !strings.Contains(joined, "my-app.caddy") || !strings.Contains(joined, "caddy reload") {
+		t.Errorf("expected write and reload commands, got:\n%s", joined)
+	}
+}

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -260,9 +260,17 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Step 10: Update Caddy config
+	// Step 10: Update Caddy config. On the app's FIRST public exposure this is
+	// THE condition for reachability: failing must fail the deploy instead of
+	// printing a success message with an unreachable https URL. On later
+	// deploys the existing Caddy config still routes to the swapped container,
+	// so a reload failure only warrants a warning.
+	firstExposure := projectCfg.Deploy.Domain != "" && !caddyAppConfigExists(ctx, client, projectCfg.Name)
 	PrintInfo("Updating reverse proxy...")
 	if err := updateCaddyConfig(ctx, client, projectCfg); err != nil {
+		if firstExposure {
+			return fmt.Errorf("reverse proxy configuration failed — the application is running on the server but NOT publicly reachable: %w", err)
+		}
 		PrintWarning("Failed to update Caddy: %v", err)
 	}
 
@@ -743,6 +751,13 @@ func fixSharedPermissions(ctx context.Context, client ssh.Executor, sharedPath s
 	}
 }
 
+// caddyAppConfigExists reports whether the app already has a Caddy config on
+// the server — i.e. whether it has ever been publicly exposed.
+func caddyAppConfigExists(ctx context.Context, client ssh.Executor, appName string) bool {
+	result, err := client.Exec(ctx, fmt.Sprintf("test -f %s && echo yes", constants.CaddyAppConfig(appName)))
+	return err == nil && result != nil && strings.TrimSpace(result.Stdout) == "yes"
+}
+
 func updateCaddyConfig(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig) error {
 	domain := cfg.Deploy.Domain
 	if domain == "" {
@@ -756,6 +771,19 @@ func updateCaddyConfig(ctx context.Context, client ssh.Executor, cfg *config.Pro
 		PrintInfo("Or run: frankendeploy init --domain your-domain.com")
 		fmt.Println()
 		return nil
+	}
+
+	// The reload runs inside the caddy container: verify it is up first so the
+	// user gets a clear diagnosis instead of an obscure docker exec failure.
+	statusResult, err := client.Exec(ctx, "docker inspect caddy --format '{{.State.Status}}' 2>/dev/null")
+	if err != nil {
+		return fmt.Errorf("could not check Caddy container status: %w", err)
+	}
+	if status := strings.TrimSpace(statusResult.Stdout); status != "running" {
+		if status == "" {
+			status = "not found"
+		}
+		return fmt.Errorf("caddy container is not running on the server (status: %s) — run 'frankendeploy server setup' first", status)
 	}
 
 	// Generate Caddy config using our generator


### PR DESCRIPTION
## Summary

Fixes #52 — the last P0-adjacent trap of wave 1: a failed Caddy configuration only produced a warning, then **"Deployment complete!" with the https URL**, while the site was completely unreachable. For a first deployment, the Caddy config is THE condition for public accessibility.

## Changes

- **First public exposure is now blocking**: when `deploy.domain` is set and `apps/<name>.caddy` does not exist on the server yet, a Caddy failure fails the deploy with an explicit error. On later deploys the previous behavior (warning) is kept — correct, because the existing Caddy config still routes to the swapped container (same name), so the site stays up.
- **Caddy container checked before reload**: `updateCaddyConfig` now verifies the `caddy` container is running and returns `caddy container is not running on the server (status: exited) — run 'frankendeploy server setup' first` instead of an obscure `docker exec` failure.
- **Missing tests added** to the `caddy` package (`ReloadCommands`, `WriteAppConfigCommands` including randomized heredoc delimiter, `RemoveAppConfigCommands`) plus cmd-level tests for the new checks.

Note: the `health_uri` alignment mentioned in the issue was already fixed by #69.

## Tests

Full suite: **617 tests green with `-race`** (was 609).

## Live validation (Hidora VPS)

Stopped the caddy container and removed the app's Caddy config to simulate a broken first exposure, then deployed:

```
EXIT=1
Error: reverse proxy configuration failed — the application is running on the server but NOT publicly reachable: caddy container is not running on the server (status: exited) — run 'frankendeploy server setup' first
```

No more lying "Deployment complete!". Then restarted caddy, redeployed successfully, site back to HTTP 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
