### PR TITLE
feat(ssh): support encrypted keys, ssh-agent, and interactive TOFU (#50)

### DIFF
--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -53,14 +53,34 @@ Skip SSH test (useful for CI setup):
 frankendeploy server add prod user@host --skip-test
 ```
 
-### SSH Key Selection
+### SSH Authentication
 
-When testing the connection, FrankenDeploy tries keys in this order:
-1. `~/.ssh/id_ed25519` (preferred)
-2. `~/.ssh/id_rsa`
-3. Other keys in `~/.ssh/`
+FrankenDeploy authenticates in this order:
 
-**Note:** Passphrase-protected keys are skipped during auto-detection.
+1. **ssh-agent** — when `SSH_AUTH_SOCK` is set, keys loaded in the agent are tried first
+2. **Key file** — the configured key (`--key`) or auto-detected: `~/.ssh/id_ed25519`, then `~/.ssh/id_rsa`, then other keys in `~/.ssh/`
+
+Passphrase-protected keys are fully supported: the passphrase is prompted when needed and never stored. In non-interactive mode (CI/CD, `--yes`), passphrase-protected keys cannot be prompted — use ssh-agent or `FRANKENDEPLOY_SSH_KEY` instead.
+
+### First Connection (Host Key Verification)
+
+On the first connection to a new server, FrankenDeploy shows the host key fingerprint and asks for confirmation, exactly like OpenSSH:
+
+```
+The authenticity of host 'your-server.com' can't be established.
+ssh-ed25519 key fingerprint is SHA256:xxxxxxxx...
+Are you sure you want to continue connecting (yes/no)?
+```
+
+The accepted key is recorded in `~/.ssh/known_hosts` — no need to run a manual `ssh` first.
+
+If the server's host key changes later (server reinstalled or recreated), the connection is refused with a clear message. When the change is expected, remove the old key with:
+
+```bash
+ssh-keygen -R your-server.com
+```
+
+In CI/CD, set `FRANKENDEPLOY_KNOWN_HOSTS` with the content of your known_hosts file (no interactive confirmation happens there).
 
 ## Setting Up the Server
 

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -189,10 +190,19 @@ func testAndConfigureSSH(name string, serverCfg *config.ServerConfig, globalCfg 
 
 	// Try connection with current configuration
 	client := ssh.NewClient(serverCfg.Host, serverCfg.User, serverCfg.Port, serverCfg.KeyPath)
-	if err := client.Connect(); err == nil {
+	err := client.Connect()
+	if err == nil {
 		client.Close()
 		PrintSuccess("SSH connection successful")
 		return nil
+	}
+
+	// A host key problem (unknown or changed) affects every key the same
+	// way: trying other keys would only bury the real message.
+	var changedErr *ssh.HostKeyChangedError
+	var unknownErr *ssh.HostKeyUnknownError
+	if errors.As(err, &changedErr) || errors.As(err, &unknownErr) {
+		return err
 	}
 
 	PrintWarning("Connection failed with default key")
@@ -203,11 +213,14 @@ func testAndConfigureSSH(name string, serverCfg *config.ServerConfig, globalCfg 
 		return fmt.Errorf("failed to discover SSH keys: %w", err)
 	}
 
-	// Filter out encrypted keys and already tried key
+	// Filter out the already tried key. Encrypted keys are kept in
+	// interactive mode (their passphrase is prompted on use) and only
+	// skipped when no terminal is available to prompt.
+	interactive := IsInteractive()
 	var availableKeys []ssh.SSHKeyInfo
 	for _, key := range keys {
-		if key.IsEncrypted {
-			PrintVerbose("Skipping encrypted key: %s", key.Name)
+		if key.IsEncrypted && !interactive {
+			PrintVerbose("Skipping encrypted key (no terminal to prompt for passphrase): %s", key.Name)
 			continue
 		}
 		if serverCfg.KeyPath != "" && key.Path == serverCfg.KeyPath {
@@ -222,7 +235,7 @@ func testAndConfigureSSH(name string, serverCfg *config.ServerConfig, globalCfg 
 
 	// Try keys - either interactively or automatically
 	var workingKey *ssh.SSHKeyInfo
-	if IsInteractive() {
+	if interactive {
 		workingKey = interactiveKeySelection(serverCfg, availableKeys)
 	} else {
 		workingKey = autoTryKeys(serverCfg, availableKeys)
@@ -248,7 +261,11 @@ func testAndConfigureSSH(name string, serverCfg *config.ServerConfig, globalCfg 
 func interactiveKeySelection(serverCfg *config.ServerConfig, keys []ssh.SSHKeyInfo) *ssh.SSHKeyInfo {
 	options := make([]string, len(keys))
 	for i, key := range keys {
-		options[i] = fmt.Sprintf("%s (%s)", key.Name, key.Type)
+		if key.IsEncrypted {
+			options[i] = fmt.Sprintf("%s (%s, passphrase-protected)", key.Name, key.Type)
+		} else {
+			options[i] = fmt.Sprintf("%s (%s)", key.Name, key.Type)
+		}
 	}
 
 	fmt.Println()

--- a/internal/ssh/auth.go
+++ b/internal/ssh/auth.go
@@ -1,0 +1,222 @@
+package ssh
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+	"golang.org/x/term"
+)
+
+// PassphraseReader prompts for the passphrase of an encrypted private key.
+type PassphraseReader func(keyPath string) ([]byte, error)
+
+// DefaultPassphraseReader reads the passphrase from the terminal without
+// echoing it. It fails when stdin is not a terminal (CI/CD): in that case
+// use ssh-agent or FRANKENDEPLOY_SSH_KEY instead.
+func DefaultPassphraseReader(keyPath string) ([]byte, error) {
+	fd := int(os.Stdin.Fd())
+	if !term.IsTerminal(fd) {
+		return nil, fmt.Errorf("key %s is passphrase-protected and no terminal is available to prompt "+
+			"(use ssh-agent or set FRANKENDEPLOY_SSH_KEY for CI/CD)", keyPath)
+	}
+
+	fmt.Printf("Enter passphrase for %s: ", keyPath)
+	passphrase, err := term.ReadPassword(fd)
+	fmt.Println()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read passphrase: %w", err)
+	}
+	return passphrase, nil
+}
+
+// agentSignersFunc returns a function producing the ssh-agent's signers,
+// or nil when SSH_AUTH_SOCK is unset or the agent is unreachable.
+func agentSignersFunc() func() ([]ssh.Signer, error) {
+	sock := os.Getenv("SSH_AUTH_SOCK")
+	if sock == "" {
+		return nil
+	}
+
+	conn, err := net.Dial("unix", sock)
+	if err != nil {
+		return nil
+	}
+	// The connection stays open for the lifetime of the process: the SSH
+	// library may query the agent again on reconnection.
+	return agent.NewClient(conn).Signers
+}
+
+// parsePrivateKeyWithPrompt parses a private key, prompting for its
+// passphrase when the key is encrypted.
+func parsePrivateKeyWithPrompt(data []byte, path string, prompt PassphraseReader) (ssh.Signer, error) {
+	signer, err := ssh.ParsePrivateKey(data)
+	if err == nil {
+		return signer, nil
+	}
+
+	var missingErr *ssh.PassphraseMissingError
+	if !errors.As(err, &missingErr) && !isPassphraseError(err) {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	if prompt == nil {
+		prompt = DefaultPassphraseReader
+	}
+	passphrase, err := prompt(path)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err = ssh.ParsePrivateKeyWithPassphrase(data, passphrase)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decrypt key %s (wrong passphrase?): %w", path, err)
+	}
+	return signer, nil
+}
+
+// resolveKeyPath returns the private key path to use: the configured path
+// (with ~ expanded) or the first default key found in ~/.ssh.
+func (c *Client) resolveKeyPath() (string, error) {
+	keyPath := c.KeyPath
+	if keyPath == "" {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		for _, p := range []string{
+			filepath.Join(homeDir, ".ssh", "id_ed25519"),
+			filepath.Join(homeDir, ".ssh", "id_rsa"),
+		} {
+			if _, err := os.Stat(p); err == nil {
+				return p, nil
+			}
+		}
+		return "", fmt.Errorf("no SSH key found")
+	}
+
+	if len(keyPath) >= 2 && keyPath[:2] == "~/" {
+		homeDir, _ := os.UserHomeDir()
+		keyPath = filepath.Join(homeDir, keyPath[2:])
+	}
+	return keyPath, nil
+}
+
+// authMethods builds the authentication methods:
+//  1. FRANKENDEPLOY_SSH_KEY (CI/CD): the provided key only
+//  2. a single publickey method combining ssh-agent signers and the key file
+//
+// Agent and key file MUST share one publickey method: the x/crypto client
+// tries at most one AuthMethod per method name, so a second publickey entry
+// would silently never be attempted.
+func (c *Client) authMethods() ([]ssh.AuthMethod, error) {
+	if envKey := os.Getenv("FRANKENDEPLOY_SSH_KEY"); envKey != "" {
+		signer, err := ssh.ParsePrivateKey([]byte(envKey))
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse FRANKENDEPLOY_SSH_KEY: %w", err)
+		}
+		return []ssh.AuthMethod{ssh.PublicKeys(signer)}, nil
+	}
+
+	agentFn := agentSignersFunc()
+	keyPath, err := c.resolveKeyPath()
+	if err != nil {
+		if agentFn == nil {
+			return nil, fmt.Errorf("%w and no ssh-agent running (set FRANKENDEPLOY_SSH_KEY for CI/CD)", err)
+		}
+		keyPath = ""
+	}
+
+	// The callback runs lazily on each connection attempt; the decrypted
+	// key file signer is memoized so the passphrase is asked at most once.
+	return []ssh.AuthMethod{ssh.PublicKeysCallback(func() ([]ssh.Signer, error) {
+		return c.collectSigners(agentFn, keyPath)
+	})}, nil
+}
+
+// collectSigners gathers the agent signers followed by the key file signer.
+// The key file passphrase is only prompted when the agent does not already
+// hold that key; when the prompt fails but the agent offers other keys,
+// authentication proceeds with those instead of aborting.
+func (c *Client) collectSigners(agentFn func() ([]ssh.Signer, error), keyPath string) ([]ssh.Signer, error) {
+	var signers []ssh.Signer
+	if agentFn != nil {
+		if agentSigners, err := agentFn(); err == nil {
+			signers = append(signers, agentSigners...)
+		}
+	}
+
+	if keyPath != "" {
+		fileSigner, err := c.keyFileSigner(keyPath, signers)
+		if err != nil {
+			if len(signers) == 0 {
+				return nil, err
+			}
+		} else if fileSigner != nil {
+			signers = append(signers, fileSigner)
+		}
+	}
+
+	if len(signers) == 0 {
+		return nil, fmt.Errorf("no usable SSH credentials for %s", keyPath)
+	}
+	return signers, nil
+}
+
+// keyFileSigner loads the key file signer, memoized on the client so a
+// passphrase is prompted at most once per process. Returns (nil, nil) when
+// the key is encrypted but already present in the agent: the agent signer
+// covers it without prompting.
+func (c *Client) keyFileSigner(keyPath string, agentSigners []ssh.Signer) (ssh.Signer, error) {
+	if c.cachedSigner != nil {
+		return c.cachedSigner, nil
+	}
+
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	signer, err := ssh.ParsePrivateKey(data)
+	if err != nil {
+		var missingErr *ssh.PassphraseMissingError
+		if !errors.As(err, &missingErr) && !isPassphraseError(err) {
+			return nil, fmt.Errorf("failed to parse private key: %w", err)
+		}
+		if agentHoldsKey(keyPath, agentSigners) {
+			return nil, nil
+		}
+		signer, err = parsePrivateKeyWithPrompt(data, keyPath, c.opts.passphrasePrompt)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	c.cachedSigner = signer
+	return signer, nil
+}
+
+// agentHoldsKey reports whether the agent already offers the public key
+// matching the given private key file (compared via its .pub sibling).
+func agentHoldsKey(keyPath string, agentSigners []ssh.Signer) bool {
+	pubData, err := os.ReadFile(keyPath + ".pub")
+	if err != nil {
+		return false
+	}
+	pubKey, _, _, _, err := ssh.ParseAuthorizedKey(pubData)
+	if err != nil {
+		return false
+	}
+	marshaled := pubKey.Marshal()
+	for _, s := range agentSigners {
+		if bytes.Equal(s.PublicKey().Marshal(), marshaled) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -1,0 +1,470 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/agent"
+)
+
+// generateKeyPEM returns a PEM-encoded ed25519 private key, optionally
+// encrypted with the given passphrase.
+func generateKeyPEM(t *testing.T, passphrase string) []byte {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
+	var block *pem.Block
+	if passphrase == "" {
+		block, err = ssh.MarshalPrivateKey(priv, "test")
+	} else {
+		block, err = ssh.MarshalPrivateKeyWithPassphrase(priv, "test", []byte(passphrase))
+	}
+	if err != nil {
+		t.Fatalf("failed to marshal key: %v", err)
+	}
+	return pem.EncodeToMemory(block)
+}
+
+func TestParsePrivateKeyWithPrompt_Unencrypted(t *testing.T) {
+	data := generateKeyPEM(t, "")
+
+	prompted := false
+	signer, err := parsePrivateKeyWithPrompt(data, "/key", func(keyPath string) ([]byte, error) {
+		prompted = true
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("parsePrivateKeyWithPrompt() error = %v", err)
+	}
+	if signer == nil {
+		t.Fatal("expected a signer")
+	}
+	if prompted {
+		t.Error("prompt was called for an unencrypted key")
+	}
+}
+
+func TestParsePrivateKeyWithPrompt_Encrypted(t *testing.T) {
+	data := generateKeyPEM(t, "secret")
+
+	var promptedPath string
+	signer, err := parsePrivateKeyWithPrompt(data, "/home/user/.ssh/id_ed25519", func(keyPath string) ([]byte, error) {
+		promptedPath = keyPath
+		return []byte("secret"), nil
+	})
+	if err != nil {
+		t.Fatalf("parsePrivateKeyWithPrompt() error = %v", err)
+	}
+	if signer == nil {
+		t.Fatal("expected a signer")
+	}
+	if promptedPath != "/home/user/.ssh/id_ed25519" {
+		t.Errorf("prompt received path %q, want the key path", promptedPath)
+	}
+}
+
+func TestParsePrivateKeyWithPrompt_WrongPassphrase(t *testing.T) {
+	data := generateKeyPEM(t, "secret")
+
+	_, err := parsePrivateKeyWithPrompt(data, "/key", func(keyPath string) ([]byte, error) {
+		return []byte("wrong"), nil
+	})
+	if err == nil {
+		t.Fatal("expected error with wrong passphrase")
+	}
+}
+
+func TestParsePrivateKeyWithPrompt_PromptError(t *testing.T) {
+	data := generateKeyPEM(t, "secret")
+
+	promptErr := errors.New("no terminal available")
+	_, err := parsePrivateKeyWithPrompt(data, "/key", func(keyPath string) ([]byte, error) {
+		return nil, promptErr
+	})
+	if !errors.Is(err, promptErr) {
+		t.Fatalf("expected prompt error to propagate, got: %v", err)
+	}
+}
+
+func TestParsePrivateKeyWithPrompt_InvalidKey(t *testing.T) {
+	prompted := false
+	_, err := parsePrivateKeyWithPrompt([]byte("not a key"), "/key", func(keyPath string) ([]byte, error) {
+		prompted = true
+		return nil, nil
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid key")
+	}
+	if prompted {
+		t.Error("prompt was called for an invalid (non-encrypted) key")
+	}
+}
+
+// startFakeAgent starts an in-process ssh-agent on a unix socket and returns
+// the socket path. A short temp dir is used directly: t.TempDir() paths embed
+// the test name and can exceed the macOS 104-char unix socket path limit.
+func startFakeAgent(t *testing.T) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "agent")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	sockPath := filepath.Join(dir, "a.sock")
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("failed to listen on unix socket: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	keyring := agent.NewKeyring()
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() { _ = agent.ServeAgent(keyring, conn) }()
+		}
+	}()
+	return sockPath
+}
+
+func TestAgentSignersFunc_NoSocket(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", "")
+	if fn := agentSignersFunc(); fn != nil {
+		t.Error("expected nil signers func without SSH_AUTH_SOCK")
+	}
+}
+
+func TestAgentSignersFunc_UnreachableSocket(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", filepath.Join(t.TempDir(), "nonexistent.sock"))
+	if fn := agentSignersFunc(); fn != nil {
+		t.Error("expected nil signers func for unreachable agent socket")
+	}
+}
+
+func TestAgentSignersFunc_WithAgent(t *testing.T) {
+	t.Setenv("SSH_AUTH_SOCK", startFakeAgent(t))
+	fn := agentSignersFunc()
+	if fn == nil {
+		t.Fatal("expected signers func with a reachable ssh-agent")
+	}
+	signers, err := fn()
+	if err != nil {
+		t.Fatalf("signers func error = %v", err)
+	}
+	if len(signers) != 0 {
+		t.Errorf("expected empty keyring, got %d signers", len(signers))
+	}
+}
+
+func TestClientAuthMethods_EnvKey(t *testing.T) {
+	data := generateKeyPEM(t, "")
+	t.Setenv("FRANKENDEPLOY_SSH_KEY", string(data))
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	client := NewClient("host", "user", 22, "")
+	methods, err := client.authMethods()
+	if err != nil {
+		t.Fatalf("authMethods() error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Errorf("expected exactly 1 auth method with FRANKENDEPLOY_SSH_KEY, got %d", len(methods))
+	}
+}
+
+func TestClientAuthMethods_KeyFileOnly(t *testing.T) {
+	t.Setenv("FRANKENDEPLOY_SSH_KEY", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, generateKeyPEM(t, ""), 0600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+
+	client := NewClient("host", "user", 22, keyPath)
+	methods, err := client.authMethods()
+	if err != nil {
+		t.Fatalf("authMethods() error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Errorf("expected 1 auth method (key file), got %d", len(methods))
+	}
+}
+
+func TestClientAuthMethods_AgentPlusKeyFile(t *testing.T) {
+	t.Setenv("FRANKENDEPLOY_SSH_KEY", "")
+	t.Setenv("SSH_AUTH_SOCK", startFakeAgent(t))
+
+	keyPath := filepath.Join(t.TempDir(), "id_ed25519")
+	if err := os.WriteFile(keyPath, generateKeyPEM(t, ""), 0600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+
+	client := NewClient("host", "user", 22, keyPath)
+	methods, err := client.authMethods()
+	if err != nil {
+		t.Fatalf("authMethods() error = %v", err)
+	}
+	// Agent and key file MUST be combined into a single publickey method:
+	// the x/crypto client only ever tries one AuthMethod per method name.
+	if len(methods) != 1 {
+		t.Errorf("expected 1 combined publickey method, got %d", len(methods))
+	}
+}
+
+func TestClientAuthMethods_AgentOnlyNoKey(t *testing.T) {
+	t.Setenv("FRANKENDEPLOY_SSH_KEY", "")
+	t.Setenv("SSH_AUTH_SOCK", startFakeAgent(t))
+
+	// Point HOME to an empty dir so no default key is discovered
+	t.Setenv("HOME", t.TempDir())
+
+	client := NewClient("host", "user", 22, "")
+	methods, err := client.authMethods()
+	if err != nil {
+		t.Fatalf("authMethods() should succeed with agent only, got error = %v", err)
+	}
+	if len(methods) != 1 {
+		t.Errorf("expected 1 auth method (agent only), got %d", len(methods))
+	}
+}
+
+func TestClientAuthMethods_NoAgentNoKey(t *testing.T) {
+	t.Setenv("FRANKENDEPLOY_SSH_KEY", "")
+	t.Setenv("SSH_AUTH_SOCK", "")
+	t.Setenv("HOME", t.TempDir())
+
+	client := NewClient("host", "user", 22, "")
+	_, err := client.authMethods()
+	if err == nil {
+		t.Fatal("expected error without agent and without key")
+	}
+}
+
+// signerFromPEM parses a PEM key into a signer for tests
+func signerFromPEM(t *testing.T, data []byte) ssh.Signer {
+	t.Helper()
+	signer, err := ssh.ParsePrivateKey(data)
+	if err != nil {
+		t.Fatalf("failed to parse key: %v", err)
+	}
+	return signer
+}
+
+// writeKeyPair writes a private key and its .pub sibling, returning the
+// private key path and the parsed signer
+func writeKeyPair(t *testing.T, dir, passphrase string) (string, ssh.Signer) {
+	t.Helper()
+	plain := generateKeyPEM(t, "")
+	signer := signerFromPEM(t, plain)
+
+	data := plain
+	if passphrase != "" {
+		// Re-encrypt the same key so the .pub matches
+		_, priv, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatalf("failed to generate key: %v", err)
+		}
+		block, err := ssh.MarshalPrivateKeyWithPassphrase(priv, "test", []byte(passphrase))
+		if err != nil {
+			t.Fatalf("failed to marshal key: %v", err)
+		}
+		data = pem.EncodeToMemory(block)
+		plainBlock, err := ssh.MarshalPrivateKey(priv, "test")
+		if err != nil {
+			t.Fatalf("failed to marshal key: %v", err)
+		}
+		signer = signerFromPEM(t, pem.EncodeToMemory(plainBlock))
+	}
+
+	keyPath := filepath.Join(dir, "id_ed25519")
+	if err := os.WriteFile(keyPath, data, 0600); err != nil {
+		t.Fatalf("failed to write key: %v", err)
+	}
+	pub := ssh.MarshalAuthorizedKey(signer.PublicKey())
+	if err := os.WriteFile(keyPath+".pub", pub, 0644); err != nil {
+		t.Fatalf("failed to write pub key: %v", err)
+	}
+	return keyPath, signer
+}
+
+func TestCollectSigners_AgentEmptyPlusPlainKey(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "")
+	client := NewClient("host", "user", 22, keyPath)
+
+	agentFn := func() ([]ssh.Signer, error) { return nil, nil }
+	signers, err := client.collectSigners(agentFn, keyPath)
+	if err != nil {
+		t.Fatalf("collectSigners() error = %v", err)
+	}
+	if len(signers) != 1 {
+		t.Errorf("expected 1 signer (key file), got %d", len(signers))
+	}
+}
+
+func TestCollectSigners_AgentKeysPlusPlainKey(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "")
+	otherSigner := signerFromPEM(t, generateKeyPEM(t, ""))
+	client := NewClient("host", "user", 22, keyPath)
+
+	agentFn := func() ([]ssh.Signer, error) { return []ssh.Signer{otherSigner}, nil }
+	signers, err := client.collectSigners(agentFn, keyPath)
+	if err != nil {
+		t.Fatalf("collectSigners() error = %v", err)
+	}
+	if len(signers) != 2 {
+		t.Errorf("expected 2 signers (agent + key file), got %d", len(signers))
+	}
+	// Agent signers come first
+	if signers[0] != otherSigner {
+		t.Error("agent signer must come before the key file signer")
+	}
+}
+
+func TestCollectSigners_EncryptedKeyPrompted(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "secret")
+	client := NewClient("host", "user", 22, keyPath,
+		WithPassphraseReader(func(kp string) ([]byte, error) { return []byte("secret"), nil }))
+
+	signers, err := client.collectSigners(nil, keyPath)
+	if err != nil {
+		t.Fatalf("collectSigners() error = %v", err)
+	}
+	if len(signers) != 1 {
+		t.Errorf("expected 1 signer (decrypted key file), got %d", len(signers))
+	}
+}
+
+func TestCollectSigners_EncryptedKeyInAgentNotPrompted(t *testing.T) {
+	dir := t.TempDir()
+	keyPath, signer := writeKeyPair(t, dir, "secret")
+
+	prompted := false
+	client := NewClient("host", "user", 22, keyPath,
+		WithPassphraseReader(func(kp string) ([]byte, error) {
+			prompted = true
+			return nil, errors.New("should not be called")
+		}))
+
+	// The agent already holds the key matching keyPath.pub
+	agentFn := func() ([]ssh.Signer, error) { return []ssh.Signer{signer}, nil }
+	signers, err := client.collectSigners(agentFn, keyPath)
+	if err != nil {
+		t.Fatalf("collectSigners() error = %v", err)
+	}
+	if prompted {
+		t.Error("passphrase prompted although the agent already holds the key")
+	}
+	if len(signers) != 1 {
+		t.Errorf("expected 1 signer (agent), got %d", len(signers))
+	}
+}
+
+func TestCollectSigners_PromptErrorFallsBackToAgent(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "secret")
+	otherSigner := signerFromPEM(t, generateKeyPEM(t, ""))
+
+	client := NewClient("host", "user", 22, keyPath,
+		WithPassphraseReader(func(kp string) ([]byte, error) {
+			return nil, errors.New("no terminal")
+		}))
+
+	// Agent holds an unrelated key: auth should proceed with it
+	agentFn := func() ([]ssh.Signer, error) { return []ssh.Signer{otherSigner}, nil }
+	signers, err := client.collectSigners(agentFn, keyPath)
+	if err != nil {
+		t.Fatalf("collectSigners() should fall back to agent signers, got error = %v", err)
+	}
+	if len(signers) != 1 {
+		t.Errorf("expected 1 signer (agent fallback), got %d", len(signers))
+	}
+}
+
+func TestCollectSigners_PromptErrorNoAgentFails(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "secret")
+
+	promptErr := errors.New("no terminal")
+	client := NewClient("host", "user", 22, keyPath,
+		WithPassphraseReader(func(kp string) ([]byte, error) { return nil, promptErr }))
+
+	_, err := client.collectSigners(nil, keyPath)
+	if !errors.Is(err, promptErr) {
+		t.Fatalf("expected prompt error, got: %v", err)
+	}
+}
+
+func TestCollectSigners_PassphrasePromptedOnce(t *testing.T) {
+	keyPath, _ := writeKeyPair(t, t.TempDir(), "secret")
+
+	promptCount := 0
+	client := NewClient("host", "user", 22, keyPath,
+		WithPassphraseReader(func(kp string) ([]byte, error) {
+			promptCount++
+			return []byte("secret"), nil
+		}))
+
+	for i := 0; i < 3; i++ {
+		if _, err := client.collectSigners(nil, keyPath); err != nil {
+			t.Fatalf("collectSigners() error = %v", err)
+		}
+	}
+	if promptCount != 1 {
+		t.Errorf("passphrase prompted %d times, want 1 (memoized)", promptCount)
+	}
+}
+
+func TestIsRetryableConnError(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		retryable bool
+	}{
+		{
+			name:      "network error is retryable",
+			err:       errors.New("dial tcp 192.0.2.1:22: connect: connection refused"),
+			retryable: true,
+		},
+		{
+			name:      "timeout is retryable",
+			err:       errors.New("dial tcp 192.0.2.1:22: i/o timeout"),
+			retryable: true,
+		},
+		{
+			name:      "auth failure is not retryable",
+			err:       errors.New("ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain"),
+			retryable: false,
+		},
+		{
+			name:      "host key changed is not retryable",
+			err:       fmt.Errorf("ssh: handshake failed: %w", &HostKeyChangedError{Host: "example.com", Fingerprint: "SHA256:abc"}),
+			retryable: false,
+		},
+		{
+			name:      "host key unknown is not retryable",
+			err:       fmt.Errorf("ssh: handshake failed: %w", &HostKeyUnknownError{Host: "example.com", Fingerprint: "SHA256:abc"}),
+			retryable: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isRetryableConnError(tt.err); got != tt.retryable {
+				t.Errorf("isRetryableConnError() = %v, want %v", got, tt.retryable)
+			}
+		})
+	}
+}

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -1,10 +1,10 @@
 package ssh
 
 import (
+	"errors"
 	"fmt"
 	"math"
-	"os"
-	"path/filepath"
+	"strings"
 	"time"
 
 	"golang.org/x/crypto/ssh"
@@ -23,18 +23,22 @@ const (
 type ClientOption func(*clientOptions)
 
 type clientOptions struct {
-	timeout      time.Duration
-	maxRetries   int
-	initialDelay time.Duration
-	maxDelay     time.Duration
+	timeout          time.Duration
+	maxRetries       int
+	initialDelay     time.Duration
+	maxDelay         time.Duration
+	passphrasePrompt PassphraseReader
+	hostKeyPrompt    HostKeyPrompt
 }
 
 func defaultOptions() clientOptions {
 	return clientOptions{
-		timeout:      DefaultTimeout,
-		maxRetries:   DefaultMaxRetries,
-		initialDelay: DefaultInitialDelay,
-		maxDelay:     DefaultMaxDelay,
+		timeout:          DefaultTimeout,
+		maxRetries:       DefaultMaxRetries,
+		initialDelay:     DefaultInitialDelay,
+		maxDelay:         DefaultMaxDelay,
+		passphrasePrompt: DefaultPassphraseReader,
+		hostKeyPrompt:    DefaultHostKeyPrompt,
 	}
 }
 
@@ -66,6 +70,20 @@ func WithMaxDelay(d time.Duration) ClientOption {
 	}
 }
 
+// WithPassphraseReader sets the prompt used for encrypted key passphrases.
+func WithPassphraseReader(r PassphraseReader) ClientOption {
+	return func(o *clientOptions) {
+		o.passphrasePrompt = r
+	}
+}
+
+// WithHostKeyPrompt sets the prompt used to confirm unknown host keys (TOFU).
+func WithHostKeyPrompt(p HostKeyPrompt) ClientOption {
+	return func(o *clientOptions) {
+		o.hostKeyPrompt = p
+	}
+}
+
 // Client represents an SSH client connection
 type Client struct {
 	Host    string
@@ -76,6 +94,9 @@ type Client struct {
 	opts    clientOptions
 	// sshConfig is stored to allow reconnection without reloading keys
 	sshConfig *ssh.ClientConfig
+	// cachedSigner memoizes the (possibly passphrase-decrypted) key file
+	// signer so the passphrase is prompted at most once per process
+	cachedSigner ssh.Signer
 }
 
 // NewClient creates a new SSH client.
@@ -99,21 +120,19 @@ func NewClient(host, user string, port int, keyPath string, opts ...ClientOption
 
 // Connect establishes an SSH connection with retry and exponential backoff.
 func (c *Client) Connect() error {
-	signer, err := c.loadPrivateKey()
+	auths, err := c.authMethods()
 	if err != nil {
-		return fmt.Errorf("failed to load private key: %w", err)
+		return fmt.Errorf("failed to load SSH credentials: %w", err)
 	}
 
-	hostKeyCallback, err := c.hostKeyCallback()
+	hostKeyCallback, err := ResolveHostKeyCallback(c.opts.hostKeyPrompt)
 	if err != nil {
 		return fmt.Errorf("host key verification failed: %w", err)
 	}
 
 	c.sshConfig = &ssh.ClientConfig{
-		User: c.User,
-		Auth: []ssh.AuthMethod{
-			ssh.PublicKeys(signer),
-		},
+		User:            c.User,
+		Auth:            auths,
 		HostKeyCallback: hostKeyCallback,
 		Timeout:         c.opts.timeout,
 	}
@@ -121,7 +140,9 @@ func (c *Client) Connect() error {
 	return c.connectWithRetry()
 }
 
-// connectWithRetry attempts to connect with exponential backoff.
+// connectWithRetry attempts to connect with exponential backoff. Only
+// network-level errors are retried: authentication and host key failures
+// are permanent and surfaced immediately.
 func (c *Client) connectWithRetry() error {
 	addr := fmt.Sprintf("%s:%d", c.Host, c.Port)
 	var lastErr error
@@ -137,10 +158,47 @@ func (c *Client) connectWithRetry() error {
 			c.client = client
 			return nil
 		}
+		if !isRetryableConnError(err) {
+			return classifyConnError(addr, err)
+		}
 		lastErr = err
 	}
 
 	return fmt.Errorf("failed to connect to %s after %d attempts: %w", addr, c.opts.maxRetries, lastErr)
+}
+
+// isRetryableConnError reports whether a connection error is worth retrying.
+// Host key and authentication failures are permanent; retrying them only
+// hides the real message behind "failed after N attempts".
+func isRetryableConnError(err error) bool {
+	var changedErr *HostKeyChangedError
+	var unknownErr *HostKeyUnknownError
+	var keyErr *knownhosts.KeyError
+	if errors.As(err, &changedErr) || errors.As(err, &unknownErr) || errors.As(err, &keyErr) {
+		return false
+	}
+
+	msg := err.Error()
+	if strings.Contains(msg, "unable to authenticate") ||
+		strings.Contains(msg, "permission denied") ||
+		strings.Contains(msg, "no supported methods remain") {
+		return false
+	}
+	return true
+}
+
+// classifyConnError unwraps host key errors so the user sees the dedicated
+// message instead of the generic handshake wrapper.
+func classifyConnError(addr string, err error) error {
+	var changedErr *HostKeyChangedError
+	if errors.As(err, &changedErr) {
+		return changedErr
+	}
+	var unknownErr *HostKeyUnknownError
+	if errors.As(err, &unknownErr) {
+		return unknownErr
+	}
+	return fmt.Errorf("failed to connect to %s: %w", addr, err)
 }
 
 // backoffDelay returns the delay for the given retry attempt using exponential backoff.
@@ -172,111 +230,6 @@ func (c *Client) Reconnect() error {
 		c.client = nil
 	}
 	return c.connectWithRetry()
-}
-
-// loadPrivateKey loads the SSH private key
-func (c *Client) loadPrivateKey() (ssh.Signer, error) {
-	// CI/CD: Check for SSH key in environment variable first
-	if envKey := os.Getenv("FRANKENDEPLOY_SSH_KEY"); envKey != "" {
-		signer, err := ssh.ParsePrivateKey([]byte(envKey))
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse FRANKENDEPLOY_SSH_KEY: %w", err)
-		}
-		return signer, nil
-	}
-
-	keyPath := c.KeyPath
-	if keyPath == "" {
-		homeDir, err := os.UserHomeDir()
-		if err != nil {
-			return nil, err
-		}
-		// Try common key locations
-		keyPaths := []string{
-			filepath.Join(homeDir, ".ssh", "id_ed25519"),
-			filepath.Join(homeDir, ".ssh", "id_rsa"),
-		}
-		for _, p := range keyPaths {
-			if _, err := os.Stat(p); err == nil {
-				keyPath = p
-				break
-			}
-		}
-		if keyPath == "" {
-			return nil, fmt.Errorf("no SSH key found (set FRANKENDEPLOY_SSH_KEY for CI/CD)")
-		}
-	}
-
-	// Expand ~ in path
-	if len(keyPath) >= 2 && keyPath[:2] == "~/" {
-		homeDir, _ := os.UserHomeDir()
-		keyPath = filepath.Join(homeDir, keyPath[2:])
-	}
-
-	key, err := os.ReadFile(keyPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read key file: %w", err)
-	}
-
-	signer, err := ssh.ParsePrivateKey(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse private key: %w", err)
-	}
-
-	return signer, nil
-}
-
-// hostKeyCallback returns the host key callback function
-// SECURITY: This function requires a valid known_hosts file by default
-// In CI/CD, set FRANKENDEPLOY_KNOWN_HOSTS with the content of known_hosts
-// or FRANKENDEPLOY_SKIP_HOST_KEY_CHECK=true to skip verification (not recommended)
-func (c *Client) hostKeyCallback() (ssh.HostKeyCallback, error) {
-	// CI/CD: Check for known_hosts content in environment variable
-	if knownHostsContent := os.Getenv("FRANKENDEPLOY_KNOWN_HOSTS"); knownHostsContent != "" {
-		// Write to temp file for knownhosts.New()
-		tmpFile, err := os.CreateTemp("", "known_hosts")
-		if err != nil {
-			return nil, fmt.Errorf("failed to create temp known_hosts: %w", err)
-		}
-		defer os.Remove(tmpFile.Name())
-
-		if _, err := tmpFile.WriteString(knownHostsContent); err != nil {
-			return nil, fmt.Errorf("failed to write temp known_hosts: %w", err)
-		}
-		tmpFile.Close()
-
-		callback, err := knownhosts.New(tmpFile.Name())
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse FRANKENDEPLOY_KNOWN_HOSTS: %w", err)
-		}
-		return callback, nil
-	}
-
-	// CI/CD: Option to skip host key verification (use with caution)
-	if os.Getenv("FRANKENDEPLOY_SKIP_HOST_KEY_CHECK") == "true" {
-		return ssh.InsecureIgnoreHostKey(), nil
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot determine home directory: %w", err)
-	}
-
-	knownHostsPath := filepath.Join(homeDir, ".ssh", "known_hosts")
-
-	if _, err := os.Stat(knownHostsPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("SSH known_hosts file not found at %s. "+
-			"Please connect to the server manually first with: ssh %s@%s -p %d\n"+
-			"For CI/CD, set FRANKENDEPLOY_KNOWN_HOSTS or FRANKENDEPLOY_SKIP_HOST_KEY_CHECK=true",
-			knownHostsPath, c.User, c.Host, c.Port)
-	}
-
-	callback, err := knownhosts.New(knownHostsPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read known_hosts: %w", err)
-	}
-
-	return callback, nil
 }
 
 // NewSession creates a new SSH session.

--- a/internal/ssh/hostkey.go
+++ b/internal/ssh/hostkey.go
@@ -1,0 +1,187 @@
+package ssh
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+	"golang.org/x/term"
+)
+
+// HostKeyPrompt asks the user whether to trust an unknown host key
+// (trust-on-first-use). It receives the normalized host, the key type
+// and the SHA256 fingerprint, and returns true to accept the key.
+type HostKeyPrompt func(host, keyType, fingerprint string) bool
+
+// HostKeyChangedError is returned when the server's host key does not match
+// the one recorded in known_hosts. This is never retried and never subject
+// to TOFU: it either means the server was reinstalled or a MITM attack.
+type HostKeyChangedError struct {
+	Host        string
+	Fingerprint string
+}
+
+func (e *HostKeyChangedError) Error() string {
+	return fmt.Sprintf("host key for %s has changed (fingerprint: %s)\n"+
+		"This happens when the server was reinstalled or recreated, but could also indicate a man-in-the-middle attack.\n"+
+		"If you recently recreated this server, remove the old key with:\n"+
+		"  ssh-keygen -R %s", e.Host, e.Fingerprint, e.Host)
+}
+
+// HostKeyUnknownError is returned when connecting to an unknown host and the
+// key was not confirmed (non-interactive session or user refusal).
+type HostKeyUnknownError struct {
+	Host        string
+	Fingerprint string
+}
+
+func (e *HostKeyUnknownError) Error() string {
+	return fmt.Sprintf("host key for %s (fingerprint: %s) is not known and was not confirmed\n"+
+		"Run the command interactively to review and accept the key, "+
+		"or set FRANKENDEPLOY_KNOWN_HOSTS with the known_hosts content for CI/CD", e.Host, e.Fingerprint)
+}
+
+// DefaultHostKeyPrompt interactively asks the user to confirm an unknown
+// host key, mimicking the standard OpenSSH first-connection prompt.
+// It refuses automatically when stdin is not a terminal.
+func DefaultHostKeyPrompt(host, keyType, fingerprint string) bool {
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return false
+	}
+
+	fmt.Printf("The authenticity of host '%s' can't be established.\n", host)
+	fmt.Printf("%s key fingerprint is %s.\n", keyType, fingerprint)
+	fmt.Print("Are you sure you want to continue connecting (yes/no)? ")
+
+	// A partial line before EOF (piped input without trailing newline) is
+	// still a valid answer, so only bail out when nothing was read.
+	line, err := bufio.NewReader(os.Stdin).ReadString('\n')
+	if err != nil && line == "" {
+		return false
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "yes" || answer == "y"
+}
+
+// ResolveHostKeyCallback returns the host key verification callback used by
+// every SSH connection (deploy, server add, TryConnect...).
+//
+// Resolution order:
+//  1. FRANKENDEPLOY_KNOWN_HOSTS: known_hosts content for CI/CD (strict, no TOFU)
+//  2. FRANKENDEPLOY_SKIP_HOST_KEY_CHECK=true: skip verification (not recommended)
+//  3. ~/.ssh/known_hosts with trust-on-first-use via prompt
+func ResolveHostKeyCallback(prompt HostKeyPrompt) (ssh.HostKeyCallback, error) {
+	if content := os.Getenv("FRANKENDEPLOY_KNOWN_HOSTS"); content != "" {
+		tmpFile, err := os.CreateTemp("", "known_hosts")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create temp known_hosts: %w", err)
+		}
+		defer os.Remove(tmpFile.Name())
+
+		if _, err := tmpFile.WriteString(content); err != nil {
+			tmpFile.Close()
+			return nil, fmt.Errorf("failed to write temp known_hosts: %w", err)
+		}
+		tmpFile.Close()
+
+		callback, err := knownhosts.New(tmpFile.Name())
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse FRANKENDEPLOY_KNOWN_HOSTS: %w", err)
+		}
+		return callback, nil
+	}
+
+	if os.Getenv("FRANKENDEPLOY_SKIP_HOST_KEY_CHECK") == "true" {
+		return ssh.InsecureIgnoreHostKey(), nil
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	return knownHostsCallbackWithTOFU(filepath.Join(homeDir, ".ssh", "known_hosts"), prompt)
+}
+
+// knownHostsCallbackWithTOFU wraps a knownhosts callback with
+// trust-on-first-use: unknown hosts are confirmed via prompt and appended to
+// the known_hosts file; key mismatches are surfaced as HostKeyChangedError.
+func knownHostsCallbackWithTOFU(path string, prompt HostKeyPrompt) (ssh.HostKeyCallback, error) {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			return nil, fmt.Errorf("failed to create %s: %w", filepath.Dir(path), err)
+		}
+		if err := os.WriteFile(path, nil, 0600); err != nil {
+			return nil, fmt.Errorf("failed to create %s: %w", path, err)
+		}
+	}
+
+	base, err := knownhosts.New(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read known_hosts: %w", err)
+	}
+
+	// Keys accepted during this process: the base callback is parsed once,
+	// so reconnections must not prompt again for a key already accepted.
+	var mu sync.Mutex
+	accepted := make(map[string]bool)
+
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		err := base(hostname, remote, key)
+		if err == nil {
+			return nil
+		}
+
+		var keyErr *knownhosts.KeyError
+		if !errors.As(err, &keyErr) {
+			return err
+		}
+
+		host := knownhosts.Normalize(hostname)
+		fingerprint := ssh.FingerprintSHA256(key)
+
+		if len(keyErr.Want) > 0 {
+			return &HostKeyChangedError{Host: host, Fingerprint: fingerprint}
+		}
+
+		mu.Lock()
+		alreadyAccepted := accepted[host+"|"+fingerprint]
+		mu.Unlock()
+		if alreadyAccepted {
+			return nil
+		}
+
+		if prompt == nil || !prompt(host, key.Type(), fingerprint) {
+			return &HostKeyUnknownError{Host: host, Fingerprint: fingerprint}
+		}
+
+		if err := appendKnownHost(path, hostname, key); err != nil {
+			return fmt.Errorf("failed to record host key: %w", err)
+		}
+
+		mu.Lock()
+		accepted[host+"|"+fingerprint] = true
+		mu.Unlock()
+		return nil
+	}, nil
+}
+
+// appendKnownHost appends the host key to the known_hosts file in the
+// standard OpenSSH format.
+func appendKnownHost(path, hostname string, key ssh.PublicKey) error {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	_, err = fmt.Fprintln(f, knownhosts.Line([]string{hostname}, key))
+	return err
+}

--- a/internal/ssh/hostkey_test.go
+++ b/internal/ssh/hostkey_test.go
@@ -1,0 +1,265 @@
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"errors"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+// testHostKey generates an ed25519 host key pair for tests
+func testHostKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	sshPub, err := ssh.NewPublicKey(pub)
+	if err != nil {
+		t.Fatalf("failed to convert key: %v", err)
+	}
+	return sshPub
+}
+
+type fakeAddr struct{ addr string }
+
+func (a fakeAddr) Network() string { return "tcp" }
+func (a fakeAddr) String() string  { return a.addr }
+
+func TestKnownHostsCallbackWithTOFU_UnknownHostAccepted(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "known_hosts")
+	key := testHostKey(t)
+
+	var promptedHost, promptedFingerprint string
+	prompt := func(host, keyType, fingerprint string) bool {
+		promptedHost = host
+		promptedFingerprint = fingerprint
+		return true
+	}
+
+	callback, err := knownHostsCallbackWithTOFU(path, prompt)
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+
+	addr := fakeAddr{"192.0.2.1:22"}
+	if err := callback("example.com:22", addr, key); err != nil {
+		t.Fatalf("expected TOFU acceptance, got error: %v", err)
+	}
+
+	if promptedHost != "example.com" {
+		t.Errorf("prompted host = %q, want %q", promptedHost, "example.com")
+	}
+	if promptedFingerprint != ssh.FingerprintSHA256(key) {
+		t.Errorf("prompted fingerprint = %q, want %q", promptedFingerprint, ssh.FingerprintSHA256(key))
+	}
+
+	// The key must have been appended to known_hosts
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read known_hosts: %v", err)
+	}
+	if !strings.Contains(string(data), "example.com") {
+		t.Errorf("known_hosts does not contain the accepted host: %s", data)
+	}
+
+	// A fresh callback (re-reading the file) must now accept without prompting
+	prompted := false
+	callback2, err := knownHostsCallbackWithTOFU(path, func(host, keyType, fingerprint string) bool {
+		prompted = true
+		return false
+	})
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+	if err := callback2("example.com:22", addr, key); err != nil {
+		t.Errorf("expected known host to be accepted, got: %v", err)
+	}
+	if prompted {
+		t.Error("prompt was called for an already-known host")
+	}
+}
+
+func TestKnownHostsCallbackWithTOFU_UnknownHostRejected(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "known_hosts")
+	key := testHostKey(t)
+
+	callback, err := knownHostsCallbackWithTOFU(path, func(host, keyType, fingerprint string) bool {
+		return false
+	})
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+
+	err = callback("example.com:22", fakeAddr{"192.0.2.1:22"}, key)
+	var unknownErr *HostKeyUnknownError
+	if !errors.As(err, &unknownErr) {
+		t.Fatalf("expected HostKeyUnknownError, got: %v", err)
+	}
+
+	// Nothing must have been written
+	if data, _ := os.ReadFile(path); strings.Contains(string(data), "example.com") {
+		t.Error("rejected host was written to known_hosts")
+	}
+}
+
+func TestKnownHostsCallbackWithTOFU_NilPromptRejects(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "known_hosts")
+	key := testHostKey(t)
+
+	callback, err := knownHostsCallbackWithTOFU(path, nil)
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+
+	err = callback("example.com:22", fakeAddr{"192.0.2.1:22"}, key)
+	var unknownErr *HostKeyUnknownError
+	if !errors.As(err, &unknownErr) {
+		t.Fatalf("expected HostKeyUnknownError with nil prompt, got: %v", err)
+	}
+}
+
+func TestKnownHostsCallbackWithTOFU_ChangedKey(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "known_hosts")
+	oldKey := testHostKey(t)
+	newKey := testHostKey(t)
+
+	// Record the old key
+	line := knownhosts.Line([]string{"example.com:22"}, oldKey)
+	if err := os.WriteFile(path, []byte(line+"\n"), 0600); err != nil {
+		t.Fatalf("failed to write known_hosts: %v", err)
+	}
+
+	prompted := false
+	callback, err := knownHostsCallbackWithTOFU(path, func(host, keyType, fingerprint string) bool {
+		prompted = true
+		return true
+	})
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+
+	err = callback("example.com:22", fakeAddr{"192.0.2.1:22"}, newKey)
+	var changedErr *HostKeyChangedError
+	if !errors.As(err, &changedErr) {
+		t.Fatalf("expected HostKeyChangedError, got: %v", err)
+	}
+	if prompted {
+		t.Error("TOFU prompt must never be offered on a host key mismatch")
+	}
+	if !strings.Contains(changedErr.Error(), "ssh-keygen -R") {
+		t.Errorf("error message should mention ssh-keygen -R, got: %v", changedErr)
+	}
+}
+
+func TestKnownHostsCallbackWithTOFU_CreatesMissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, ".ssh", "known_hosts")
+
+	if _, err := knownHostsCallbackWithTOFU(path, nil); err != nil {
+		t.Fatalf("expected missing known_hosts to be created, got error: %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("known_hosts was not created: %v", err)
+	}
+	if info.Mode().Perm() != 0600 {
+		t.Errorf("known_hosts permissions = %o, want 0600", info.Mode().Perm())
+	}
+}
+
+func TestKnownHostsCallbackWithTOFU_NonStandardPort(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "known_hosts")
+	key := testHostKey(t)
+
+	callback, err := knownHostsCallbackWithTOFU(path, func(host, keyType, fingerprint string) bool {
+		return true
+	})
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+
+	addr := fakeAddr{"192.0.2.1:3022"}
+	if err := callback("gate.example.com:3022", addr, key); err != nil {
+		t.Fatalf("expected TOFU acceptance, got error: %v", err)
+	}
+
+	// A fresh callback must recognize the host on its non-standard port
+	callback2, err := knownHostsCallbackWithTOFU(path, nil)
+	if err != nil {
+		t.Fatalf("knownHostsCallbackWithTOFU() error = %v", err)
+	}
+	if err := callback2("gate.example.com:3022", addr, key); err != nil {
+		t.Errorf("host on non-standard port not recognized after TOFU: %v", err)
+	}
+}
+
+func TestResolveHostKeyCallback_EnvKnownHosts(t *testing.T) {
+	key := testHostKey(t)
+	line := knownhosts.Line([]string{"example.com:22"}, key)
+	t.Setenv("FRANKENDEPLOY_KNOWN_HOSTS", line+"\n")
+
+	callback, err := ResolveHostKeyCallback(nil)
+	if err != nil {
+		t.Fatalf("ResolveHostKeyCallback() error = %v", err)
+	}
+
+	if err := callback("example.com:22", fakeAddr{"192.0.2.1:22"}, key); err != nil {
+		t.Errorf("host from FRANKENDEPLOY_KNOWN_HOSTS rejected: %v", err)
+	}
+
+	// An unknown host must be rejected (no TOFU on env-provided known_hosts)
+	otherKey := testHostKey(t)
+	if err := callback("other.com:22", fakeAddr{"192.0.2.2:22"}, otherKey); err == nil {
+		t.Error("unknown host accepted with FRANKENDEPLOY_KNOWN_HOSTS set")
+	}
+}
+
+func TestResolveHostKeyCallback_SkipCheck(t *testing.T) {
+	t.Setenv("FRANKENDEPLOY_SKIP_HOST_KEY_CHECK", "true")
+
+	callback, err := ResolveHostKeyCallback(nil)
+	if err != nil {
+		t.Fatalf("ResolveHostKeyCallback() error = %v", err)
+	}
+
+	if err := callback("anything.com:22", fakeAddr{"192.0.2.1:22"}, testHostKey(t)); err != nil {
+		t.Errorf("expected host to be accepted with skip check, got: %v", err)
+	}
+}
+
+func TestHostKeyChangedError_Message(t *testing.T) {
+	err := &HostKeyChangedError{Host: "example.com", Fingerprint: "SHA256:abc"}
+	msg := err.Error()
+	for _, want := range []string{"example.com", "SHA256:abc", "ssh-keygen -R", "man-in-the-middle"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("HostKeyChangedError message missing %q: %s", want, msg)
+		}
+	}
+}
+
+func TestHostKeyUnknownError_Message(t *testing.T) {
+	err := &HostKeyUnknownError{Host: "example.com", Fingerprint: "SHA256:abc"}
+	msg := err.Error()
+	for _, want := range []string{"example.com", "SHA256:abc", "FRANKENDEPLOY_KNOWN_HOSTS"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("HostKeyUnknownError message missing %q: %s", want, msg)
+		}
+	}
+}
+
+// Guard against net import being reported unused if tests change
+var _ net.Addr = fakeAddr{}

--- a/internal/ssh/keys.go
+++ b/internal/ssh/keys.go
@@ -3,6 +3,7 @@ package ssh
 import (
 	"bytes"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"time"
 
 	"golang.org/x/crypto/ssh"
-	"golang.org/x/crypto/ssh/knownhosts"
 )
 
 // SSHKeyInfo contains information about an SSH key
@@ -122,6 +122,10 @@ func ValidateSSHKey(path string) (*SSHKeyInfo, error) {
 
 // isPassphraseError checks if the error indicates a passphrase-protected key
 func isPassphraseError(err error) bool {
+	var missingErr *ssh.PassphraseMissingError
+	if errors.As(err, &missingErr) {
+		return true
+	}
 	errStr := err.Error()
 	return strings.Contains(errStr, "passphrase") ||
 		strings.Contains(errStr, "encrypted") ||
@@ -163,26 +167,26 @@ func detectKeyType(data []byte) string {
 	return "unknown"
 }
 
-// TryConnect attempts to connect to a server with a specific key
-// Returns nil on success, error on failure
+// TryConnect attempts to connect to a server with a specific key file
+// (encrypted keys prompt for their passphrase). The ssh-agent is deliberately
+// not used here: this function validates one specific key.
+// Returns nil on success, error on failure.
 func TryConnect(host, user string, port int, keyPath string) error {
 	if port == 0 {
 		port = 22
 	}
 
-	// Load the private key
 	keyData, err := os.ReadFile(keyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read key: %w", err)
 	}
 
-	signer, err := ssh.ParsePrivateKey(keyData)
+	signer, err := parsePrivateKeyWithPrompt(keyData, keyPath, nil)
 	if err != nil {
-		return fmt.Errorf("failed to parse key: %w", err)
+		return err
 	}
 
-	// Get host key callback
-	hostKeyCallback, err := getHostKeyCallback(host, user, port)
+	hostKeyCallback, err := ResolveHostKeyCallback(DefaultHostKeyPrompt)
 	if err != nil {
 		return err
 	}
@@ -199,43 +203,9 @@ func TryConnect(host, user string, port int, keyPath string) error {
 	addr := fmt.Sprintf("%s:%d", host, port)
 	client, err := ssh.Dial("tcp", addr, config)
 	if err != nil {
-		return fmt.Errorf("connection failed: %w", err)
+		return classifyConnError(addr, err)
 	}
 	client.Close()
 
 	return nil
-}
-
-// getHostKeyCallback returns the host key callback for connection testing
-func getHostKeyCallback(host, user string, port int) (ssh.HostKeyCallback, error) {
-	// Check for CI/CD environment variables first
-	if os.Getenv("FRANKENDEPLOY_SKIP_HOST_KEY_CHECK") == "true" {
-		return ssh.InsecureIgnoreHostKey(), nil
-	}
-
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return nil, fmt.Errorf("cannot determine home directory: %w", err)
-	}
-
-	knownHostsPath := filepath.Join(homeDir, ".ssh", "known_hosts")
-
-	if _, err := os.Stat(knownHostsPath); os.IsNotExist(err) {
-		return nil, fmt.Errorf("SSH known_hosts file not found at %s. "+
-			"Please connect to the server manually first with: ssh %s@%s -p %d\n"+
-			"For CI/CD, set FRANKENDEPLOY_SKIP_HOST_KEY_CHECK=true",
-			knownHostsPath, user, host, port)
-	}
-
-	callback, err := newKnownHostsCallback(knownHostsPath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read known_hosts: %w", err)
-	}
-
-	return callback, nil
-}
-
-// newKnownHostsCallback creates a host key callback from a known_hosts file
-func newKnownHostsCallback(path string) (ssh.HostKeyCallback, error) {
-	return knownhosts.New(path)
 }


### PR DESCRIPTION
## Summary

Implements #50: the SSH stack now matches what a developer expects from OpenSSH.

- **ssh-agent support**: signers from `SSH_AUTH_SOCK` are tried first. Agent and key file are combined into a **single** publickey auth method — the x/crypto client only attempts one `AuthMethod` per method name, so separate methods would silently never try the key file (found during live testing).
- **Encrypted keys**: passphrase prompted with `term.ReadPassword` (never echoed, never stored, asked at most once per process). No prompt when the agent already holds the key (matched via the `.pub` sibling). `server add` no longer silently skips encrypted keys in interactive mode.
- **Trust-on-first-use**: first connection shows the SHA256 fingerprint with an OpenSSH-style yes/no prompt and records the key in `~/.ssh/known_hosts` (created `0600` if missing). No more manual `ssh` required before using FrankenDeploy.
- **Host key mismatch**: dedicated error with the exact `ssh-keygen -R <host>` command, shown immediately — never retried, never offered TOFU.
- **Retry classification**: only network errors get the retry/backoff; auth and host-key failures surface immediately instead of being buried under "failed after 3 attempts".
- **`ResolveHostKeyCallback()`**: single resolution honoring `FRANKENDEPLOY_KNOWN_HOSTS` and `FRANKENDEPLOY_SKIP_HOST_KEY_CHECK` for both `Connect` and `TryConnect` (previously inconsistent between `server add` and `deploy`).

Docs: `server-setup.md` updated (SSH authentication order, first-connection flow, CI/CD notes).

## Test plan

- [x] 31 new unit tests (TOFU accept/reject/mismatch, non-standard ports, env vars, passphrase parsing, agent socket, signer collection & memoization, retry classification) — 653 total, `-race`
- [x] golangci-lint v1.64.2 (CI version) clean
- [x] Live on a fresh VPS (Ubuntu 24.04, x86_64):
  - TOFU refused non-interactively → clear message, no retry (0.35s)
  - TOFU accepted interactively → key recorded, connection succeeds in the same run
  - Tampered known_hosts entry → `HostKeyChangedError` with `ssh-keygen -R` hint in 0.17s
  - Encrypted key: passphrase prompt → connect OK; same key in ssh-agent → zero prompt
  - Full chain via the new stack: `server add` → `server setup` → `deploy` of a Symfony demo app → HTTP 200 over HTTPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)