### PR TITLE
fix(generator): production Dockerfile hardening (#48)

### DIFF
--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -120,6 +120,7 @@ assets:
   build_tool: npm        # npm, yarn, pnpm, or assetmapper
   build_command: "npm run build"
   output_dir: "public/build"
+  node_version: "22"     # Node.js version for the build stage (default: 22)
 ```
 
 For Symfony AssetMapper, set:

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -107,7 +107,7 @@ deploy:
   healthcheck_path: /health
 ```
 
-The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used by Caddy's active health checks on the running container.
+The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used by Caddy's active health checks on the running container **and by the Docker `HEALTHCHECK` baked into the generated image**, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
 
 The check window is generous by default (90 seconds — a cold Symfony container needs time for opcache warmup and database wait) and tunable:
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -46,6 +46,9 @@ type AssetsConfig struct {
 	BuildTool    string `yaml:"build_tool,omitempty"`
 	BuildCommand string `yaml:"build_command,omitempty"`
 	OutputDir    string `yaml:"output_dir,omitempty"`
+	// NodeVersion is the Node.js major version for the asset build stage
+	// (default: 22)
+	NodeVersion string `yaml:"node_version,omitempty"`
 }
 
 // MessengerConfig holds Symfony Messenger worker configuration.

--- a/internal/generator/constants.go
+++ b/internal/generator/constants.go
@@ -11,7 +11,6 @@ import "github.com/yoanbernabeu/frankendeploy/internal/constants"
 const (
 	// Ports — sourced from constants package
 	AppPort         = constants.AppPort
-	MetricsPort     = "2019"
 	DevExternalPort = "8000"
 
 	// User/Group IDs — sourced from constants package

--- a/internal/generator/dockerfile.go
+++ b/internal/generator/dockerfile.go
@@ -28,6 +28,12 @@ type DockerfileData struct {
 	Assets            *config.AssetsConfig
 	Dockerfile        config.DockerfileConfig
 	FrankenPHPVersion string
+	// HealthcheckPath is the app endpoint probed by the container
+	// HEALTHCHECK (default "/")
+	HealthcheckPath string
+	// HasPreload enables opcache.preload when the project ships a
+	// config/preload.php
+	HasPreload bool
 }
 
 // Generate generates the Dockerfile content
@@ -37,6 +43,8 @@ func (g *DockerfileGenerator) Generate() (string, error) {
 		PHP:               g.config.PHP,
 		Dockerfile:        g.config.Dockerfile,
 		FrankenPHPVersion: g.config.FrankenPHPVersion,
+		HealthcheckPath:   g.config.Deploy.HealthcheckPath,
+		HasPreload:        hasPreloadFile(),
 	}
 
 	if g.config.Assets.BuildTool != "" {
@@ -56,6 +64,13 @@ func (g *DockerfileGenerator) Generate() (string, error) {
 	}
 
 	return g.loader.Execute("dockerfile.tmpl", data)
+}
+
+// hasPreloadFile reports whether the project (current directory, where
+// generation runs) ships a config/preload.php for OPcache preloading.
+func hasPreloadFile() bool {
+	info, err := os.Stat("config/preload.php")
+	return err == nil && !info.IsDir()
 }
 
 // WriteDockerfile writes the Dockerfile to the specified path

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -428,7 +428,7 @@ func TestDockerfileGenerator_Generate_NPMVite(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate: %v", err)
 	}
-	if !strings.Contains(dockerfile, "FROM node:20-slim AS node_build") {
+	if !strings.Contains(dockerfile, "FROM node:22-slim AS node_build") {
 		t.Error("npm/Vite should have Node build stage")
 	}
 	if !strings.Contains(dockerfile, "COPY --from=node_build") {
@@ -457,7 +457,7 @@ func TestDockerfileGenerator_Generate_CustomAssetOutputDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generate: %v", err)
 	}
-	want := "COPY --from=node_build /app/public/dist public/dist"
+	want := "COPY --from=node_build --link --chown=" + DefaultUID + ":" + DefaultGID + " /app/public/dist public/dist"
 	if !strings.Contains(dockerfile, want) {
 		t.Errorf("dockerfile should contain %q:\n%s", want, dockerfile)
 	}
@@ -596,8 +596,8 @@ func TestDockerfileGenerator_Generate_Constants(t *testing.T) {
 	if !strings.Contains(dockerfile, "ARG GID="+DefaultGID) {
 		t.Error("Dockerfile should use DefaultGID constant")
 	}
-	if !strings.Contains(dockerfile, "localhost:"+MetricsPort+"/metrics") {
-		t.Error("Dockerfile should use MetricsPort constant")
+	if !strings.Contains(dockerfile, "localhost:"+AppPort+"/") {
+		t.Error("Dockerfile healthcheck should use AppPort constant")
 	}
 }
 
@@ -804,8 +804,8 @@ func TestComposeGenerator_GenerateDev_HasHealthCheck(t *testing.T) {
 	if !strings.Contains(compose, "healthcheck:") {
 		t.Error("compose-dev should have a healthcheck for the app service")
 	}
-	if !strings.Contains(compose, "localhost:"+MetricsPort+"/metrics") {
-		t.Error("compose-dev healthcheck should use metrics port")
+	if !strings.Contains(compose, "localhost:"+AppPort+"/") {
+		t.Error("compose-dev healthcheck should probe the app port")
 	}
 }
 
@@ -854,7 +854,7 @@ func TestComposeGenerator_GenerateProd(t *testing.T) {
 		"test-app:${TAG:-latest}",
 		"expose:",
 		`"` + AppPort + `"`,
-		"localhost:" + MetricsPort + "/metrics",
+		"localhost:" + AppPort + "/",
 		NetworkName,
 		"app.domain=example.com",
 		DefaultUID + ":" + DefaultGID,

--- a/internal/generator/hardening_test.go
+++ b/internal/generator/hardening_test.go
@@ -1,0 +1,229 @@
+package generator
+
+// Tests for issue #48: production Dockerfile hardening.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+)
+
+func minimalConfig() *config.ProjectConfig {
+	return &config.ProjectConfig{
+		Name: "test-app",
+		PHP:  config.PHPConfig{Version: "8.3", Extensions: []string{"intl"}},
+	}
+}
+
+func generateDockerfile(t *testing.T, cfg *config.ProjectConfig) string {
+	t.Helper()
+	dockerfile, err := NewDockerfileGenerator(cfg).Generate()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	return dockerfile
+}
+
+func TestDockerfile_NoSilentBuildFailures(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	if strings.Contains(dockerfile, "post-install-cmd || true") {
+		t.Error("composer post-install-cmd must not be silenced with || true: a failing build script must fail the image build")
+	}
+	if !strings.Contains(dockerfile, "post-install-cmd") {
+		t.Error("Dockerfile should still run post-install-cmd")
+	}
+	if !strings.Contains(dockerfile, "cache:warmup") {
+		t.Error("Dockerfile should explicitly warm the Symfony cache at build time")
+	}
+}
+
+func TestDockerfile_NoVolumeVar(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	if strings.Contains(dockerfile, "VOLUME") {
+		t.Error("Dockerfile must not declare VOLUME /app/var: it can discard build-time cache warmup with the classic builder")
+	}
+}
+
+func TestDockerfile_ProdOpcacheIni(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	for _, want := range []string{
+		"app.prod.ini",
+		"opcache.validate_timestamps = 0",
+		"opcache.memory_consumption",
+		"opcache.max_accelerated_files",
+		"realpath_cache_size",
+	} {
+		if !strings.Contains(dockerfile, want) {
+			t.Errorf("Dockerfile should contain production PHP setting %q", want)
+		}
+	}
+
+	// The prod ini must live in the prod stage, not the base stage (shared
+	// with dev): validate_timestamps=0 in dev would require container
+	// restarts on every code change.
+	prodStage := strings.Index(dockerfile, "AS frankenphp_prod")
+	iniPos := strings.Index(dockerfile, "opcache.validate_timestamps")
+	if prodStage == -1 || iniPos < prodStage {
+		t.Error("production OPcache settings must be in the frankenphp_prod stage only")
+	}
+}
+
+func TestDockerfile_PreloadWhenConfigExists(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "config"), 0755); err != nil {
+		t.Fatalf("failed to create config dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "preload.php"), []byte("<?php"), 0644); err != nil {
+		t.Fatalf("failed to write preload.php: %v", err)
+	}
+	t.Chdir(dir)
+
+	dockerfile := generateDockerfile(t, minimalConfig())
+	if !strings.Contains(dockerfile, "opcache.preload = /app/config/preload.php") {
+		t.Error("Dockerfile should enable opcache.preload when config/preload.php exists")
+	}
+}
+
+func TestDockerfile_NoPreloadWithoutConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	dockerfile := generateDockerfile(t, minimalConfig())
+	if strings.Contains(dockerfile, "opcache.preload") {
+		t.Error("Dockerfile must not enable opcache.preload when config/preload.php does not exist")
+	}
+}
+
+func TestDockerfile_NoFullAppChown(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	if strings.Contains(dockerfile, "chown -R app:app /app;") {
+		t.Error("Dockerfile must not chown -R the whole /app in a RUN layer: it duplicates every file and doubles the image size")
+	}
+
+	wantCopy := fmt.Sprintf("COPY --link --chown=%s:%s . ./", DefaultUID, DefaultGID)
+	if !strings.Contains(dockerfile, wantCopy) {
+		t.Errorf("Dockerfile should copy sources with %q instead of a separate chown layer", wantCopy)
+	}
+
+	// Files created by root during the build RUN (cache warmup) still need
+	// app ownership, but only var/ — a small tree.
+	if !strings.Contains(dockerfile, "chown -R app:app var") {
+		t.Error("Dockerfile should chown var/ (created during build) to the app user")
+	}
+}
+
+func TestDockerfile_NodeVersionDefault(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Assets = config.AssetsConfig{BuildTool: "npm", BuildCommand: "npm run build"}
+
+	dockerfile := generateDockerfile(t, cfg)
+	if !strings.Contains(dockerfile, "FROM node:22-slim AS node_build") {
+		t.Error("default Node version should be 22 (Node 20 EOL April 2026)")
+	}
+}
+
+func TestDockerfile_NodeVersionConfigurable(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Assets = config.AssetsConfig{BuildTool: "npm", BuildCommand: "npm run build", NodeVersion: "24"}
+
+	dockerfile := generateDockerfile(t, cfg)
+	if !strings.Contains(dockerfile, "FROM node:24-slim AS node_build") {
+		t.Error("assets.node_version should override the Node image version")
+	}
+}
+
+func TestDockerfile_NodeVersionRejectsUnsafe(t *testing.T) {
+	for _, bad := range []string{"22-slim; RUN evil", "22 AS x", "$(cat)", "latest\nRUN evil"} {
+		t.Run(bad, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.Assets = config.AssetsConfig{BuildTool: "npm", BuildCommand: "npm run build", NodeVersion: bad}
+			if _, err := NewDockerfileGenerator(cfg).Generate(); err == nil {
+				t.Errorf("expected error for unsafe node_version %q, got nil", bad)
+			}
+		})
+	}
+}
+
+func TestDockerfile_NoPersistentComposerSuperuser(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	if strings.Contains(dockerfile, "ENV COMPOSER_ALLOW_SUPERUSER") {
+		t.Error("COMPOSER_ALLOW_SUPERUSER must not persist as ENV in the final image")
+	}
+	if !strings.Contains(dockerfile, "COMPOSER_ALLOW_SUPERUSER=1 composer") {
+		t.Error("composer invocations during build should set COMPOSER_ALLOW_SUPERUSER inline")
+	}
+}
+
+func TestDockerfile_AppLevelHealthcheck(t *testing.T) {
+	dockerfile := generateDockerfile(t, minimalConfig())
+
+	if strings.Contains(dockerfile, "2019/metrics") {
+		t.Error("HEALTHCHECK must not hit the Caddy admin endpoint: it only proves Caddy is up, not the app")
+	}
+	want := fmt.Sprintf("http://localhost:%s/", AppPort)
+	if !strings.Contains(dockerfile, want) {
+		t.Errorf("HEALTHCHECK should hit the app on %q", want)
+	}
+}
+
+func TestDockerfile_HealthcheckCustomPath(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Deploy.HealthcheckPath = "/health"
+
+	dockerfile := generateDockerfile(t, cfg)
+	want := fmt.Sprintf("http://localhost:%s/health", AppPort)
+	if !strings.Contains(dockerfile, want) {
+		t.Errorf("HEALTHCHECK should use the configured healthcheck_path, want %q", want)
+	}
+}
+
+func TestDockerfile_HealthcheckPathRejectsUnsafe(t *testing.T) {
+	for _, bad := range []string{"no-leading-slash", "/path; rm -rf /", "/path$(evil)", "/path space", "/path\nRUN evil"} {
+		t.Run(bad, func(t *testing.T) {
+			cfg := minimalConfig()
+			cfg.Deploy.HealthcheckPath = bad
+			if _, err := NewDockerfileGenerator(cfg).Generate(); err == nil {
+				t.Errorf("expected error for unsafe healthcheck_path %q, got nil", bad)
+			}
+		})
+	}
+}
+
+func TestComposeProd_AppLevelHealthcheck(t *testing.T) {
+	cfg := minimalConfig()
+	cfg.Deploy.HealthcheckPath = "/health"
+
+	compose, err := NewComposeGenerator(cfg).GenerateProd()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	if strings.Contains(compose, "2019/metrics") {
+		t.Error("prod compose healthcheck must not hit the Caddy admin endpoint")
+	}
+	want := fmt.Sprintf("http://localhost:%s/health", AppPort)
+	if !strings.Contains(compose, want) {
+		t.Errorf("prod compose healthcheck should hit the app on %q", want)
+	}
+}
+
+func TestComposeDev_AppLevelHealthcheck(t *testing.T) {
+	compose, err := NewComposeGenerator(minimalConfig()).GenerateDev()
+	if err != nil {
+		t.Fatalf("failed to generate: %v", err)
+	}
+	if strings.Contains(compose, "2019/metrics") {
+		t.Error("dev compose healthcheck must not hit the Caddy admin endpoint")
+	}
+	want := fmt.Sprintf("http://localhost:%s/", AppPort)
+	if !strings.Contains(compose, want) {
+		t.Errorf("dev compose healthcheck should hit the app on %q", want)
+	}
+}

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -86,7 +86,6 @@ func templateFuncs() template.FuncMap {
 			return replacer.Replace(s)
 		},
 		"appPort":     func() string { return AppPort },
-		"metricsPort": func() string { return MetricsPort },
 		"devPort":     func() string { return DevExternalPort },
 		"defaultUID":  func() string { return DefaultUID },
 		"defaultGID":  func() string { return DefaultGID },

--- a/internal/generator/templates/compose-dev.tmpl
+++ b/internal/generator/templates/compose-dev.tmpl
@@ -32,7 +32,7 @@ services:
 {{- end }}
 {{- end }}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{{ metricsPort }}/metrics"]
+      test: ["CMD", "curl", "-f", "http://localhost:{{ appPort }}{{ default "/" .Deploy.HealthcheckPath }}"]
       interval: 10s
       timeout: 5s
       retries: 3

--- a/internal/generator/templates/compose-prod.tmpl
+++ b/internal/generator/templates/compose-prod.tmpl
@@ -29,7 +29,7 @@ services:
 {{- end }}
 {{- end }}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:{{ metricsPort }}/metrics"]
+      test: ["CMD", "curl", "-f", "http://localhost:{{ appPort }}{{ default "/" .Deploy.HealthcheckPath }}"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/internal/generator/templates/dockerfile.tmpl
+++ b/internal/generator/templates/dockerfile.tmpl
@@ -11,7 +11,7 @@ FROM dunglas/frankenphp:{{ default "1" .FrankenPHPVersion }}-php{{ .PHP.Version 
 ###################
 # Node Build Stage
 ###################
-FROM node:20-slim AS node_build
+FROM node:{{ default "22" .Assets.NodeVersion }}-slim AS node_build
 
 WORKDIR /app
 
@@ -28,8 +28,6 @@ RUN {{ .Assets.BuildCommand }}
 FROM frankenphp_upstream AS frankenphp_base
 
 WORKDIR /app
-
-VOLUME /app/var/
 
 # Install system dependencies (netcat-openbsd is used by docker-entrypoint for
 # the database wait loop)
@@ -70,9 +68,6 @@ RUN groupadd --gid ${GID} app && \
     mkdir -p /app/var /data /config && \
     chown -R app:app /app /data /config
 
-# Allow Composer to run as superuser during build only
-ENV COMPOSER_ALLOW_SUPERUSER=1
-
 {{- if .PHP.IniValues }}
 
 # Custom PHP settings
@@ -87,7 +82,9 @@ EOF
 COPY --link --chmod=755 docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 
 ENTRYPOINT ["docker-entrypoint"]
-HEALTHCHECK --start-period=60s CMD curl -f http://localhost:{{ metricsPort }}/metrics || exit 1
+# App-level health probe: proves the application answers, not just that the
+# Caddy process is up
+HEALTHCHECK --start-period=60s CMD curl -f http://localhost:{{ appPort }}{{ default "/" .HealthcheckPath }} || exit 1
 CMD ["frankenphp", "run", "--config", "/etc/caddy/Caddyfile"]
 
 ###################
@@ -103,7 +100,7 @@ RUN mv "$PHP_INI_DIR/php.ini-development" "$PHP_INI_DIR/php.ini"
 # Copy source and install dependencies
 COPY --link . ./
 RUN set -eux; \
-    composer install --no-scripts --no-progress --prefer-dist; \
+    COMPOSER_ALLOW_SUPERUSER=1 composer install --no-scripts --no-progress --prefer-dist; \
     # Build Symfony assets (Sass, AssetMapper)
     if php bin/console list 2>/dev/null | grep -q "sass:build"; then \
         php bin/console sass:build; \
@@ -130,18 +127,33 @@ ENV APP_DEBUG=0
 
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
+# Production PHP settings: OPcache tuned for immutable containers
+# (timestamps never revalidated: the code cannot change without a redeploy)
+COPY <<EOF $PHP_INI_DIR/conf.d/app.prod.ini
+opcache.validate_timestamps = 0
+opcache.memory_consumption = 256
+opcache.max_accelerated_files = 20000
+opcache.interned_strings_buffer = 16
+realpath_cache_size = 4096K
+realpath_cache_ttl = 600
+{{- if .HasPreload }}
+opcache.preload = /app/config/preload.php
+{{- end }}
+EOF
+
 # Copy composer files first for better caching
-COPY --link composer.* symfony.* ./
+COPY --link --chown={{ defaultUID }}:{{ defaultGID }} composer.* symfony.* ./
 
 # Install dependencies (no dev)
 RUN set -eux; \
-    composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
+    COMPOSER_ALLOW_SUPERUSER=1 composer install --no-cache --prefer-dist --no-dev --no-autoloader --no-scripts --no-progress
 
-# Copy application source
-COPY --link . ./
+# Copy application source (chown at copy time: a separate chown -R layer
+# would duplicate every file and double the image size)
+COPY --link --chown={{ defaultUID }}:{{ defaultGID }} . ./
 
 # Generate autoloader (required before running any Symfony commands)
-RUN composer dump-autoload --classmap-authoritative --no-dev
+RUN COMPOSER_ALLOW_SUPERUSER=1 composer dump-autoload --classmap-authoritative --no-dev
 
 # Build assets
 {{- if and .Assets .Assets.BuildTool }}
@@ -152,18 +164,23 @@ RUN set -eux; \
     php bin/console asset-map:compile --no-interaction
 {{- else }}
 # Webpack/Vite: copy pre-built assets from node_build stage
-COPY --from=node_build /app/{{ .Assets.OutputDir }} {{ .Assets.OutputDir }}
+COPY --from=node_build --link --chown={{ defaultUID }}:{{ defaultGID }} /app/{{ .Assets.OutputDir }} {{ .Assets.OutputDir }}
 {{- end }}
 {{- end }}
 
-# Finalize build
+# Finalize build: a failing script or warmup MUST fail the image build —
+# masking it only moves the explosion to the first HTTP request in production
 # Note: We don't use "composer dump-env prod" because env vars are provided at runtime
 # via mounted .env.local or Docker environment variables
 RUN set -eux; \
     mkdir -p var/cache var/log; \
-    composer run-script --no-dev post-install-cmd || true; \
+    if COMPOSER_ALLOW_SUPERUSER=1 composer run-script --list --no-dev | grep -q post-install-cmd; then \
+        COMPOSER_ALLOW_SUPERUSER=1 composer run-script --no-dev post-install-cmd; \
+    fi; \
+    php bin/console cache:clear --no-interaction; \
+    php bin/console cache:warmup --no-interaction; \
     chmod +x bin/console; \
-    chown -R app:app /app; \
+    chown -R app:app var; \
     sync
 
 # SECURITY: Run as non-root user

--- a/internal/generator/validate.go
+++ b/internal/generator/validate.go
@@ -17,6 +17,12 @@ var (
 	// assetOutputDirRegex: relative path, no traversal, safe chars only.
 	// Flows into a Dockerfile COPY line so must be sanitized.
 	assetOutputDirRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._/-]*$`)
+	// nodeVersionRegex: numeric version only (e.g. 22, 22.11). Flows into a
+	// Dockerfile FROM line so must be sanitized.
+	nodeVersionRegex = regexp.MustCompile(`^[0-9]+(\.[0-9]+)*$`)
+	// healthPathRegex: absolute URL path, safe chars only. Flows into the
+	// Dockerfile HEALTHCHECK shell command and compose healthcheck test.
+	healthPathRegex = regexp.MustCompile(`^/[a-zA-Z0-9._/-]*$`)
 )
 
 // dockerfileInstructions are the valid Dockerfile instruction keywords
@@ -83,6 +89,26 @@ func ValidateDockerfileData(data DockerfileData) error {
 		return fmt.Errorf("invalid FrankenPHP version %q: only alphanumeric, dots, underscores, and hyphens allowed", data.FrankenPHPVersion)
 	}
 
+	if data.Assets != nil && data.Assets.NodeVersion != "" && !nodeVersionRegex.MatchString(data.Assets.NodeVersion) {
+		return fmt.Errorf("invalid assets node_version %q: must be numeric (e.g. 22)", data.Assets.NodeVersion)
+	}
+
+	if err := validateHealthcheckPath(data.HealthcheckPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateHealthcheckPath checks that a healthcheck path is a safe absolute
+// URL path (it flows into shell commands in the Dockerfile and compose files).
+func validateHealthcheckPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	if !healthPathRegex.MatchString(path) {
+		return fmt.Errorf("invalid healthcheck_path %q: must start with / and contain only alphanumeric, dots, underscores, slashes, and hyphens", path)
+	}
 	return nil
 }
 
@@ -109,6 +135,10 @@ func ValidateComposeData(data ComposeData) error {
 	}
 	if err := validateEnvKeys(data.Env.Prod); err != nil {
 		return fmt.Errorf("compose data: env.prod: %w", err)
+	}
+
+	if err := validateHealthcheckPath(data.Deploy.HealthcheckPath); err != nil {
+		return fmt.Errorf("compose data: %w", err)
 	}
 
 	return nil

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -458,6 +458,16 @@ func TestIsRetryableConnError(t *testing.T) {
 			err:       fmt.Errorf("ssh: handshake failed: %w", &HostKeyUnknownError{Host: "example.com", Fingerprint: "SHA256:abc"}),
 			retryable: false,
 		},
+		{
+			name:      "unpromptable passphrase is not retryable",
+			err:       errors.New("ssh: handshake failed: key /k is passphrase-protected and no terminal is available to prompt"),
+			retryable: false,
+		},
+		{
+			name:      "wrong passphrase is not retryable",
+			err:       errors.New("ssh: handshake failed: failed to decrypt key /k (wrong passphrase?)"),
+			retryable: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/ssh/client.go
+++ b/internal/ssh/client.go
@@ -181,7 +181,11 @@ func isRetryableConnError(err error) bool {
 	msg := err.Error()
 	if strings.Contains(msg, "unable to authenticate") ||
 		strings.Contains(msg, "permission denied") ||
-		strings.Contains(msg, "no supported methods remain") {
+		strings.Contains(msg, "no supported methods remain") ||
+		// Local credential errors (unpromptable or wrong passphrase) are
+		// deterministic: retrying cannot fix them.
+		strings.Contains(msg, "passphrase-protected") ||
+		strings.Contains(msg, "failed to decrypt key") {
 		return false
 	}
 	return true


### PR DESCRIPTION
## Summary

Implements #48 — the generated production image now follows symfony-docker practices and fails at build time instead of at the first production request.

- **No silenced build failures**: `composer run-script --no-dev post-install-cmd` runs without `|| true` (guarded by `--list` so projects without the script still build), followed by explicit `cache:clear` + `cache:warmup`. A missing extension or misconfigured bundle now fails the image build.
- **`VOLUME /app/var` removed**: it could discard the build-time warmup with the classic builder.
- **Production OPcache tuning** (`app.prod.ini`, prod stage only so dev keeps timestamp validation): `validate_timestamps=0`, `memory_consumption=256`, `max_accelerated_files=20000`, `interned_strings_buffer=16`, realpath cache, and `opcache.preload` when the project ships `config/preload.php`.
- **`COPY --link --chown`** replaces the whole-tree `chown -R app:app /app` RUN layer that duplicated every file into a new layer; only `var/` (written by root during build) is chowned.
- **`node:22-slim`** by default (Node 20 EOL April 2026), configurable via `assets.node_version` (numeric-only validation — flows into a `FROM` line).
- **`COMPOSER_ALLOW_SUPERUSER`** no longer persists as `ENV` in the final image: set inline on build-time composer invocations only.
- **App-level healthcheck**: the image `HEALTHCHECK` and both compose healthchecks probe `http://localhost:8080<healthcheck_path>` instead of the Caddy admin `:2019/metrics` — Docker health now reflects the app answering, which also makes the `env --reload` health wait meaningful. `healthcheck_path` is validated (it flows into shell command lines).
- **ssh (follow-up to #78)**: unpromptable/wrong-passphrase errors are classified as permanent — no more pointless 3-attempt backoff on a deterministic local error.

Docs updated in the same PR (`configuration.md`: `node_version`; `deployment.md`: Docker HEALTHCHECK behavior).

## Test plan

- [x] 17 new unit tests (`hardening_test.go`): no `|| true`, no VOLUME, prod-stage-only OPcache ini, preload detection, chown strategy, node version default/override/injection-rejection, no persistent superuser ENV, app-level healthcheck + path validation, compose dev/prod healthchecks
- [x] 5 existing tests updated to the new expectations, 677 total with `-race`
- [x] golangci-lint v1.64.2 (CI version) clean
- [x] Live on the fresh VPS (remote build, x86_64): image builds with explicit warmup, deploy succeeds, HTTPS 200, `docker inspect`: `health=healthy` (app-level probe), user `1000:1000`, zero `COMPOSER_ALLOW_SUPERUSER` in image env, `opcache.validate_timestamps=0` effective, `var/cache/prod` pre-compiled (`App_KernelProdContainer` present), image 973MB vs 987MB before on a tiny skeleton (bigger gain on real apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)