### PR TITLE
fix(env): chmod 600 on all env writes, unified writer, --from-stdin (#56)

### DIFF
--- a/docs/src/content/docs/guides/environment-variables.md
+++ b/docs/src/content/docs/guides/environment-variables.md
@@ -22,6 +22,18 @@ frankendeploy env set prod MAILER_DSN="smtp://..." --reload
 
 Without `--reload`, changes take effect on the next deployment.
 
+### Secrets: use `--from-stdin`
+
+Passing a secret as `KEY=value` leaves it in your shell history. With `--from-stdin`, the value never touches the history:
+
+```bash
+# Interactive: hidden prompt
+frankendeploy env set prod APP_SECRET --from-stdin
+
+# Scripted: pipe the value
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+```
+
 ## Listing Variables
 
 ```bash
@@ -94,7 +106,9 @@ For Symfony applications, you typically need:
 ## Security Notes
 
 - Variables are stored in `/opt/frankendeploy/apps/<app>/shared/.env.local`
+- Every write (`env set`, `env push`, `env remove`, deploy-generated secrets) enforces `chmod 600` on the file — secrets are never left world-readable
 - The file is mounted read-only into containers
+- Sensitive values are masked in `env list` output and in verbose command logs (same detection list for both)
 - Never commit `.env.prod.backup` files to git
 - Use strong, unique secrets for production
 

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -3,15 +3,19 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/deploy"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+	"golang.org/x/term"
 )
 
 var envCmd = &cobra.Command{
@@ -20,18 +24,27 @@ var envCmd = &cobra.Command{
 	Long:  `Commands to manage environment variables for your application on remote servers.`,
 }
 
-var envSetReload bool
+var (
+	envSetReload    bool
+	envSetFromStdin bool
+)
 
 var envSetCmd = &cobra.Command{
-	Use:   "set <server> <KEY=value>",
+	Use:   "set <server> <KEY=value | KEY --from-stdin>",
 	Short: "Set an environment variable",
 	Long: `Sets an environment variable on the server.
+
+For secrets, prefer --from-stdin: the value never appears in your shell
+history nor in the remote command line. Interactively, the value is asked
+with a hidden prompt; in scripts, it is read from stdin.
 
 Use --reload to apply changes immediately (restarts the container).
 Without --reload, changes take effect on next deployment.
 
 Example:
   frankendeploy env set prod DATABASE_URL="postgresql://user:pass@host/db"
+  frankendeploy env set prod APP_SECRET --from-stdin
+  openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
   frankendeploy env set prod APP_SECRET="my-secret-key" --reload`,
 	Args: cobra.ExactArgs(2),
 	RunE: runEnvSet,
@@ -106,26 +119,18 @@ func init() {
 	envCmd.AddCommand(envPullCmd)
 
 	envSetCmd.Flags().BoolVar(&envSetReload, "reload", false, "Restart container to apply changes immediately")
+	envSetCmd.Flags().BoolVar(&envSetFromStdin, "from-stdin", false, "Read the value from stdin (keeps secrets out of shell history)")
 	envPushCmd.Flags().BoolVar(&envPushReload, "reload", false, "Restart container to apply changes immediately")
 }
 
 func runEnvSet(cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
 	serverName := args[0]
-	keyValue := args[1]
 
-	// Parse KEY=value
-	parts := strings.SplitN(keyValue, "=", 2)
-	if len(parts) != 2 {
-		return fmt.Errorf("invalid format, use KEY=value")
+	key, value, err := resolveEnvSetInput(args[1], envSetFromStdin, os.Stdin)
+	if err != nil {
+		return err
 	}
-	key, value := parts[0], parts[1]
-
-	// Validate environment variable key
-	if err := security.ValidateEnvKey(key); err != nil {
-		return fmt.Errorf("invalid environment variable key: %w", err)
-	}
-	_ = value // Value is not validated as it can contain any content
 
 	conn, err := ConnectToServer(serverName)
 	if err != nil {
@@ -133,36 +138,14 @@ func runEnvSet(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Client.Close()
 
-	envFile := constants.AppEnvFilePath(conn.Project.Name)
-
-	// Ensure directory exists
-	mkdirCmd := fmt.Sprintf("mkdir -p $(dirname %s)", envFile)
-	if _, err := conn.Client.Exec(ctx, mkdirCmd); err != nil {
-		PrintWarning("Could not create directory: %v", err)
-	}
-
-	// Read existing env file
-	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	// Read, update, write through the unified writer (chmod 600 + chown)
+	envVars, err := deploy.ReadEnvVars(ctx, conn.Client, conn.Project.Name)
 	if err != nil {
-		return fmt.Errorf("failed to read env file: %w", err)
+		return err
 	}
-	existingContent := result.Stdout
-
-	// Parse existing variables
-	envVars := parseEnvContent(existingContent)
-
-	// Set/update the variable
 	envVars[key] = value
-
-	// Write back
-	newContent := buildEnvContent(envVars)
-	delim, err := security.GenerateHeredocDelimiter("ENVEOF")
-	if err != nil {
-		return fmt.Errorf("failed to generate delimiter: %w", err)
-	}
-	writeCmd := fmt.Sprintf("cat > %s << '%s'\n%s%s", envFile, delim, newContent, delim)
-	if _, err := conn.Client.Exec(ctx, writeCmd); err != nil {
-		return fmt.Errorf("failed to write env file: %w", err)
+	if err := deploy.WriteEnvVars(ctx, conn.Client, conn.Project.Name, envVars); err != nil {
+		return err
 	}
 
 	PrintSuccess("Set %s on %s", key, serverName)
@@ -202,11 +185,18 @@ func runEnvList(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Environment variables for %s on %s:\n\n", conn.Project.Name, serverName)
 
-	envVars := parseEnvContent(result.Stdout)
-	for key, value := range envVars {
+	envVars := deploy.ParseEnvContent(result.Stdout)
+	keys := make([]string, 0, len(envVars))
+	for key := range envVars {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
+		value := envVars[key]
 		// Mask sensitive values
 		displayValue := value
-		if isSensitiveKey(key) && len(value) > 8 {
+		if security.IsSensitiveEnvKey(key) && len(value) > 8 {
 			displayValue = value[:4] + "****" + value[len(value)-4:]
 		}
 		fmt.Printf("  %s=%s\n", key, displayValue)
@@ -237,7 +227,7 @@ func runEnvGet(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("failed to read env file: %w", err)
 	}
-	envVars := parseEnvContent(result.Stdout)
+	envVars := deploy.ParseEnvContent(result.Stdout)
 
 	if value, ok := envVars[key]; ok {
 		fmt.Println(value)
@@ -264,13 +254,10 @@ func runEnvRemove(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Client.Close()
 
-	envFile := constants.AppEnvFilePath(conn.Project.Name)
-
-	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", envFile))
+	envVars, err := deploy.ReadEnvVars(ctx, conn.Client, conn.Project.Name)
 	if err != nil {
-		return fmt.Errorf("failed to read env file: %w", err)
+		return err
 	}
-	envVars := parseEnvContent(result.Stdout)
 
 	if _, ok := envVars[key]; !ok {
 		return fmt.Errorf("variable %s not found", key)
@@ -278,14 +265,8 @@ func runEnvRemove(cmd *cobra.Command, args []string) error {
 
 	delete(envVars, key)
 
-	newContent := buildEnvContent(envVars)
-	delim, err := security.GenerateHeredocDelimiter("ENVEOF")
-	if err != nil {
-		return fmt.Errorf("failed to generate delimiter: %w", err)
-	}
-	writeCmd := fmt.Sprintf("cat > %s << '%s'\n%s%s", envFile, delim, newContent, delim)
-	if _, err := conn.Client.Exec(ctx, writeCmd); err != nil {
-		return fmt.Errorf("failed to write env file: %w", err)
+	if err := deploy.WriteEnvVars(ctx, conn.Client, conn.Project.Name, envVars); err != nil {
+		return err
 	}
 
 	PrintSuccess("Removed %s from %s", key, serverName)
@@ -328,36 +309,18 @@ func runEnvPush(cmd *cobra.Command, args []string) error {
 	}
 	defer conn.Client.Close()
 
-	envFile := constants.AppEnvFilePath(conn.Project.Name)
-
-	// Ensure directory exists
-	mkdirCmd := fmt.Sprintf("mkdir -p $(dirname %s)", envFile)
-	if _, err := conn.Client.Exec(ctx, mkdirCmd); err != nil {
-		PrintWarning("Could not create directory: %v", err)
-	}
-
-	// Read existing and merge
-	result, err := conn.Client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	// Read existing and merge (new values override existing), then write
+	// through the unified writer (chmod 600 + chown)
+	existingVars, err := deploy.ReadEnvVars(ctx, conn.Client, conn.Project.Name)
 	if err != nil {
-		return fmt.Errorf("failed to read env file: %w", err)
+		return err
 	}
-	existingVars := parseEnvContent(result.Stdout)
-	newVars := parseEnvContent(string(content))
-
-	// Merge (new values override existing)
+	newVars := deploy.ParseEnvContent(string(content))
 	for key, value := range newVars {
 		existingVars[key] = value
 	}
-
-	// Write merged content
-	mergedContent := buildEnvContent(existingVars)
-	delim, err := security.GenerateHeredocDelimiter("ENVEOF")
-	if err != nil {
-		return fmt.Errorf("failed to generate delimiter: %w", err)
-	}
-	writeCmd := fmt.Sprintf("cat > %s << '%s'\n%s%s", envFile, delim, mergedContent, delim)
-	if _, err := conn.Client.Exec(ctx, writeCmd); err != nil {
-		return fmt.Errorf("failed to write env file: %w", err)
+	if err := deploy.WriteEnvVars(ctx, conn.Client, conn.Project.Name, existingVars); err != nil {
+		return err
 	}
 
 	PrintSuccess("Pushed %d variables from %s to %s", len(newVars), localFile, serverName)
@@ -406,42 +369,58 @@ func runEnvPull(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// parseEnvContent parses .env file content into a map
-func parseEnvContent(content string) map[string]string {
-	vars := make(map[string]string)
-	lines := strings.Split(content, "\n")
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+// resolveEnvSetInput turns the `env set` argument into a (key, value) pair.
+// With fromStdin, the argument is the bare key and the value is read from
+// stdin: a hidden prompt on a terminal, raw stdin otherwise — either way the
+// secret stays out of shell history and remote command lines.
+func resolveEnvSetInput(arg string, fromStdin bool, stdin *os.File) (string, string, error) {
+	if !fromStdin {
+		parts := strings.SplitN(arg, "=", 2)
+		if len(parts) != 2 {
+			return "", "", fmt.Errorf("invalid format, use KEY=value (or KEY --from-stdin)")
 		}
-		// Parse KEY=value
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			// Remove quotes if present
-			value = strings.Trim(value, "\"'")
-			vars[key] = value
+		if err := security.ValidateEnvKey(parts[0]); err != nil {
+			return "", "", fmt.Errorf("invalid environment variable key: %w", err)
 		}
+		return parts[0], parts[1], nil
 	}
 
-	return vars
+	if strings.Contains(arg, "=") {
+		return "", "", fmt.Errorf("with --from-stdin, pass the key only (got %q)", arg)
+	}
+	if err := security.ValidateEnvKey(arg); err != nil {
+		return "", "", fmt.Errorf("invalid environment variable key: %w", err)
+	}
+
+	if term.IsTerminal(int(stdin.Fd())) {
+		fmt.Printf("Enter value for %s (input hidden): ", arg)
+		value, err := term.ReadPassword(int(stdin.Fd()))
+		fmt.Println()
+		if err != nil {
+			return "", "", fmt.Errorf("failed to read value: %w", err)
+		}
+		return arg, string(value), nil
+	}
+
+	value, err := readStdinValue(stdin)
+	if err != nil {
+		return "", "", err
+	}
+	return arg, value, nil
 }
 
-// buildEnvContent builds .env file content from a map
-func buildEnvContent(vars map[string]string) string {
-	var lines []string
-	for key, value := range vars {
-		// Quote values with spaces or special characters
-		if strings.ContainsAny(value, " \t\n\"'") {
-			value = fmt.Sprintf("\"%s\"", value)
-		}
-		lines = append(lines, fmt.Sprintf("%s=%s", key, value))
+// readStdinValue reads a piped value from stdin, trimming the trailing
+// newline that `echo` or `openssl rand` append.
+func readStdinValue(r io.Reader) (string, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return "", fmt.Errorf("failed to read value from stdin: %w", err)
 	}
-	return strings.Join(lines, "\n") + "\n"
+	value := strings.TrimRight(string(data), "\r\n")
+	if value == "" {
+		return "", fmt.Errorf("empty value on stdin")
+	}
+	return value, nil
 }
 
 // reloadContainer performs a rolling restart to apply env changes without
@@ -493,19 +472,4 @@ func reloadContainer(ctx context.Context, client ssh.Executor, cfg *config.Proje
 	}
 
 	return nil
-}
-
-// isSensitiveKey checks if a key likely contains sensitive data
-func isSensitiveKey(key string) bool {
-	sensitivePatterns := []string{
-		"SECRET", "PASSWORD", "PASS", "KEY", "TOKEN",
-		"DATABASE_URL", "MAILER_DSN", "API_KEY",
-	}
-	keyUpper := strings.ToUpper(key)
-	for _, pattern := range sensitivePatterns {
-		if strings.Contains(keyUpper, pattern) {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/cmd/env_test.go
+++ b/internal/cmd/env_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+// Tests for issue #56: --from-stdin secret input for env set.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// stdinFrom returns an *os.File whose content is the given string (a real
+// file, so term.IsTerminal reports false — the piped-stdin path).
+func stdinFrom(t *testing.T, content string) *os.File {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "stdin")
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write stdin file: %v", err)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("failed to open stdin file: %v", err)
+	}
+	t.Cleanup(func() { f.Close() })
+	return f
+}
+
+func TestResolveEnvSetInput_KeyValue(t *testing.T) {
+	key, value, err := resolveEnvSetInput("APP_SECRET=abc=def", false, nil)
+	if err != nil {
+		t.Fatalf("resolveEnvSetInput() error = %v", err)
+	}
+	if key != "APP_SECRET" || value != "abc=def" {
+		t.Errorf("got (%q, %q), want (APP_SECRET, abc=def)", key, value)
+	}
+}
+
+func TestResolveEnvSetInput_MissingEquals(t *testing.T) {
+	if _, _, err := resolveEnvSetInput("APP_SECRET", false, nil); err == nil {
+		t.Error("expected error for KEY without =value and without --from-stdin")
+	}
+}
+
+func TestResolveEnvSetInput_InvalidKey(t *testing.T) {
+	if _, _, err := resolveEnvSetInput("BAD-KEY=x", false, nil); err == nil {
+		t.Error("expected error for invalid key")
+	}
+}
+
+func TestResolveEnvSetInput_FromStdin(t *testing.T) {
+	stdin := stdinFrom(t, "s3cret-value\n")
+	key, value, err := resolveEnvSetInput("APP_SECRET", true, stdin)
+	if err != nil {
+		t.Fatalf("resolveEnvSetInput() error = %v", err)
+	}
+	if key != "APP_SECRET" || value != "s3cret-value" {
+		t.Errorf("got (%q, %q), want (APP_SECRET, s3cret-value)", key, value)
+	}
+}
+
+func TestResolveEnvSetInput_FromStdinTrimsTrailingNewlinesOnly(t *testing.T) {
+	stdin := stdinFrom(t, "  spaced value \r\n")
+	_, value, err := resolveEnvSetInput("APP_SECRET", true, stdin)
+	if err != nil {
+		t.Fatalf("resolveEnvSetInput() error = %v", err)
+	}
+	if value != "  spaced value " {
+		t.Errorf("only trailing newlines must be trimmed, got %q", value)
+	}
+}
+
+func TestResolveEnvSetInput_FromStdinRejectsKeyValue(t *testing.T) {
+	stdin := stdinFrom(t, "x\n")
+	if _, _, err := resolveEnvSetInput("APP_SECRET=x", true, stdin); err == nil {
+		t.Error("expected error when --from-stdin is combined with KEY=value")
+	}
+}
+
+func TestResolveEnvSetInput_FromStdinEmptyValue(t *testing.T) {
+	stdin := stdinFrom(t, "\n")
+	_, _, err := resolveEnvSetInput("APP_SECRET", true, stdin)
+	if err == nil || !strings.Contains(err.Error(), "empty") {
+		t.Errorf("expected empty-value error, got: %v", err)
+	}
+}
+
+func TestResolveEnvSetInput_FromStdinInvalidKey(t *testing.T) {
+	stdin := stdinFrom(t, "x\n")
+	if _, _, err := resolveEnvSetInput("BAD KEY", true, stdin); err == nil {
+		t.Error("expected error for invalid key with --from-stdin")
+	}
+}

--- a/internal/deploy/envcheck.go
+++ b/internal/deploy/envcheck.go
@@ -5,12 +5,9 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"sort"
 	"strings"
 
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
-	"github.com/yoanbernabeu/frankendeploy/internal/constants"
-	"github.com/yoanbernabeu/frankendeploy/internal/security"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
 )
 
@@ -45,15 +42,11 @@ func CheckEnvVars(ctx context.Context, client ssh.Executor, cfg *config.ProjectC
 		Generated: make(map[string]string),
 	}
 
-	// Get the env file path
-	envFile := constants.AppEnvFilePath(cfg.Name)
-
 	// Read existing env variables
-	execResult, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	existingVars, err := ReadEnvVars(ctx, client, cfg.Name)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read env file: %w", err)
+		return nil, err
 	}
-	existingVars := parseEnvContent(execResult.Stdout)
 
 	// Get framework requirements (default to Symfony)
 	requirements := FrameworkEnvRequirements["symfony"]
@@ -144,48 +137,16 @@ func SaveGeneratedSecrets(ctx context.Context, client ssh.Executor, appName stri
 		return nil
 	}
 
-	envFile := constants.AppEnvFilePath(appName)
-
-	// Ensure directory exists
-	mkdirCmd := fmt.Sprintf("mkdir -p $(dirname %s)", envFile)
-	if _, err := client.Exec(ctx, mkdirCmd); err != nil {
-		return fmt.Errorf("failed to create directory: %w", err)
-	}
-
-	// Read existing env file
-	result, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	// Read existing env file and merge new secrets
+	existingVars, err := ReadEnvVars(ctx, client, appName)
 	if err != nil {
-		return fmt.Errorf("failed to read env file: %w", err)
+		return err
 	}
-	existingVars := parseEnvContent(result.Stdout)
-
-	// Merge new secrets
 	for key, value := range secrets {
 		existingVars[key] = value
 	}
 
-	// Write back
-	newContent := buildEnvContent(existingVars)
-	delim, err := security.GenerateHeredocDelimiter("ENVEOF")
-	if err != nil {
-		return fmt.Errorf("failed to generate delimiter: %w", err)
-	}
-	writeCmd := fmt.Sprintf("cat > %s << '%s'\n%s%s", envFile, delim, newContent, delim)
-	if _, err := client.Exec(ctx, writeCmd); err != nil {
-		return fmt.Errorf("failed to write env file: %w", err)
-	}
-
-	// Fix permissions for container user
-	if _, err := client.Exec(ctx, fmt.Sprintf("sudo chown %s %s 2>/dev/null || true", constants.ContainerUser, envFile)); err != nil {
-		// Non-critical: permissions may need manual fix
-		_ = err
-	}
-	if _, err := client.Exec(ctx, fmt.Sprintf("sudo chmod 600 %s 2>/dev/null || true", envFile)); err != nil {
-		// Non-critical: permissions may need manual fix
-		_ = err
-	}
-
-	return nil
+	return WriteEnvVars(ctx, client, appName, existingVars)
 }
 
 // FormatEnvCheckError formats an error message with commands to run
@@ -217,48 +178,3 @@ func FormatEnvCheckError(missing []EnvRequirement, serverName string) string {
 	return sb.String()
 }
 
-// parseEnvContent parses .env file content into a map
-func parseEnvContent(content string) map[string]string {
-	vars := make(map[string]string)
-	lines := strings.Split(content, "\n")
-
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		// Skip empty lines and comments
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		// Parse KEY=value
-		parts := strings.SplitN(line, "=", 2)
-		if len(parts) == 2 {
-			key := strings.TrimSpace(parts[0])
-			value := strings.TrimSpace(parts[1])
-			// Remove quotes if present
-			value = strings.Trim(value, "\"'")
-			vars[key] = value
-		}
-	}
-
-	return vars
-}
-
-// buildEnvContent builds .env file content from a map.
-// Keys are sorted alphabetically so repeated writes produce stable diffs.
-func buildEnvContent(vars map[string]string) string {
-	keys := make([]string, 0, len(vars))
-	for k := range vars {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
-	lines := make([]string, 0, len(keys))
-	for _, key := range keys {
-		value := vars[key]
-		// Quote values with spaces or special characters
-		if strings.ContainsAny(value, " \t\n\"'") {
-			value = fmt.Sprintf("\"%s\"", value)
-		}
-		lines = append(lines, fmt.Sprintf("%s=%s", key, value))
-	}
-	return strings.Join(lines, "\n") + "\n"
-}

--- a/internal/deploy/envcheck_test.go
+++ b/internal/deploy/envcheck_test.go
@@ -254,13 +254,13 @@ func TestParseEnvContent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := parseEnvContent(tt.content)
+			result := ParseEnvContent(tt.content)
 			if len(result) != len(tt.expected) {
-				t.Errorf("parseEnvContent() returned %d items, expected %d", len(result), len(tt.expected))
+				t.Errorf("ParseEnvContent() returned %d items, expected %d", len(result), len(tt.expected))
 			}
 			for key, expectedValue := range tt.expected {
 				if result[key] != expectedValue {
-					t.Errorf("parseEnvContent()[%s] = %s, expected %s", key, result[key], expectedValue)
+					t.Errorf("ParseEnvContent()[%s] = %s, expected %s", key, result[key], expectedValue)
 				}
 			}
 		})
@@ -272,15 +272,15 @@ func TestBuildEnvContent(t *testing.T) {
 		"APP_ENV": "prod",
 	}
 
-	result := buildEnvContent(vars)
+	result := BuildEnvContent(vars)
 
 	if !strings.Contains(result, "APP_ENV=prod") {
-		t.Errorf("buildEnvContent() = %s, expected to contain APP_ENV=prod", result)
+		t.Errorf("BuildEnvContent() = %s, expected to contain APP_ENV=prod", result)
 	}
 
 	// Check it ends with newline
 	if !strings.HasSuffix(result, "\n") {
-		t.Error("buildEnvContent() should end with newline")
+		t.Error("BuildEnvContent() should end with newline")
 	}
 }
 
@@ -295,17 +295,17 @@ func TestBuildEnvContent_DeterministicOrdering(t *testing.T) {
 	}
 
 	// Calling buildEnvContent repeatedly must produce the exact same bytes.
-	first := buildEnvContent(vars)
+	first := BuildEnvContent(vars)
 	for i := 0; i < 20; i++ {
-		if got := buildEnvContent(vars); got != first {
-			t.Fatalf("buildEnvContent() is non-deterministic:\nfirst=%q\ngot  =%q", first, got)
+		if got := BuildEnvContent(vars); got != first {
+			t.Fatalf("BuildEnvContent() is non-deterministic:\nfirst=%q\ngot  =%q", first, got)
 		}
 	}
 
 	// Keys must appear in alphabetical order.
 	want := "APP_ENV=prod\nAPP_SECRET=abc\nDATABASE_URL=postgres://u:p@h/db\nZEBRA=z\n"
 	if first != want {
-		t.Errorf("buildEnvContent() = %q, want %q", first, want)
+		t.Errorf("BuildEnvContent() = %q, want %q", first, want)
 	}
 }
 

--- a/internal/deploy/envfile.go
+++ b/internal/deploy/envfile.go
@@ -1,0 +1,110 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/security"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// ParseEnvContent parses .env file content into a map. Double-quoted values
+// are unquoted and unescaped (\" and \\), matching BuildEnvContent output.
+func ParseEnvContent(content string) map[string]string {
+	vars := make(map[string]string)
+
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
+			value = value[1 : len(value)-1]
+			value = strings.ReplaceAll(value, `\"`, `"`)
+			value = strings.ReplaceAll(value, `\\`, `\`)
+		} else {
+			value = strings.Trim(value, "'")
+		}
+		vars[key] = value
+	}
+
+	return vars
+}
+
+// BuildEnvContent builds .env file content from a map. Keys are sorted so the
+// file is stable across writes (clean diffs), and values needing quoting are
+// double-quoted with backslashes and double quotes escaped.
+func BuildEnvContent(vars map[string]string) string {
+	keys := make([]string, 0, len(vars))
+	for key := range vars {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var sb strings.Builder
+	for _, key := range keys {
+		value := vars[key]
+		if strings.ContainsAny(value, " \t\n\"'\\") {
+			value = strings.ReplaceAll(value, `\`, `\\`)
+			value = strings.ReplaceAll(value, `"`, `\"`)
+			value = `"` + value + `"`
+		}
+		fmt.Fprintf(&sb, "%s=%s\n", key, value)
+	}
+	return sb.String()
+}
+
+// ReadEnvVars reads and parses the app's .env.local file on the server.
+// A missing file yields an empty map.
+func ReadEnvVars(ctx context.Context, client ssh.Executor, appName string) (map[string]string, error) {
+	envFile := constants.AppEnvFilePath(appName)
+	result, err := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null || echo ''", envFile))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read env file: %w", err)
+	}
+	return ParseEnvContent(result.Stdout), nil
+}
+
+// WriteEnvVars writes the app's .env.local file on the server. This is the
+// single write path for env files: it creates the directory, writes the
+// sorted content, then enforces container-user ownership and 0600
+// permissions so secrets are never left world-readable.
+func WriteEnvVars(ctx context.Context, client ssh.Executor, appName string, vars map[string]string) error {
+	envFile := constants.AppEnvFilePath(appName)
+
+	if _, err := client.Exec(ctx, fmt.Sprintf("mkdir -p $(dirname %s)", envFile)); err != nil {
+		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	content := BuildEnvContent(vars)
+	delim, err := security.GenerateHeredocDelimiter("ENVEOF")
+	if err != nil {
+		return fmt.Errorf("failed to generate delimiter: %w", err)
+	}
+	writeCmd := fmt.Sprintf("cat > %s << '%s'\n%s%s", envFile, delim, content, delim)
+	if _, err := client.Exec(ctx, writeCmd); err != nil {
+		return fmt.Errorf("failed to write env file: %w", err)
+	}
+
+	// Never leave secrets world-readable: enforce ownership and 0600 on every
+	// write. Failures are non-critical (sudo may be unavailable) — the
+	// deploy-time fixSharedPermissions pass retries the same commands.
+	if _, err := client.Exec(ctx, fmt.Sprintf("sudo chown %s %s 2>/dev/null || true", constants.ContainerUser, envFile)); err != nil {
+		_ = err
+	}
+	if _, err := client.Exec(ctx, fmt.Sprintf("sudo chmod 600 %s 2>/dev/null || true", envFile)); err != nil {
+		_ = err
+	}
+
+	return nil
+}

--- a/internal/deploy/envfile_test.go
+++ b/internal/deploy/envfile_test.go
@@ -1,0 +1,138 @@
+package deploy
+
+// Tests for issue #56: unified env-file writer with strict permissions.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func TestBuildEnvContent_SortedKeys(t *testing.T) {
+	vars := map[string]string{
+		"ZULU":  "1",
+		"ALPHA": "2",
+		"MIKE":  "3",
+	}
+
+	content := BuildEnvContent(vars)
+	alpha := strings.Index(content, "ALPHA=")
+	mike := strings.Index(content, "MIKE=")
+	zulu := strings.Index(content, "ZULU=")
+	if alpha == -1 || mike == -1 || zulu == -1 {
+		t.Fatalf("missing keys in content: %q", content)
+	}
+	if !(alpha < mike && mike < zulu) {
+		t.Errorf("keys must be sorted for stable diffs, got: %q", content)
+	}
+
+	// Deterministic across calls
+	if BuildEnvContent(vars) != content {
+		t.Error("BuildEnvContent must be deterministic")
+	}
+}
+
+func TestBuildEnvContent_EscapesQuotes(t *testing.T) {
+	vars := map[string]string{"MESSAGE": `he said "hello" to me`}
+
+	content := BuildEnvContent(vars)
+	if !strings.Contains(content, `MESSAGE="he said \"hello\" to me"`) {
+		t.Errorf("double quotes must be escaped, got: %q", content)
+	}
+}
+
+func TestBuildEnvContent_EscapesBackslashes(t *testing.T) {
+	vars := map[string]string{"WINPATH": `C:\Users\app "x"`}
+
+	content := BuildEnvContent(vars)
+	if !strings.Contains(content, `WINPATH="C:\\Users\\app \"x\""`) {
+		t.Errorf("backslashes must be escaped inside quoted values, got: %q", content)
+	}
+}
+
+func TestBuildEnvContent_SimpleValueUnquoted(t *testing.T) {
+	content := BuildEnvContent(map[string]string{"APP_ENV": "prod"})
+	if !strings.Contains(content, "APP_ENV=prod\n") {
+		t.Errorf("simple values should stay unquoted, got: %q", content)
+	}
+}
+
+func TestParseEnvContent_RoundTrip(t *testing.T) {
+	original := map[string]string{
+		"SIMPLE":    "value",
+		"SPACED":    "a value with spaces",
+		"QUOTED":    `he said "hello"`,
+		"BACKSLASH": `C:\path with "quote"`,
+		"URL":       "postgresql://user:pass@host:5432/db?serverVersion=16",
+	}
+
+	parsed := ParseEnvContent(BuildEnvContent(original))
+	for key, want := range original {
+		if got, ok := parsed[key]; !ok || got != want {
+			t.Errorf("round trip %s: got %q, want %q", key, parsed[key], want)
+		}
+	}
+}
+
+func TestParseEnvContent_SkipsCommentsAndBlanks(t *testing.T) {
+	content := "# comment\n\nKEY=value\n  # indented comment\nOTHER=x\n"
+	vars := ParseEnvContent(content)
+	if len(vars) != 2 || vars["KEY"] != "value" || vars["OTHER"] != "x" {
+		t.Errorf("unexpected parse result: %v", vars)
+	}
+}
+
+func TestWriteEnvVars_PermissionsAndOwnership(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+
+	err := WriteEnvVars(context.Background(), mock, "myapp", map[string]string{"APP_SECRET": "s3cret"})
+	if err != nil {
+		t.Fatalf("WriteEnvVars() error = %v", err)
+	}
+
+	all := strings.Join(mock.Commands, "\n---\n")
+	if !strings.Contains(all, "mkdir -p") {
+		t.Error("WriteEnvVars should ensure the directory exists")
+	}
+	if !strings.Contains(all, "APP_SECRET=s3cret") {
+		t.Error("WriteEnvVars should write the variables")
+	}
+	if !strings.Contains(all, "chmod 600") {
+		t.Error("WriteEnvVars must chmod 600 the env file: secrets must not be world-readable")
+	}
+	if !strings.Contains(all, "chown") {
+		t.Error("WriteEnvVars should chown the env file for the container user")
+	}
+
+	// chmod must come after the write
+	writeIdx, chmodIdx := -1, -1
+	for i, c := range mock.Commands {
+		if strings.Contains(c, "APP_SECRET") {
+			writeIdx = i
+		}
+		if strings.Contains(c, "chmod 600") {
+			chmodIdx = i
+		}
+	}
+	if chmodIdx < writeIdx {
+		t.Error("chmod 600 must happen after the file write")
+	}
+}
+
+func TestReadEnvVars_ParsesRemoteFile(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			return &ssh.ExecResult{Stdout: "KEY=value\nOTHER=\"a b\"\n", ExitCode: 0}, nil
+		},
+	}
+
+	vars, err := ReadEnvVars(context.Background(), mock, "myapp")
+	if err != nil {
+		t.Fatalf("ReadEnvVars() error = %v", err)
+	}
+	if vars["KEY"] != "value" || vars["OTHER"] != "a b" {
+		t.Errorf("unexpected vars: %v", vars)
+	}
+}

--- a/internal/security/sanitize.go
+++ b/internal/security/sanitize.go
@@ -51,14 +51,31 @@ var (
 	// Allows: alphanumeric, underscores, hyphens, dots, forward slashes (no ..)
 	sharedDirRegex = regexp.MustCompile(`^[a-zA-Z0-9_.-]+(/[a-zA-Z0-9_.-]+)*$`)
 
-	// sensitivePatterns used by SanitizeCommandForLog to mask secrets
-	sensitiveLogPatterns = []string{
-		"DATABASE_URL=",
-		"POSTGRES_PASSWORD=",
-		"MYSQL_PASSWORD=",
-		"MYSQL_ROOT_PASSWORD=",
+	// sensitiveKeyPatterns is the single list of substrings marking an
+	// environment variable key as sensitive. Used both for masking values
+	// in logs (SanitizeCommandForLog) and for masking display output
+	// (env list). Matched case-insensitively on the key.
+	sensitiveKeyPatterns = []string{
+		"SECRET", "PASSWORD", "PASS", "KEY", "TOKEN", "DSN", "DATABASE_URL",
 	}
+
+	// envAssignmentRegex finds KEY=value assignments in a command line so
+	// sensitive values can be masked before logging.
+	envAssignmentRegex = regexp.MustCompile(`([A-Za-z_][A-Za-z0-9_]*)=`)
 )
+
+// IsSensitiveEnvKey reports whether an environment variable key likely
+// holds a secret (matched case-insensitively against the shared pattern
+// list).
+func IsSensitiveEnvKey(key string) bool {
+	keyUpper := strings.ToUpper(key)
+	for _, pattern := range sensitiveKeyPatterns {
+		if strings.Contains(keyUpper, pattern) {
+			return true
+		}
+	}
+	return false
+}
 
 // ValidateAppName validates an application name
 // Application names must be DNS-compatible for Docker container naming
@@ -223,7 +240,7 @@ func ValidateDockerCommand(command string) error {
 
 // ShellEscape escapes a string for safe use in shell commands by wrapping it
 // in single quotes and escaping any internal single quotes using the POSIX
-// pattern: ' → '\''
+// pattern: ' → '\”
 func ShellEscape(s string) string {
 	// Replace single quotes with the POSIX escape sequence: end quote, escaped quote, start quote
 	escaped := strings.ReplaceAll(s, "'", "'\\''")
@@ -290,32 +307,32 @@ func GenerateHeredocDelimiter(prefix string) (string, error) {
 
 // SanitizeCommandForLog masks sensitive values in commands before logging.
 // This prevents secrets from leaking into verbose output or log files.
+// Any KEY=value assignment whose key matches the shared sensitive-key list
+// (IsSensitiveEnvKey) has its value masked.
 func SanitizeCommandForLog(cmd string) string {
-	result := cmd
+	var sb strings.Builder
+	rest := cmd
 
-	// Mask sensitive environment variable values
-	for _, pattern := range sensitiveLogPatterns {
-		searchFrom := 0
-		for {
-			idx := strings.Index(result[searchFrom:], pattern)
-			if idx == -1 {
-				break
-			}
-			absIdx := searchFrom + idx
-			// Find the end of the value (next space or end of string)
-			valueStart := absIdx + len(pattern)
-			valueEnd := findValueEnd(result, valueStart)
-			masked := "****"
-			result = result[:valueStart] + masked + result[valueEnd:]
-			// Advance past the replacement to avoid infinite loop
-			searchFrom = valueStart + len(masked)
+	for {
+		loc := envAssignmentRegex.FindStringSubmatchIndex(rest)
+		if loc == nil {
+			sb.WriteString(rest)
+			break
 		}
+
+		key := rest[loc[2]:loc[3]]
+		sb.WriteString(rest[:loc[1]])
+		valueEnd := findValueEnd(rest, loc[1])
+		if IsSensitiveEnvKey(key) {
+			sb.WriteString("****")
+		} else {
+			sb.WriteString(rest[loc[1]:valueEnd])
+		}
+		rest = rest[valueEnd:]
 	}
 
 	// Mask -p<password> pattern (MySQL password flag)
-	result = maskMySQLPasswordFlag(result)
-
-	return result
+	return maskMySQLPasswordFlag(sb.String())
 }
 
 // findValueEnd finds where a shell value ends (handles quoted and unquoted values)

--- a/internal/security/sensitive_test.go
+++ b/internal/security/sensitive_test.go
@@ -1,0 +1,96 @@
+package security
+
+// Tests for issue #56: single sensitive-key list shared by log masking
+// and display masking.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsSensitiveEnvKey(t *testing.T) {
+	sensitive := []string{
+		"APP_SECRET", "DATABASE_URL", "MAILER_DSN", "MY_API_KEY",
+		"GITHUB_TOKEN", "POSTGRES_PASSWORD", "MYSQL_ROOT_PASSWORD",
+		"SMTP_PASS", "JWT_SECRET_KEY", "SENTRY_DSN", "app_secret",
+	}
+	for _, key := range sensitive {
+		if !IsSensitiveEnvKey(key) {
+			t.Errorf("IsSensitiveEnvKey(%q) = false, want true", key)
+		}
+	}
+
+	notSensitive := []string{"APP_ENV", "APP_DEBUG", "TZ", "LOCALE", "TRUSTED_PROXIES"}
+	for _, key := range notSensitive {
+		if IsSensitiveEnvKey(key) {
+			t.Errorf("IsSensitiveEnvKey(%q) = true, want false", key)
+		}
+	}
+}
+
+func TestSanitizeCommandForLog_MasksAllSensitiveKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		cmd    string
+		hidden string
+		kept   string
+	}{
+		{
+			name:   "DATABASE_URL",
+			cmd:    `docker run -e DATABASE_URL=postgresql://user:hunter2@host/db app`,
+			hidden: "hunter2",
+			kept:   "docker run",
+		},
+		{
+			name:   "MAILER_DSN",
+			cmd:    `docker run -e MAILER_DSN=smtp://user:hunter2@smtp.example.com app`,
+			hidden: "hunter2",
+			kept:   "docker run",
+		},
+		{
+			name:   "custom token",
+			cmd:    `export GITHUB_TOKEN=ghp_supersecret123`,
+			hidden: "ghp_supersecret123",
+			kept:   "export",
+		},
+		{
+			name:   "custom api key",
+			cmd:    `run -e STRIPE_API_KEY="sk_live_secret"`,
+			hidden: "sk_live_secret",
+			kept:   "run",
+		},
+		{
+			name:   "app secret",
+			cmd:    `echo APP_SECRET=abc123 >> .env.local`,
+			hidden: "abc123",
+			kept:   ".env.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SanitizeCommandForLog(tt.cmd)
+			if strings.Contains(got, tt.hidden) {
+				t.Errorf("secret %q leaked in sanitized output: %q", tt.hidden, got)
+			}
+			if !strings.Contains(got, tt.kept) {
+				t.Errorf("non-secret part %q lost in sanitized output: %q", tt.kept, got)
+			}
+		})
+	}
+}
+
+func TestSanitizeCommandForLog_KeepsNonSensitiveValues(t *testing.T) {
+	cmd := `docker run -e APP_ENV=prod -e APP_DEBUG=0 app`
+	got := SanitizeCommandForLog(cmd)
+	if !strings.Contains(got, "APP_ENV=prod") || !strings.Contains(got, "APP_DEBUG=0") {
+		t.Errorf("non-sensitive values must not be masked: %q", got)
+	}
+}
+
+func TestSanitizeCommandForLog_MySQLPasswordFlag(t *testing.T) {
+	got := SanitizeCommandForLog(`mysqldump -phunter2 -u root db`)
+	if strings.Contains(got, "hunter2") {
+		t.Errorf("MySQL -p password leaked: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #56 — secrets on the server are never left world-readable, and never leak into shell history or logs.

- **Unified writer** (`deploy.WriteEnvVars`): the single write path for `.env.local` — mkdir, sorted content, `chown` container user, `chmod 600`. Used by `env set`/`push`/`remove` and deploy-generated secrets. Previously the write logic was duplicated 4 times and 3 of the sites never chmod'ed (file left 644 with server umask).
- **`env set <server> KEY --from-stdin`**: hidden prompt (`term.ReadPassword`) on a terminal, raw stdin in scripts (`openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin`). The secret stays out of local shell history and works with the suggested workflow in the missing-env error.
- **Single sensitive-key list** (`security.IsSensitiveEnvKey`): shared by `env list` display masking and `SanitizeCommandForLog`. Log masking now covers any `KEY=value` whose key matches (previously only 4 hardcoded prefixes — `MAILER_DSN=`, `*_TOKEN=`, `*_API_KEY=` were logged in clear in verbose output).
- **`BuildEnvContent`/`ParseEnvContent`**: keys sorted (stable file, clean diffs), backslashes and double quotes escaped on write and unescaped on read — values containing quotes no longer corrupt `.env.local`. `env list` output is sorted too.

Docs updated in the same PR (`environment-variables.md`: `--from-stdin` section + security notes; CLI reference regenerates via docs CI).

## Test plan

- [x] 27 new unit tests: writer (chmod-after-write ordering, ownership), content build/parse roundtrip incl. quotes and backslashes, sorted determinism, sensitive-key list, log masking (DATABASE_URL, MAILER_DSN, GITHUB_TOKEN, STRIPE_API_KEY, APP_SECRET masked; APP_ENV kept), `--from-stdin` input resolution (piped, trailing-newline trim, empty, invalid key, KEY=value rejection) — 704 total with `-race`
- [x] golangci-lint v1.64.2 (CI version) clean
- [x] Live on the VPS: `env set --from-stdin` piped, quoted value roundtrip via `env get`, file at `600` after set/push/remove, `env list` masked and sorted, `env set --from-stdin --reload` → zero-downtime rolling restart (HTTP 200 throughout, app-level healthcheck from #79) with the new value visible in the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)