### PR TITLE
feat(deploy): automatic database backup before migration hooks (#47)

### DIFF
--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -177,6 +177,31 @@ This warning only appears once per application. Once you add migrations and rede
 
 **Note:** This check only runs when you have a migration hook configured in your `pre_deploy` hooks.
 
+## Automatic Database Backup Before Migrations
+
+With a **managed database** (`database.managed: true`), FrankenDeploy dumps the database automatically before any `pre_deploy` hook containing `doctrine:migrations:migrate`:
+
+- The dump is gzipped and stored on the server in `/opt/frankendeploy/apps/<app>/shared/backups/` (permissions `600`)
+- Retention follows `deploy.keep_releases` (default: 5 backups)
+- A failed backup **aborts the deploy** — use `--force` to deploy without this safety net (not recommended)
+
+Why this matters: migrations run **before** the traffic switch, while the old code still serves requests. If the health check fails after a successful migration, the containers are rolled back but **the database schema is not** — the previous version then runs on the new schema. When that happens, FrankenDeploy tells you explicitly and points to the backup:
+
+```
+⚠️  The database was already migrated during this deploy. Rolling back the code may not be enough...
+⚠️  Database backup taken before the migration: /opt/frankendeploy/apps/demo/shared/backups/pgsql-20260721-120000.sql.gz
+```
+
+Restore example (PostgreSQL):
+
+```bash
+gunzip -c backups/pgsql-<tag>.sql.gz | docker exec -i <app>-db psql -U <user> <db>
+```
+
+**Best practice:** write backward-compatible migrations (expand/contract pattern — add columns before using them, drop them one release later). A code rollback then stays safe even after a migration.
+
+For an **external database** (not managed by FrankenDeploy), no automatic backup is possible — back it up yourself before deploying migrations.
+
 ## Release Management
 
 FrankenDeploy keeps multiple releases for instant rollback:

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -196,20 +196,47 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 6: Run pre-deploy hooks on the NEW container
+	hasMigrationHook := deploy.HasMigrationHook(projectCfg.Deploy.Hooks.PreDeploy)
+	migrationAttempted := false
+	var dbBackupPath string
 	if len(projectCfg.Deploy.Hooks.PreDeploy) > 0 {
+		// Step 6a: Automatic database backup before any migration. Migrations
+		// run while the old code still serves traffic: if anything fails
+		// afterwards, the container rollback does NOT roll the schema back —
+		// the dump is the only safety net.
+		if hasMigrationHook && projectCfg.Database.IsManaged() && databaseURL != "" {
+			PrintInfo("Backing up database before migration...")
+			backupPath, err := deploy.BackupManagedDatabase(ctx, client, projectCfg, databaseURL, deployTag)
+			if err != nil {
+				if !deployForce {
+					PrintWarning("Database backup failed, rolling back...")
+					rollbackNewContainer(ctx, client, state)
+					return fmt.Errorf("database backup failed (use --force to deploy without a backup): %w", err)
+				}
+				PrintWarning("Database backup failed but continuing (--force): %v", err)
+			} else {
+				dbBackupPath = backupPath
+				PrintSuccess("Database backup: %s", backupPath)
+			}
+		}
+
 		PrintInfo("Running pre-deploy hooks...")
 		state.Phase = deploy.PhasePreDeployHooks
+		migrationAttempted = hasMigrationHook
 		if err := runDeployHooks(ctx, client, state.TempContainerName, projectCfg.Deploy.Hooks.PreDeploy); err != nil {
 			if !deployForce {
 				PrintWarning("Pre-deploy hooks failed, rolling back...")
 				rollbackNewContainer(ctx, client, state)
+				if hasMigrationHook {
+					warnDatabaseMigrationRollback("The migration may have been partially applied (non-transactional DDL on MySQL/MariaDB leaves a partial schema).", dbBackupPath)
+				}
 				return fmt.Errorf("pre-deploy hooks failed: %w", err)
 			}
 			PrintWarning("Pre-deploy hooks failed but continuing (--force)")
 		}
 
 		// Check for empty migrations if migration hook was run
-		if deploy.HasMigrationHook(projectCfg.Deploy.Hooks.PreDeploy) {
+		if hasMigrationHook {
 			checkAndWarnMigrationState(ctx, client, state.TempContainerName)
 		}
 	}
@@ -225,6 +252,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 			if !deployForce {
 				PrintWarning("Health check failed, rolling back...")
 				rollbackNewContainer(ctx, client, state)
+				if migrationAttempted {
+					warnDatabaseMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
+				}
 				return fmt.Errorf("deployment failed health check: %w", err)
 			}
 			PrintWarning("Health check failed but continuing (--force)")
@@ -238,6 +268,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	state.Phase = deploy.PhaseSwapContainers
 	if err := swapContainers(ctx, client, projectCfg.Name, remoteAppPath, deployTag, state.TempContainerName, state.OldContainerExists); err != nil {
 		rollbackNewContainer(ctx, client, state)
+		if migrationAttempted {
+			warnDatabaseMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
+		}
 		return fmt.Errorf("swap failed: %w", err)
 	}
 
@@ -606,6 +639,20 @@ func swapContainerNames(ctx context.Context, client ssh.Executor, appName, tempC
 }
 
 // rollbackNewContainer removes the temporary new container, leaving the old one intact.
+// warnDatabaseMigrationRollback tells the user that rolling back the code
+// does not roll back the database schema — the previous version now runs on
+// the new schema, and the pre-migration dump is the only safety net.
+func warnDatabaseMigrationRollback(situation, backupPath string) {
+	PrintWarning("%s Rolling back the code may not be enough: the previous version now runs on the migrated schema.", situation)
+	if backupPath != "" {
+		PrintWarning("Database backup taken before the migration: %s", backupPath)
+		PrintWarning("Restore it if needed, e.g.: gunzip -c <backup> | docker exec -i <app>-db psql -U <user> <db>  (or mysql for MySQL)")
+	} else {
+		PrintWarning("No automatic backup was taken (the database is not managed by FrankenDeploy)")
+	}
+	PrintWarning("Tip: write backward-compatible migrations (expand/contract) so a code rollback stays safe")
+}
+
 func rollbackNewContainer(ctx context.Context, client ssh.Executor, state *deploy.DeployState) {
 	actions := state.RollbackActions()
 	for _, action := range actions {

--- a/internal/deploy/dbbackup.go
+++ b/internal/deploy/dbbackup.go
@@ -1,0 +1,97 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"strings"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/generator"
+	"github.com/yoanbernabeu/frankendeploy/internal/security"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// parseDatabaseURL extracts the credentials from a Symfony DATABASE_URL
+// (scheme://user:password@host:port/dbname?params).
+func parseDatabaseURL(databaseURL string) (user, password, dbName string, err error) {
+	parsed, err := url.Parse(databaseURL)
+	if err != nil {
+		return "", "", "", fmt.Errorf("invalid DATABASE_URL: %w", err)
+	}
+	if parsed.User == nil || parsed.User.Username() == "" {
+		return "", "", "", fmt.Errorf("DATABASE_URL has no user")
+	}
+	dbName = strings.TrimPrefix(parsed.Path, "/")
+	if dbName == "" {
+		return "", "", "", fmt.Errorf("DATABASE_URL has no database name")
+	}
+	password, _ = parsed.User.Password()
+	return parsed.User.Username(), password, dbName, nil
+}
+
+// BackupManagedDatabase dumps the app's managed database container into
+// shared/backups/ before a migration runs. The dump is gzipped, chmod 600,
+// verified non-empty, and old backups are pruned to the keep_releases count.
+// Returns the remote path of the backup file.
+func BackupManagedDatabase(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, databaseURL, tag string) (string, error) {
+	info, err := generator.GetDBDriverInfo(cfg.Database.Driver)
+	if err != nil {
+		return "", fmt.Errorf("unsupported database driver for backup: %s", cfg.Database.Driver)
+	}
+
+	user, password, dbName, err := parseDatabaseURL(databaseURL)
+	if err != nil {
+		return "", err
+	}
+
+	dbContainerName := fmt.Sprintf("%s-db", cfg.Name)
+	backupDir := filepath.Join(constants.AppSharedPath(cfg.Name), "backups")
+	backupPath := filepath.Join(backupDir, fmt.Sprintf("%s-%s.sql.gz", cfg.Database.Driver, tag))
+
+	if _, err := client.Exec(ctx, fmt.Sprintf("mkdir -p %s && chmod 700 %s", backupDir, backupDir)); err != nil {
+		return "", fmt.Errorf("failed to create backup directory: %w", err)
+	}
+
+	dumpCmd := info.BuildDumpCmd(
+		dbContainerName,
+		security.ShellEscape(user),
+		security.ShellEscape(password),
+		security.ShellEscape(dbName),
+	)
+	// pipefail: a failing dump must not be masked by a succeeding gzip
+	fullCmd := fmt.Sprintf("set -o pipefail; %s | gzip > %s", dumpCmd, backupPath)
+	result, err := client.Exec(ctx, fullCmd)
+	if err != nil {
+		return "", fmt.Errorf("database dump failed: %w", err)
+	}
+	if result.ExitCode != 0 {
+		return "", fmt.Errorf("database dump failed: %s", strings.TrimSpace(result.Stderr))
+	}
+
+	// An empty file means the dump silently produced nothing: refuse it
+	// rather than pretend a safety net exists.
+	checkResult, err := client.Exec(ctx, fmt.Sprintf("test -s %s", backupPath))
+	if err != nil || checkResult == nil || checkResult.ExitCode != 0 {
+		return "", fmt.Errorf("database dump produced an empty file at %s", backupPath)
+	}
+
+	if _, err := client.Exec(ctx, fmt.Sprintf("chmod 600 %s", backupPath)); err != nil {
+		return "", fmt.Errorf("failed to set backup permissions: %w", err)
+	}
+
+	// Retention aligned with keep_releases: newest first, delete the rest
+	keep := cfg.Deploy.KeepReleases
+	if keep <= 0 {
+		keep = constants.DefaultKeepReleases
+	}
+	pruneCmd := fmt.Sprintf("ls -1t %s/*.sql.gz 2>/dev/null | tail -n +%d | xargs -r rm -f", backupDir, keep+1)
+	if _, err := client.Exec(ctx, pruneCmd); err != nil {
+		// Non-critical: a failed prune never blocks a deploy
+		_ = err
+	}
+
+	return backupPath, nil
+}

--- a/internal/deploy/dbbackup_test.go
+++ b/internal/deploy/dbbackup_test.go
@@ -1,0 +1,161 @@
+package deploy
+
+// Tests for issue #47: automatic database backup before migration hooks.
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func managedPgConfig() *config.ProjectConfig {
+	managed := true
+	return &config.ProjectConfig{
+		Name: "myapp",
+		Database: config.DatabaseConfig{
+			Driver:  "pgsql",
+			Version: "16",
+			Managed: &managed,
+		},
+		Deploy: config.DeployConfig{KeepReleases: 3},
+	}
+}
+
+const testDatabaseURL = "postgresql://myapp:hex1234@myapp-db:5432/myapp?serverVersion=16&charset=utf8"
+
+func TestParseDatabaseURL(t *testing.T) {
+	user, password, dbName, err := parseDatabaseURL(testDatabaseURL)
+	if err != nil {
+		t.Fatalf("parseDatabaseURL() error = %v", err)
+	}
+	if user != "myapp" || password != "hex1234" || dbName != "myapp" {
+		t.Errorf("got (%q, %q, %q), want (myapp, hex1234, myapp)", user, password, dbName)
+	}
+}
+
+func TestParseDatabaseURL_Underscored(t *testing.T) {
+	_, _, dbName, err := parseDatabaseURL("mysql://my_app:pw@my-app-db:3306/my_app?serverVersion=8.0")
+	if err != nil {
+		t.Fatalf("parseDatabaseURL() error = %v", err)
+	}
+	if dbName != "my_app" {
+		t.Errorf("dbName = %q, want my_app", dbName)
+	}
+}
+
+func TestParseDatabaseURL_Invalid(t *testing.T) {
+	for _, bad := range []string{"", "not-a-url", "postgresql://host/"} {
+		if _, _, _, err := parseDatabaseURL(bad); err == nil {
+			t.Errorf("expected error for %q", bad)
+		}
+	}
+}
+
+func TestBackupManagedDatabase_Success(t *testing.T) {
+	mock := &ssh.MockExecutor{}
+
+	path, err := BackupManagedDatabase(context.Background(), mock, managedPgConfig(), testDatabaseURL, "20260721-120000")
+	if err != nil {
+		t.Fatalf("BackupManagedDatabase() error = %v", err)
+	}
+
+	if !strings.Contains(path, "/opt/frankendeploy/apps/myapp/shared/backups/") {
+		t.Errorf("backup path should live in shared/backups, got %q", path)
+	}
+	if !strings.Contains(path, "20260721-120000") {
+		t.Errorf("backup path should embed the deploy tag, got %q", path)
+	}
+	if !strings.HasSuffix(path, ".sql.gz") {
+		t.Errorf("backup should be gzipped SQL, got %q", path)
+	}
+
+	all := strings.Join(mock.Commands, "\n---\n")
+	if !strings.Contains(all, "mkdir -p") {
+		t.Error("should create the backups directory")
+	}
+	if !strings.Contains(all, "pg_dump") || !strings.Contains(all, "gzip") {
+		t.Errorf("should run pg_dump piped to gzip, commands:\n%s", all)
+	}
+	if !strings.Contains(all, "myapp-db") {
+		t.Error("dump should target the managed DB container")
+	}
+	if !strings.Contains(all, "chmod 600") {
+		t.Error("backup file must be chmod 600 (it contains all the data)")
+	}
+	// Retention: keep_releases=3
+	if !strings.Contains(all, "tail -n +4") {
+		t.Errorf("retention should keep 3 backups (tail -n +4), commands:\n%s", all)
+	}
+}
+
+func TestBackupManagedDatabase_MySQLUsesSingleTransaction(t *testing.T) {
+	managed := true
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		Database: config.DatabaseConfig{
+			Driver:  "mysql",
+			Version: "8.0",
+			Managed: &managed,
+		},
+	}
+
+	mock := &ssh.MockExecutor{}
+	_, err := BackupManagedDatabase(context.Background(), mock, cfg,
+		"mysql://myapp:pw@myapp-db:3306/myapp?serverVersion=8.0&charset=utf8mb4", "tag1")
+	if err != nil {
+		t.Fatalf("BackupManagedDatabase() error = %v", err)
+	}
+
+	all := strings.Join(mock.Commands, "\n")
+	if !strings.Contains(all, "mysqldump") || !strings.Contains(all, "--single-transaction") {
+		t.Errorf("mysql backup should use mysqldump --single-transaction, commands:\n%s", all)
+	}
+}
+
+func TestBackupManagedDatabase_DumpFailure(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "pg_dump") {
+				return &ssh.ExecResult{ExitCode: 1, Stderr: "connection refused"}, nil
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	if _, err := BackupManagedDatabase(context.Background(), mock, managedPgConfig(), testDatabaseURL, "tag1"); err == nil {
+		t.Fatal("expected error when the dump command fails")
+	}
+}
+
+func TestBackupManagedDatabase_EmptyDumpFails(t *testing.T) {
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "test -s") {
+				return &ssh.ExecResult{ExitCode: 1}, nil
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+
+	if _, err := BackupManagedDatabase(context.Background(), mock, managedPgConfig(), testDatabaseURL, "tag1"); err == nil {
+		t.Fatal("expected error when the dump file is empty")
+	}
+}
+
+func TestBackupManagedDatabase_DefaultRetention(t *testing.T) {
+	cfg := managedPgConfig()
+	cfg.Deploy.KeepReleases = 0 // unset → default
+
+	mock := &ssh.MockExecutor{}
+	if _, err := BackupManagedDatabase(context.Background(), mock, cfg, testDatabaseURL, "tag1"); err != nil {
+		t.Fatalf("BackupManagedDatabase() error = %v", err)
+	}
+
+	all := strings.Join(mock.Commands, "\n")
+	if !strings.Contains(all, "tail -n +6") {
+		t.Errorf("default retention should keep %d backups, commands:\n%s", 5, all)
+	}
+}

--- a/internal/deploy/envcheck.go
+++ b/internal/deploy/envcheck.go
@@ -177,4 +177,3 @@ func FormatEnvCheckError(missing []EnvRequirement, serverName string) string {
 
 	return sb.String()
 }
-

--- a/internal/generator/database.go
+++ b/internal/generator/database.go
@@ -21,6 +21,11 @@ type DBDriverInfo struct {
 	// BuildHealthCmd returns a command to check if the database is ready.
 	// Arguments (containerName, user, password) should be pre-escaped for shell safety.
 	BuildHealthCmd func(containerName, user, password string) string
+
+	// BuildDumpCmd returns a command writing a full SQL dump of the database
+	// to stdout (the caller pipes it to gzip and a file).
+	// Arguments (user, password, dbName) should be pre-escaped for shell safety.
+	BuildDumpCmd func(containerName, user, password, dbName string) string
 }
 
 // FullImage returns the Docker image reference with version and optional suffix.
@@ -58,6 +63,12 @@ var dbDriverRegistry = map[string]DBDriverInfo{
 		BuildHealthCmd: func(containerName, user, _ string) string {
 			return fmt.Sprintf("docker exec %s pg_isready -U %s", containerName, user)
 		},
+		// pg_dump runs inside the container over the local socket (trusted),
+		// so no password ever appears on a command line.
+		BuildDumpCmd: func(containerName, user, _, dbName string) string {
+			return fmt.Sprintf("docker exec %s pg_dump -U %s --clean --if-exists %s",
+				containerName, user, dbName)
+		},
 	},
 	"mysql": {
 		DockerImage:    "mysql",
@@ -76,6 +87,12 @@ var dbDriverRegistry = map[string]DBDriverInfo{
 		BuildHealthCmd: func(containerName, user, password string) string {
 			return fmt.Sprintf("docker exec %s mysqladmin ping -u%s -p%s --silent",
 				containerName, user, password)
+		},
+		// --single-transaction gives a consistent snapshot of InnoDB tables
+		// without locking the database while the old code still serves traffic.
+		BuildDumpCmd: func(containerName, user, password, dbName string) string {
+			return fmt.Sprintf("docker exec %s mysqldump -u%s -p%s --single-transaction --routines --triggers %s",
+				containerName, user, password, dbName)
 		},
 	},
 }

--- a/internal/generator/database_dump_test.go
+++ b/internal/generator/database_dump_test.go
@@ -1,0 +1,39 @@
+package generator
+
+// Tests for issue #47: per-driver dump commands in the DB registry.
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildDumpCmd_Postgres(t *testing.T) {
+	info, err := GetDBDriverInfo("pgsql")
+	if err != nil {
+		t.Fatalf("GetDBDriverInfo() error = %v", err)
+	}
+
+	cmd := info.BuildDumpCmd("myapp-db", "'myapp'", "'pw'", "'myapp'")
+	for _, want := range []string{"docker exec", "myapp-db", "pg_dump", "--clean", "--if-exists"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("pgsql dump command missing %q: %s", want, cmd)
+		}
+	}
+	if strings.Contains(cmd, "'pw'") {
+		t.Error("pg_dump inside the container uses the local socket: the password must not appear on the command line")
+	}
+}
+
+func TestBuildDumpCmd_MySQL(t *testing.T) {
+	info, err := GetDBDriverInfo("mysql")
+	if err != nil {
+		t.Fatalf("GetDBDriverInfo() error = %v", err)
+	}
+
+	cmd := info.BuildDumpCmd("myapp-db", "'myapp'", "'pw'", "'myapp'")
+	for _, want := range []string{"docker exec", "myapp-db", "mysqldump", "--single-transaction"} {
+		if !strings.Contains(cmd, want) {
+			t.Errorf("mysql dump command missing %q: %s", want, cmd)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements #47 — the last big safety net of the P1 waves: a migration can no longer silently diverge from the code it belongs to.

- **Automatic backup**: with a managed database, any `pre_deploy` hook containing `doctrine:migrations:migrate` triggers a dump first — `pg_dump --clean --if-exists` (via the container's local socket, no password on any command line) or `mysqldump --single-transaction --routines --triggers`, gzipped into `shared/backups/<driver>-<tag>.sql.gz`, `chmod 600`, verified non-empty (`set -o pipefail` + `test -s`), retention aligned with `keep_releases`.
- **Fail-safe by default**: a failed backup aborts the deploy and rolls back the temp container; `--force` deploys without the safety net.
- **Honest rollback message**: when a rollback happens after the migration ran (health check failure, swap failure, or partially-applied hook), the CLI now says explicitly that the schema was NOT rolled back with the code, prints the backup path, a restore one-liner, and the backward-compatible-migrations (expand/contract) tip.
- **Registry pattern**: per-driver dump commands live in the DB driver registry next to health/env commands (single source of truth).

The issue's side note about `--force` printing "Health check passed" unconditionally was already fixed by #76.

Docs: new "Automatic Database Backup Before Migrations" section in `deployment.md` (restore example + expand/contract best practice).

## Test plan

- [x] 10 new unit tests: dump command shape per driver (no password on the pg command line), backup path/tag/gzip, chmod 600, mkdir, retention math (custom + default `keep_releases`), dump failure, empty-dump refusal, DATABASE_URL parsing — 714 total with `-race`
- [x] golangci-lint v1.64.2 (CI version) clean
- [x] Live on the VPS (managed PostgreSQL 16, real Doctrine migrations):
  - Happy path: backup taken before migration → migration applied → healthy → swap; dump on server is valid gzipped SQL at `600`
  - Failure path: second migration + broken healthcheck path → backup taken, migration applied, health check fails → rollback with the full warning block (schema migrated, backup path, restore hint) while the old app kept serving (HTTP 200 throughout)
  - Retention: successive deploys accumulate pruned, `600`-only backups

🤖 Generated with [Claude Code](https://claude.com/claude-code)