### PR TITLE
feat(deploy): prune old Docker images according to keep_releases (#55)

### DIFF
--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -213,6 +213,8 @@ deploy:
 
 Releases are stored in `/opt/frankendeploy/apps/your-app/releases/`.
 
+`keep_releases` also drives **disk usage**: after each deploy, FrankenDeploy removes the Docker images whose tag left the retention window (an image never in use by a container is the only kind removed), plus the pre-migration database backups beyond the same count. With remote builds, dangling intermediate layers are pruned after each build. Rollback targets and disk retention therefore always match.
+
 View releases:
 ```bash
 frankendeploy app status production

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -311,6 +311,14 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	state.Phase = deploy.PhaseCleanup
 	PrintInfo("Cleaning up old releases...")
 	cleanupOldReleases(ctx, client, remoteAppPath, projectCfg.Deploy.KeepReleases)
+
+	// Prune images whose tag left the retention window: each deploy leaves a
+	// full image behind, and a small VPS fills up after a few dozen deploys
+	if removed, err := deploy.PruneOldImages(ctx, client, projectCfg.Name, remoteAppPath); err != nil {
+		PrintVerbose("Could not prune old images: %v", err)
+	} else if len(removed) > 0 {
+		PrintInfo("Removed %d old image(s): %s", len(removed), strings.Join(removed, ", "))
+	}
 	state.Phase = deploy.PhaseDone
 
 	PrintSuccess("Deployment complete!")
@@ -390,8 +398,9 @@ func transferImage(ctx context.Context, client ssh.Executor, serverCfg *config.S
 		return fmt.Errorf("failed to upload image: %w", err)
 	}
 
-	// Load image on remote
-	result, err := client.Exec(ctx, fmt.Sprintf("docker load -i %s && rm %s", remoteTarPath, remoteTarPath))
+	// Load image on remote. The tar is removed even when the load fails: a
+	// 500MB+ leftover in /tmp on every failed deploy fills the disk silently.
+	result, err := client.Exec(ctx, fmt.Sprintf("docker load -i %s; status=$?; rm -f %s; exit $status", remoteTarPath, remoteTarPath))
 	if err != nil {
 		return fmt.Errorf("failed to load image on server: %w", err)
 	}
@@ -453,6 +462,12 @@ func buildDockerImageRemote(ctx context.Context, client ssh.Executor, imageName,
 	// Cleanup build directory
 	if _, err := client.Exec(ctx, fmt.Sprintf("rm -rf %s", buildPath)); err != nil {
 		PrintVerbose("Could not cleanup build directory: %v", err)
+	}
+
+	// Remote builds leave dangling layers behind (each rebuild orphans the
+	// previous intermediate layers); prune them so they don't pile up
+	if _, err := client.Exec(ctx, "docker image prune -f"); err != nil {
+		PrintVerbose("Could not prune dangling images: %v", err)
 	}
 
 	return nil

--- a/internal/deploy/imageprune.go
+++ b/internal/deploy/imageprune.go
@@ -1,0 +1,59 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// PruneOldImages removes the app's Docker images whose tag no longer matches
+// a kept release directory, keeping the rollback window and the disk usage
+// aligned with keep_releases. Each deploy leaves a full 500MB–1GB image
+// behind: without pruning, a small VPS fills up after a few dozen deploys.
+//
+// Safety rules:
+//   - nothing is removed when the kept-releases list cannot be read or is
+//     empty (an unknown kept set would make every image "old")
+//   - docker rmi is never forced: an image still used by a container (the
+//     running app, a worker on an older tag) survives and is retried on the
+//     next deploy
+//
+// Returns the list of removed tags.
+func PruneOldImages(ctx context.Context, client ssh.Executor, appName, appPath string) ([]string, error) {
+	keptResult, err := client.Exec(ctx, fmt.Sprintf("ls -1 %s/releases 2>/dev/null", appPath))
+	if err != nil || keptResult == nil {
+		return nil, fmt.Errorf("cannot list kept releases: %w", err)
+	}
+	kept := make(map[string]bool)
+	for _, line := range strings.Split(keptResult.Stdout, "\n") {
+		if tag := strings.TrimSpace(line); tag != "" {
+			kept[tag] = true
+		}
+	}
+	if len(kept) == 0 {
+		return nil, nil
+	}
+
+	imagesResult, err := client.Exec(ctx, fmt.Sprintf("docker images %s --format '{{.Tag}}'", appName))
+	if err != nil || imagesResult == nil {
+		return nil, fmt.Errorf("cannot list images: %w", err)
+	}
+
+	var removed []string
+	for _, line := range strings.Split(imagesResult.Stdout, "\n") {
+		tag := strings.TrimSpace(line)
+		if tag == "" || tag == "<none>" || tag == "latest" || kept[tag] {
+			continue
+		}
+		result, err := client.Exec(ctx, fmt.Sprintf("docker rmi %s:%s", appName, tag))
+		if err != nil || result == nil || result.ExitCode != 0 {
+			// In use or transient error: skip, the next deploy retries
+			continue
+		}
+		removed = append(removed, tag)
+	}
+
+	return removed, nil
+}

--- a/internal/deploy/imageprune_test.go
+++ b/internal/deploy/imageprune_test.go
@@ -1,0 +1,161 @@
+package deploy
+
+// Tests for issue #55: prune old Docker images according to keep_releases.
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// pruneMock builds a MockExecutor where `ls releases` returns keptTags and
+// `docker images` returns imageTags.
+func pruneMock(keptTags, imageTags []string) *ssh.MockExecutor {
+	return &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			switch {
+			case strings.Contains(command, "releases"):
+				return &ssh.ExecResult{Stdout: strings.Join(keptTags, "\n") + "\n", ExitCode: 0}, nil
+			case strings.Contains(command, "docker images"):
+				return &ssh.ExecResult{Stdout: strings.Join(imageTags, "\n") + "\n", ExitCode: 0}, nil
+			default:
+				return &ssh.ExecResult{ExitCode: 0}, nil
+			}
+		},
+	}
+}
+
+func rmiCommands(mock *ssh.MockExecutor) []string {
+	var rmis []string
+	for _, cmd := range mock.Commands {
+		if strings.Contains(cmd, "docker rmi") {
+			rmis = append(rmis, cmd)
+		}
+	}
+	return rmis
+}
+
+func TestPruneOldImages_RemovesOnlyUnkeptTags(t *testing.T) {
+	mock := pruneMock(
+		[]string{"tag3", "tag4", "tag5"},
+		[]string{"tag1", "tag2", "tag3", "tag4", "tag5"},
+	)
+
+	removed, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err != nil {
+		t.Fatalf("PruneOldImages() error = %v", err)
+	}
+
+	if len(removed) != 2 {
+		t.Fatalf("removed = %v, want [tag1 tag2]", removed)
+	}
+	rmis := rmiCommands(mock)
+	if len(rmis) != 2 {
+		t.Fatalf("expected 2 docker rmi commands, got %d: %v", len(rmis), rmis)
+	}
+	for _, rmi := range rmis {
+		if !strings.Contains(rmi, "myapp:tag1") && !strings.Contains(rmi, "myapp:tag2") {
+			t.Errorf("unexpected rmi target: %s", rmi)
+		}
+		if strings.Contains(rmi, "tag3") || strings.Contains(rmi, "tag4") || strings.Contains(rmi, "tag5") {
+			t.Errorf("kept tag must never be removed: %s", rmi)
+		}
+		if strings.Contains(rmi, "-f") {
+			t.Errorf("rmi must not force: an image still used by a container must survive: %s", rmi)
+		}
+	}
+}
+
+func TestPruneOldImages_SkipsSpecialTags(t *testing.T) {
+	mock := pruneMock(
+		[]string{"tag2"},
+		[]string{"<none>", "latest", "tag1", "tag2"},
+	)
+
+	removed, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err != nil {
+		t.Fatalf("PruneOldImages() error = %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "tag1" {
+		t.Errorf("removed = %v, want [tag1]", removed)
+	}
+}
+
+func TestPruneOldImages_NothingToRemove(t *testing.T) {
+	mock := pruneMock([]string{"tag1", "tag2"}, []string{"tag1", "tag2"})
+
+	removed, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err != nil {
+		t.Fatalf("PruneOldImages() error = %v", err)
+	}
+	if len(removed) != 0 {
+		t.Errorf("removed = %v, want none", removed)
+	}
+	if len(rmiCommands(mock)) != 0 {
+		t.Error("no rmi command expected")
+	}
+}
+
+func TestPruneOldImages_NoKeptListNoPrune(t *testing.T) {
+	// If the kept-releases list cannot be read, removing anything based on an
+	// empty set would wipe every image — it must be an error instead.
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			if strings.Contains(command, "releases") {
+				return nil, errors.New("connection lost")
+			}
+			return &ssh.ExecResult{Stdout: "tag1\ntag2\n", ExitCode: 0}, nil
+		},
+	}
+
+	_, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err == nil {
+		t.Fatal("expected error when the kept-releases list is unreadable")
+	}
+	if len(rmiCommands(mock)) != 0 {
+		t.Error("must not remove any image when the kept list is unknown")
+	}
+}
+
+func TestPruneOldImages_EmptyKeptListNoPrune(t *testing.T) {
+	// An empty releases dir means we cannot tell what is safe: do not prune.
+	mock := pruneMock([]string{}, []string{"tag1", "tag2"})
+
+	removed, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err != nil {
+		t.Fatalf("PruneOldImages() error = %v", err)
+	}
+	if len(removed) != 0 || len(rmiCommands(mock)) != 0 {
+		t.Errorf("must not prune with an empty kept list, removed = %v", removed)
+	}
+}
+
+func TestPruneOldImages_RmiFailureIsNotFatal(t *testing.T) {
+	// docker rmi fails when a container still uses the image (e.g. a worker
+	// on an old tag): skip it, keep pruning the rest.
+	mock := &ssh.MockExecutor{
+		ExecFunc: func(ctx context.Context, command string) (*ssh.ExecResult, error) {
+			switch {
+			case strings.Contains(command, "releases"):
+				return &ssh.ExecResult{Stdout: "tag3\n", ExitCode: 0}, nil
+			case strings.Contains(command, "docker images"):
+				return &ssh.ExecResult{Stdout: "tag1\ntag2\ntag3\n", ExitCode: 0}, nil
+			case strings.Contains(command, "docker rmi myapp:tag1"):
+				return &ssh.ExecResult{ExitCode: 1, Stderr: "image is being used"}, nil
+			default:
+				return &ssh.ExecResult{ExitCode: 0}, nil
+			}
+		},
+	}
+
+	removed, err := PruneOldImages(context.Background(), mock, "myapp", "/opt/frankendeploy/apps/myapp")
+	if err != nil {
+		t.Fatalf("PruneOldImages() error = %v", err)
+	}
+	if len(removed) != 1 || removed[0] != "tag2" {
+		t.Errorf("removed = %v, want [tag2] (tag1 in use, tag3 kept)", removed)
+	}
+}


### PR DESCRIPTION
## Summary

Implements #55 — each deploy leaves a full 500MB–1GB image behind and nothing ever removed them: on the 20–40GB VPS the pitch targets, that meant disk full after 10–30 deploys with incomprehensible `docker load`/build failures.

- **Image pruning after release cleanup**: images of the app whose tag no longer matches a kept `releases/` directory are removed. `docker rmi` is never forced — an image still used by a container (running app, worker on an older tag) survives and is retried on the next deploy. Rollback targets and disk usage now both follow `keep_releases`.
- **Safety first**: nothing is pruned when the kept-releases list is unreadable or empty — an unknown kept set would make every image look old.
- **`docker image prune -f` after remote builds**: every rebuild orphans the previous intermediate layers; they now get cleaned on the spot.
- **Leftover tar cleanup**: with local builds, the image tar on the server is now removed even when `docker load` fails (previously a 500MB+ file stayed in `/tmp` per failed deploy).

The disk-space preflight suggested as a bonus belongs to `frankendeploy doctor` (#57).

## Test plan

- [x] 6 new unit tests: prune only unkept tags, `<none>`/`latest` skipped, no-op when everything is kept, **no prune on unreadable or empty kept list**, in-use image (rmi failure) skipped without aborting the rest — 720 total with `-race`
- [x] golangci-lint v1.64.2 (CI version) clean
- [x] Live on the VPS: starting state 6 images (~5.9GB) for 5 kept releases → deploy removed exactly the 2 out-of-window images (`Removed 2 old image(s): ...`), leaving a strict 1:1 images↔releases match, 0 dangling layers after the remote build, app serving HTTP 200 throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)