### PR TITLE
feat(generator): opt-in FrankenPHP worker mode with generated app Caddyfile

### DIFF
--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -34,6 +34,14 @@ php:
     - "upload_max_filesize=50M"
     - "post_max_size=50M"
 
+# FrankenPHP Runtime Options (optional)
+frankenphp:
+  # Worker mode: boots the Symfony kernel once and keeps it in memory
+  # between requests (significant latency improvement).
+  # Requires the runtime/frankenphp-symfony composer package.
+  # Auto-enabled by 'frankendeploy init' when the package is detected.
+  worker: true
+
 # Database Configuration (optional)
 database:
   # Driver: pgsql, mysql, or sqlite
@@ -166,6 +174,25 @@ Common extensions:
 - `gd` - Image processing
 - `imagick` - ImageMagick
 - `xdebug` - Debugging (dev only)
+
+### `frankenphp.worker`
+
+FrankenPHP worker mode boots the Symfony kernel **once** and keeps it in memory between requests, removing the per-request bootstrap cost.
+
+```yaml
+frankenphp:
+  worker: true
+```
+
+Requirements and constraints:
+
+- The `runtime/frankenphp-symfony` composer package must be installed (`composer require runtime/frankenphp-symfony`). `frankendeploy build` fails with a clear message if it is missing.
+- **The application must be stateless**: any static property or service state survives between requests. Symfony services are reset automatically, but hand-written static caches are not.
+- Memory leaks surface as automatic worker restarts (FrankenPHP restarts workers hitting their memory limit).
+- `frankendeploy init` enables it automatically (with a warning) when the package is detected. Opt out with `worker: false`.
+- Worker mode applies to **production only** — the dev environment keeps classic mode for easier debugging.
+
+When enabled, `frankendeploy build` generates a `Caddyfile` at the project root that is baked into the production image.
 
 ### `database.driver`
 

--- a/internal/cmd/artifacts.go
+++ b/internal/cmd/artifacts.go
@@ -23,6 +23,10 @@ func ensureDockerArtifacts(cfg *config.ProjectConfig) error {
 		{"docker-entrypoint.sh", func(g *generator.DockerfileGenerator) error { return g.WriteEntrypoint("") }},
 		{".dockerignore", func(g *generator.DockerfileGenerator) error { return g.WriteDockerignore("") }},
 	}
+	if cfg.FrankenPHP.Worker {
+		// Worker mode bakes the generated Caddyfile into the image
+		artifacts = append(artifacts, artifact{"Caddyfile", func(g *generator.DockerfileGenerator) error { return g.WriteCaddyfile("") }})
+	}
 
 	var missing []artifact
 	for _, a := range artifacts {

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -6,6 +6,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/generator"
+	"github.com/yoanbernabeu/frankendeploy/internal/scanner"
 )
 
 var buildCmd = &cobra.Command{
@@ -45,6 +46,14 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("configuration validation failed: %w", errors)
 	}
 
+	// Worker mode requires the FrankenPHP Symfony runtime: without it the
+	// container would crash-loop at boot (APP_RUNTIME points to a missing class)
+	if cfg.FrankenPHP.Worker {
+		if err := checkWorkerRuntime(); err != nil {
+			return err
+		}
+	}
+
 	generateAll := buildAll || (!buildDockerfile && !buildCompose)
 
 	// Generate Dockerfile and entrypoint
@@ -65,6 +74,13 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		PrintSuccess("Generated .dockerignore")
+
+		if cfg.FrankenPHP.Worker {
+			if err := dockerGen.WriteCaddyfile(""); err != nil {
+				return err
+			}
+			PrintSuccess("Generated Caddyfile (FrankenPHP worker mode)")
+		}
 	}
 
 	// Generate compose files
@@ -86,5 +102,20 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	fmt.Println("Next steps:")
 	fmt.Println("  Run 'frankendeploy dev up' to start the development environment")
 
+	return nil
+}
+
+// checkWorkerRuntime verifies that runtime/frankenphp-symfony is present in
+// composer.json before generating worker-mode artifacts.
+func checkWorkerRuntime() error {
+	comp, err := scanner.New(".").ParseComposer()
+	if err != nil {
+		return fmt.Errorf("frankenphp.worker is enabled but composer.json cannot be read: %w", err)
+	}
+	if !comp.HasPackage("runtime/frankenphp-symfony") {
+		return fmt.Errorf("frankenphp.worker is enabled but runtime/frankenphp-symfony is missing from composer.json.\n" +
+			"Install it with: composer require runtime/frankenphp-symfony\n" +
+			"Or disable worker mode: set frankenphp.worker: false in frankendeploy.yaml")
+	}
 	return nil
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,6 +4,7 @@ package config
 type ProjectConfig struct {
 	Name              string           `yaml:"name"`
 	FrankenPHPVersion string           `yaml:"frankenphp_version,omitempty"`
+	FrankenPHP        FrankenPHPConfig `yaml:"frankenphp,omitempty"`
 	PHP               PHPConfig        `yaml:"php"`
 	Database          DatabaseConfig   `yaml:"database,omitempty"`
 	Assets            AssetsConfig     `yaml:"assets,omitempty"`
@@ -12,6 +13,15 @@ type ProjectConfig struct {
 	Dockerfile        DockerfileConfig `yaml:"dockerfile,omitempty"`
 	Deploy            DeployConfig     `yaml:"deploy,omitempty"`
 	Env               EnvConfig        `yaml:"env,omitempty"`
+}
+
+// FrankenPHPConfig holds FrankenPHP runtime options.
+type FrankenPHPConfig struct {
+	// Worker enables FrankenPHP worker mode in production: the Symfony
+	// kernel is booted once and kept in memory between requests.
+	// Requires the runtime/frankenphp-symfony composer package and a
+	// stateless application (no static state shared between requests).
+	Worker bool `yaml:"worker,omitempty"`
 }
 
 // PHPConfig holds PHP-specific configuration
@@ -167,8 +177,11 @@ type ScanResult struct {
 	HasMessenger   bool
 	HasMailer      bool
 	HasAPIPlatform bool
-	Framework      string
-	Warnings       []string
+	// HasFrankenPHPRuntime is true when runtime/frankenphp-symfony is in
+	// composer.json, making the app eligible for FrankenPHP worker mode.
+	HasFrankenPHPRuntime bool
+	Framework            string
+	Warnings             []string
 }
 
 // DefaultProjectConfig returns a default project configuration

--- a/internal/generator/dockerfile.go
+++ b/internal/generator/dockerfile.go
@@ -34,6 +34,9 @@ type DockerfileData struct {
 	// HasPreload enables opcache.preload when the project ships a
 	// config/preload.php
 	HasPreload bool
+	// Worker enables FrankenPHP worker mode: the generated Caddyfile is
+	// copied into the prod stage (dev keeps the image default, classic mode)
+	Worker bool
 }
 
 // Generate generates the Dockerfile content
@@ -45,6 +48,7 @@ func (g *DockerfileGenerator) Generate() (string, error) {
 		FrankenPHPVersion: g.config.FrankenPHPVersion,
 		HealthcheckPath:   g.config.Deploy.HealthcheckPath,
 		HasPreload:        hasPreloadFile(),
+		Worker:            g.config.FrankenPHP.Worker,
 	}
 
 	if g.config.Assets.BuildTool != "" {
@@ -109,6 +113,35 @@ func (g *DockerfileGenerator) WriteDockerignore(path string) error {
 
 	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		return fmt.Errorf("failed to write .dockerignore: %w", err)
+	}
+
+	return nil
+}
+
+// CaddyfileData holds data for the app Caddyfile template (worker mode).
+type CaddyfileData struct {
+	Name string
+}
+
+// GenerateCaddyfile generates the app-level Caddyfile enabling FrankenPHP
+// worker mode. Only relevant when config frankenphp.worker is true.
+func (g *DockerfileGenerator) GenerateCaddyfile() (string, error) {
+	return g.loader.Execute("caddyfile.tmpl", CaddyfileData{Name: g.config.Name})
+}
+
+// WriteCaddyfile writes the app Caddyfile to the specified path.
+func (g *DockerfileGenerator) WriteCaddyfile(path string) error {
+	if path == "" {
+		path = "Caddyfile"
+	}
+
+	content, err := g.GenerateCaddyfile()
+	if err != nil {
+		return fmt.Errorf("failed to generate Caddyfile: %w", err)
+	}
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return fmt.Errorf("failed to write Caddyfile: %w", err)
 	}
 
 	return nil

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1479,3 +1479,69 @@ func TestDefaultEntrypointData(t *testing.T) {
 		t.Errorf("expected DBWaitInterval=%d, got %d", DefaultDBWaitInterval, data.DBWaitInterval)
 	}
 }
+
+func TestDockerfileGenerator_WorkerMode_CopiesCaddyfile(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP:  config.PHPConfig{Version: "8.3"},
+	}
+	cfg.FrankenPHP.Worker = true
+
+	gen := NewDockerfileGenerator(cfg)
+	out, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if !strings.Contains(out, "COPY --link Caddyfile /etc/caddy/Caddyfile") {
+		t.Errorf("worker mode must copy the generated Caddyfile into the image:\n%s", out)
+	}
+	// The copy must live in the prod stage, after the frankenphp_prod FROM line
+	prodIdx := strings.Index(out, "AS frankenphp_prod")
+	copyIdx := strings.Index(out, "COPY --link Caddyfile /etc/caddy/Caddyfile")
+	if copyIdx < prodIdx {
+		t.Error("Caddyfile copy must be in the prod stage (dev keeps classic mode)")
+	}
+}
+
+func TestDockerfileGenerator_ClassicMode_NoCaddyfileCopy(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP:  config.PHPConfig{Version: "8.3"},
+	}
+
+	gen := NewDockerfileGenerator(cfg)
+	out, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(out, "COPY --link Caddyfile") {
+		t.Errorf("classic mode must rely on the image default Caddyfile:\n%s", out)
+	}
+}
+
+func TestGenerateCaddyfile_WorkerBlock(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP:  config.PHPConfig{Version: "8.3"},
+	}
+	cfg.FrankenPHP.Worker = true
+
+	gen := NewDockerfileGenerator(cfg)
+	out, err := gen.GenerateCaddyfile()
+	if err != nil {
+		t.Fatalf("GenerateCaddyfile: %v", err)
+	}
+	for _, want := range []string{
+		"worker {",
+		"file ./public/index.php",
+		`env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime`,
+		"{$SERVER_NAME:localhost}",
+		"php_server",
+		"{$FRANKENPHP_CONFIG}",
+		"encode zstd br gzip",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("generated Caddyfile missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/internal/generator/templates/caddyfile.tmpl
+++ b/internal/generator/templates/caddyfile.tmpl
@@ -1,0 +1,31 @@
+# FrankenDeploy - FrankenPHP Caddyfile for {{ .Name }}
+# Worker mode: the Symfony kernel is booted once and kept in memory between
+# requests. The application MUST be stateless (no static state surviving a
+# request); memory leaks surface as automatic worker restarts.
+# https://frankenphp.dev/docs/worker/
+
+{
+	skip_install_trust
+
+	{$CADDY_GLOBAL_OPTIONS}
+
+	frankenphp {
+		worker {
+			file ./public/index.php
+			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+		}
+
+		{$FRANKENPHP_CONFIG}
+	}
+}
+
+{$CADDY_EXTRA_CONFIG}
+
+{$SERVER_NAME:localhost} {
+	root {$SERVER_ROOT:public/}
+	encode zstd br gzip
+
+	{$CADDY_SERVER_EXTRA_DIRECTIVES}
+
+	php_server
+}

--- a/internal/generator/templates/dockerfile.tmpl
+++ b/internal/generator/templates/dockerfile.tmpl
@@ -151,6 +151,13 @@ RUN set -eux; \
 # Copy application source (chown at copy time: a separate chown -R layer
 # would duplicate every file and double the image size)
 COPY --link --chown={{ defaultUID }}:{{ defaultGID }} . ./
+{{- if .Worker }}
+
+# FrankenPHP worker mode: replace the image default Caddyfile with the
+# generated one (worker block booting the Symfony kernel once).
+# Dev stage keeps the image default (classic mode) for easier debugging.
+COPY --link Caddyfile /etc/caddy/Caddyfile
+{{- end }}
 
 # Generate autoloader (required before running any Symfony commands)
 RUN COMPOSER_ALLOW_SUPERUSER=1 composer dump-autoload --classmap-authoritative --no-dev

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -66,6 +66,15 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	// api-platform/core (v2/v3) or api-platform/symfony (v4 split packages)
 	result.HasAPIPlatform = composer.HasAnyPackage("api-platform/core", "api-platform/symfony")
 
+	// FrankenPHP worker mode eligibility (runtime/frankenphp-symfony)
+	result.HasFrankenPHPRuntime = composer.HasPackage("runtime/frankenphp-symfony")
+	if result.HasFrankenPHPRuntime {
+		result.Warnings = append(result.Warnings,
+			"runtime/frankenphp-symfony detected: enabling FrankenPHP worker mode (frankenphp.worker: true in frankendeploy.yaml). "+
+				"Worker mode keeps the Symfony kernel in memory between requests — the app must be stateless. "+
+				"Set frankenphp.worker: false to opt out")
+	}
+
 	// Add required extensions based on detected features
 	result.PHPExtensions = s.enhanceExtensions(result.PHPExtensions, result)
 
@@ -179,6 +188,12 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 	// would fail the deploy health check: default to the API entrypoint.
 	if result.HasAPIPlatform {
 		cfg.Deploy.HealthcheckPath = "/api"
+	}
+
+	// Enable FrankenPHP worker mode when the app ships the runtime package
+	// (announced via a scanner warning — never silent)
+	if result.HasFrankenPHPRuntime {
+		cfg.FrankenPHP.Worker = true
 	}
 
 	// For SQLite, add the database directory to shared_dirs for persistence

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -212,3 +212,67 @@ EMPTY_VALUE=
 		})
 	}
 }
+
+func TestScan_FrankenPHPRuntime_EnablesWorker(t *testing.T) {
+	tempDir := t.TempDir()
+	composer := `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1",
+			"runtime/frankenphp-symfony": "^0.2"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tempDir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(tempDir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !result.HasFrankenPHPRuntime {
+		t.Error("expected HasFrankenPHPRuntime to be true")
+	}
+
+	cfg := s.ToProjectConfig(result, "myapp")
+	if !cfg.FrankenPHP.Worker {
+		t.Error("expected FrankenPHP.Worker to be enabled when runtime/frankenphp-symfony is present")
+	}
+
+	foundWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "worker") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected a warning announcing worker mode, got: %v", result.Warnings)
+	}
+}
+
+func TestScan_NoFrankenPHPRuntime_WorkerDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	composer := `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tempDir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(tempDir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.HasFrankenPHPRuntime {
+		t.Error("expected HasFrankenPHPRuntime to be false")
+	}
+	cfg := s.ToProjectConfig(result, "myapp")
+	if cfg.FrankenPHP.Worker {
+		t.Error("worker mode must stay opt-in without the runtime package")
+	}
+}


### PR DESCRIPTION
## Summary

Adds opt-in FrankenPHP worker mode — the #1 FrankenPHP selling point. When `frankenphp.worker: true`, `build` generates an app-level `Caddyfile` (worker block booting the Symfony kernel once) baked into the production image. Classic mode is strictly untouched: without the option, no Caddyfile is generated and the image default applies.

## Changes

- **Config**: new `frankenphp.worker` block in `frankendeploy.yaml` (extensible later: `num_threads`…)
- **Template** `caddyfile.tmpl`: modeled on the `dunglas/frankenphp` image default (`{$SERVER_NAME}`, `{$FRANKENPHP_CONFIG}` env parametrization preserved), plus `worker { file ./public/index.php; env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime }`
- **Dockerfile**: conditional `COPY --link Caddyfile /etc/caddy/Caddyfile` in the **prod stage only** — dev keeps classic mode for debugging
- **Scanner**: detects `runtime/frankenphp-symfony` → enables worker at `init` with an explicit warning (transparency principle, opt-out documented)
- **Guard rail**: `build` fails with an actionable message if worker is enabled without the runtime package (would otherwise crash-loop at boot: `APP_RUNTIME` pointing to a missing class)
- **Self-sufficient deploy**: `ensureDockerArtifacts` regenerates the Caddyfile when missing
- **Docs**: `frankenphp.worker` reference — stateless constraint, memory-leak behavior (worker restarts), prod-only scope

## Test Plan

- TDD: 5 new tests (scanner detection + warning + opt-in default, Dockerfile conditional copy both ways, Caddyfile content)
- `make pre-commit` green (fmt, vet, lint, race tests)
- **Live validation on the test VPS**: demo app with `runtime/frankenphp-symfony`; `init` announces and enables worker; `build` generates the Caddyfile; blue-green deploy green; **worker mode proven live**: a static request counter increments across requests (3→4→5) — the kernel stays in memory. Negative path validated: `build` with worker enabled but no runtime package fails with the actionable message.

## Related Issue

Closes #58

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g6xzbLBxeu81U1LYNbg3P