### PR TITLE
feat(scanner): smarter detection — .env.local, MariaDB, extensions, Tailwind, Messenger, scheduler

### DIFF
--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -200,7 +200,12 @@ When enabled, `frankendeploy build` generates a `Caddyfile` at the project root 
 |--------|-------------|
 | `pgsql` | postgres:VERSION-alpine |
 | `mysql` | mysql:VERSION |
+| `mariadb` | mariadb:VERSION |
 | `sqlite` | No container needed |
+
+MariaDB is auto-detected from `DATABASE_URL` (a `mariadb://` scheme or a `serverVersion` ending in `-MariaDB`). The generated `DATABASE_URL` uses the `mysql://` scheme with the `-MariaDB` serverVersion suffix, as Doctrine expects.
+
+The scanner reads `DATABASE_URL` from `.env` **and** `.env.local` (the latter wins, matching Symfony's runtime behavior), and warns when the two files disagree on the driver.
 
 ### `database.path`
 
@@ -244,6 +249,8 @@ messenger:
 
 When enabled, FrankenDeploy deploys a separate container (`<app>-worker`) running `messenger:consume`.
 
+`frankendeploy init` fills `transports` from the transports actually configured in `config/packages/messenger.yaml` (resolving `%env()%` DSNs through `.env`/`.env.local`). The failure transport and `sync://` transports are excluded. With `symfony/scheduler` installed, `scheduler_default` is added so scheduled tasks actually run in production. An `amqp://` or `redis://` transport DSN also adds the matching PHP extension, and `pcntl` is always added with Messenger for graceful worker shutdown — every inference is announced at `init`.
+
 ### `dockerfile`
 
 Customize the generated Dockerfile:
@@ -255,6 +262,16 @@ dockerfile:
     - ffmpeg
   extra_commands:     # Raw Dockerfile instructions
     - "RUN pecl install redis && docker-php-ext-enable redis"
+```
+
+### `assets.tailwind`
+
+With `symfonycasts/tailwind-bundle` (AssetMapper), `tailwind:build --minify` must run **before** `asset-map:compile` — otherwise the site deploys without CSS. The scanner detects the bundle and sets `tailwind: true` automatically (announced at `init`).
+
+```yaml
+assets:
+  build_tool: assetmapper
+  tailwind: true
 ```
 
 ### `assets.build_tool`

--- a/internal/cmd/connect.go
+++ b/internal/cmd/connect.go
@@ -43,6 +43,11 @@ func connectToServerInternal(serverName string, loadProject bool, opts ...ssh.Cl
 		if err != nil {
 			return nil, fmt.Errorf("failed to load project config: %w", err)
 		}
+		// A hand-edited invalid frankendeploy.yaml must fail here, not
+		// flow into the generator or the deployment
+		if errs := config.ValidateProjectConfig(projectCfg); errs.HasErrors() {
+			return nil, fmt.Errorf("invalid frankendeploy.yaml: %w", errs)
+		}
 	}
 
 	globalCfg, err := config.LoadGlobalConfig()

--- a/internal/config/global.go
+++ b/internal/config/global.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -35,7 +36,13 @@ func LoadGlobalConfig() (*GlobalConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	return LoadGlobalConfigFromPath(path)
+}
 
+// LoadGlobalConfigFromPath loads the global configuration from an explicit
+// path. Unknown fields are rejected (a typo in a server entry must fail
+// loudly, like the project config).
+func LoadGlobalConfigFromPath(path string) (*GlobalConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -45,7 +52,9 @@ func LoadGlobalConfig() (*GlobalConfig, error) {
 	}
 
 	var config GlobalConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(data))
+	decoder.KnownFields(true)
+	if err := decoder.Decode(&config); err != nil {
 		return nil, fmt.Errorf("failed to parse global config: %w", err)
 	}
 

--- a/internal/config/global_test.go
+++ b/internal/config/global_test.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadGlobalConfig_RejectsUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "servers:\n  prod:\n    host: example.com\n    usre: typo\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadGlobalConfigFromPath(path); err == nil {
+		t.Error("a typoed field in the global config must be rejected (KnownFields), not silently ignored")
+	}
+}
+
+func TestLoadGlobalConfig_ValidFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "servers:\n  prod:\n    host: example.com\n    user: deploy\n    port: 22\n"
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadGlobalConfigFromPath(path)
+	if err != nil {
+		t.Fatalf("LoadGlobalConfigFromPath: %v", err)
+	}
+	if cfg.Servers["prod"].Host != "example.com" {
+		t.Errorf("unexpected host: %+v", cfg.Servers["prod"])
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -134,8 +134,10 @@ func NormalizeDBDriver(driver string) string {
 	switch strings.ToLower(driver) {
 	case "pdo_pgsql", "postgresql", "postgres", "pgsql":
 		return "pgsql"
-	case "pdo_mysql", "mysqli", "mysql":
+	case "pdo_mysql", "mysqli", "mysql", "mysql2":
 		return "mysql"
+	case "mariadb":
+		return "mariadb"
 	case "pdo_sqlite", "sqlite3", "sqlite":
 		return "sqlite"
 	default:

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -59,6 +59,10 @@ type AssetsConfig struct {
 	// NodeVersion is the Node.js major version for the asset build stage
 	// (default: 22)
 	NodeVersion string `yaml:"node_version,omitempty"`
+	// Tailwind: with symfonycasts/tailwind-bundle (AssetMapper),
+	// tailwind:build must run before asset-map:compile or the site
+	// deploys without CSS.
+	Tailwind bool `yaml:"tailwind,omitempty"`
 }
 
 // MessengerConfig holds Symfony Messenger worker configuration.
@@ -180,8 +184,15 @@ type ScanResult struct {
 	// HasFrankenPHPRuntime is true when runtime/frankenphp-symfony is in
 	// composer.json, making the app eligible for FrankenPHP worker mode.
 	HasFrankenPHPRuntime bool
-	Framework            string
-	Warnings             []string
+	// HasScheduler is true when symfony/scheduler is installed: its
+	// scheduler_* transports must be consumed or scheduled tasks
+	// silently never run.
+	HasScheduler bool
+	// MessengerTransports are the transports to consume, read from
+	// messenger.yaml (failure and sync transports excluded).
+	MessengerTransports []string
+	Framework           string
+	Warnings            []string
 }
 
 // DefaultProjectConfig returns a default project configuration

--- a/internal/config/validation.go
+++ b/internal/config/validation.go
@@ -233,7 +233,7 @@ func isValidPHPVersion(version string) bool {
 }
 
 func isValidDatabaseDriver(driver string) bool {
-	validDrivers := []string{"pgsql", "mysql", "sqlite", "pdo_pgsql", "pdo_mysql", "pdo_sqlite"}
+	validDrivers := []string{"pgsql", "mysql", "mariadb", "sqlite", "pdo_pgsql", "pdo_mysql", "pdo_sqlite"}
 	for _, d := range validDrivers {
 		if driver == d {
 			return true

--- a/internal/generator/database.go
+++ b/internal/generator/database.go
@@ -13,6 +13,9 @@ type DBDriverInfo struct {
 	HealthcheckCmd []string
 	DataVolumePath string
 	PHPExtension   string
+	// ServerVersionSuffix is appended to the version in the Doctrine
+	// DATABASE_URL serverVersion parameter (e.g. "-MariaDB").
+	ServerVersionSuffix string
 
 	// BuildEnvArgs returns Docker env flags (-e ...) for the database container.
 	// Arguments (user, password, dbName) should be pre-escaped for shell safety.
@@ -41,8 +44,8 @@ func (d DBDriverInfo) BuildDatabaseURL(user, password, host, dbName, version str
 	if version == "" {
 		version = d.DefaultVersion
 	}
-	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?serverVersion=%s&charset=%s",
-		d.URLScheme, user, password, host, d.Port, dbName, version, d.URLCharset)
+	return fmt.Sprintf("%s://%s:%s@%s:%s/%s?serverVersion=%s%s&charset=%s",
+		d.URLScheme, user, password, host, d.Port, dbName, version, d.ServerVersionSuffix, d.URLCharset)
 }
 
 var dbDriverRegistry = map[string]DBDriverInfo{
@@ -92,6 +95,32 @@ var dbDriverRegistry = map[string]DBDriverInfo{
 		// without locking the database while the old code still serves traffic.
 		BuildDumpCmd: func(containerName, user, password, dbName string) string {
 			return fmt.Sprintf("docker exec %s mysqldump -u%s -p%s --single-transaction --routines --triggers %s",
+				containerName, user, password, dbName)
+		},
+	},
+	"mariadb": {
+		DockerImage:    "mariadb",
+		DefaultVersion: "11",
+		ImageSuffix:    "",
+		Port:           MySQLPort,
+		// Doctrine reaches MariaDB through the mysql driver; the
+		// -MariaDB serverVersion suffix tells it which SQL dialect to use
+		URLScheme:           "mysql",
+		URLCharset:          "utf8mb4",
+		ServerVersionSuffix: "-MariaDB",
+		// healthcheck.sh ships with the official mariadb image
+		HealthcheckCmd: []string{"CMD", "healthcheck.sh", "--connect", "--innodb_initialized"},
+		DataVolumePath: "/var/lib/mysql",
+		PHPExtension:   "pdo_mysql",
+		BuildEnvArgs: func(user, password, dbName string) string {
+			return fmt.Sprintf("-e MARIADB_ROOT_PASSWORD=%s -e MARIADB_USER=%s -e MARIADB_PASSWORD=%s -e MARIADB_DATABASE=%s",
+				password, user, password, dbName)
+		},
+		BuildHealthCmd: func(containerName, _, _ string) string {
+			return fmt.Sprintf("docker exec %s healthcheck.sh --connect --innodb_initialized", containerName)
+		},
+		BuildDumpCmd: func(containerName, user, password, dbName string) string {
+			return fmt.Sprintf("docker exec %s mariadb-dump -u%s -p%s --single-transaction --routines --triggers %s",
 				containerName, user, password, dbName)
 		},
 	},

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1545,3 +1545,92 @@ func TestGenerateCaddyfile_WorkerBlock(t *testing.T) {
 		}
 	}
 }
+
+// --- Issue #59: MariaDB + Tailwind support ---
+
+func TestGetDBDriverInfo_MariaDB(t *testing.T) {
+	info, err := GetDBDriverInfo("mariadb")
+	if err != nil {
+		t.Fatalf("GetDBDriverInfo: %v", err)
+	}
+	if info.DockerImage != "mariadb" {
+		t.Errorf("expected mariadb image, got %q", info.DockerImage)
+	}
+	if img := info.FullImage("10.11"); img != "mariadb:10.11" {
+		t.Errorf("expected mariadb:10.11, got %q", img)
+	}
+	url := info.BuildDatabaseURL("u", "p", "h", "db", "10.11")
+	if !strings.Contains(url, "serverVersion=10.11-MariaDB") {
+		t.Errorf("Doctrine needs the -MariaDB serverVersion suffix, got %q", url)
+	}
+	if !strings.HasPrefix(url, "mysql://") {
+		t.Errorf("MariaDB uses the mysql:// scheme, got %q", url)
+	}
+	dump := info.BuildDumpCmd("c", "u", "p", "db")
+	if !strings.Contains(dump, "mariadb-dump") {
+		t.Errorf("expected mariadb-dump, got %q", dump)
+	}
+}
+
+func TestComposeProd_MariaDB(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP:  config.PHPConfig{Version: "8.3"},
+	}
+	managed := true
+	cfg.Database = config.DatabaseConfig{Driver: "mariadb", Version: "10.11", Managed: &managed}
+
+	gen := NewComposeGenerator(cfg)
+	out, err := gen.GenerateProd()
+	if err != nil {
+		t.Fatalf("GenerateProd: %v", err)
+	}
+	if !strings.Contains(out, "image: mariadb:10.11") {
+		t.Errorf("expected mariadb image (mysql:10.11.2 does not exist), got:\n%s", out)
+	}
+	if !strings.Contains(out, "MARIADB_RANDOM_ROOT_PASSWORD") {
+		t.Errorf("root password must be randomized like mysql, got:\n%s", out)
+	}
+	if !strings.Contains(out, "healthcheck.sh") {
+		t.Errorf("expected official mariadb healthcheck script, got:\n%s", out)
+	}
+}
+
+func TestDockerfile_TailwindBuildBeforeAssetMapCompile(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name:   "myapp",
+		PHP:    config.PHPConfig{Version: "8.3"},
+		Assets: config.AssetsConfig{BuildTool: "assetmapper", OutputDir: "public/assets", Tailwind: true},
+	}
+
+	gen := NewDockerfileGenerator(cfg)
+	out, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	twIdx := strings.Index(out, "php bin/console tailwind:build")
+	compileIdx := strings.Index(out, "php bin/console asset-map:compile")
+	if twIdx == -1 {
+		t.Fatalf("expected tailwind:build in Dockerfile (site deploys without CSS otherwise):\n%s", out)
+	}
+	if compileIdx == -1 || twIdx > compileIdx {
+		t.Error("tailwind:build must run before asset-map:compile")
+	}
+}
+
+func TestDockerfile_NoTailwindWithoutBundle(t *testing.T) {
+	cfg := &config.ProjectConfig{
+		Name:   "myapp",
+		PHP:    config.PHPConfig{Version: "8.3"},
+		Assets: config.AssetsConfig{BuildTool: "assetmapper", OutputDir: "public/assets"},
+	}
+
+	gen := NewDockerfileGenerator(cfg)
+	out, err := gen.Generate()
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(out, "tailwind:build") {
+		t.Errorf("tailwind:build must not appear without the bundle:\n%s", out)
+	}
+}

--- a/internal/generator/templates/compose-dev.tmpl
+++ b/internal/generator/templates/compose-dev.tmpl
@@ -44,7 +44,7 @@ services:
       options:
         max-size: "{{ logMaxSize }}"
         max-file: "{{ logMaxFile }}"
-{{- if or (eq .Database.Driver "pgsql") (eq .Database.Driver "mysql") }}
+{{- if or (eq .Database.Driver "pgsql") (eq .Database.Driver "mysql") (eq .Database.Driver "mariadb") }}
     depends_on:
       database:
         condition: service_healthy
@@ -86,6 +86,28 @@ services:
       - db_data:/var/lib/mysql
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+{{- end }}
+
+{{- if eq .Database.Driver "mariadb" }}
+
+  database:
+    image: mariadb:{{ .Database.Version }}
+    environment:
+      MARIADB_ROOT_PASSWORD: root
+      MARIADB_USER: {{ .DevDBUser }}
+      MARIADB_PASSWORD: {{ .DevDBPassword }}
+      MARIADB_DATABASE: {{ .DevDBName }}
+    ports:
+      # Bind to localhost only: no reason to expose the dev DB on the LAN
+      - "127.0.0.1:3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      # healthcheck.sh ships with the official mariadb image
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 5s
       timeout: 5s
       retries: 5

--- a/internal/generator/templates/compose-prod.tmpl
+++ b/internal/generator/templates/compose-prod.tmpl
@@ -88,6 +88,23 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+{{- else if eq .Database.Driver "mariadb" }}
+    image: mariadb:{{ .Database.Version }}
+    environment:
+      # Root gets a random one-time password: the app password must not
+      # double as the root password
+      MARIADB_RANDOM_ROOT_PASSWORD: "1"
+      MARIADB_USER: ${DATABASE_USER:-{{ .Name }}}
+      MARIADB_PASSWORD: ${DATABASE_PASSWORD:?DATABASE_PASSWORD is required}
+      MARIADB_DATABASE: ${DATABASE_NAME:-{{ .Name }}}
+    volumes:
+      - db_data:/var/lib/mysql
+    healthcheck:
+      # healthcheck.sh ships with the official mariadb image
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 {{- end }}
     restart: unless-stopped
     logging:

--- a/internal/generator/templates/dockerfile.tmpl
+++ b/internal/generator/templates/dockerfile.tmpl
@@ -168,6 +168,11 @@ RUN COMPOSER_ALLOW_SUPERUSER=1 composer dump-autoload --classmap-authoritative -
 # AssetMapper: install importmap dependencies and compile assets
 RUN set -eux; \
     php bin/console importmap:install --no-interaction; \
+{{- if .Assets.Tailwind }}
+    # Tailwind CSS must be built BEFORE asset-map:compile or the site
+    # deploys without any CSS
+    php bin/console tailwind:build --minify; \
+{{- end }}
     php bin/console asset-map:compile --no-interaction
 {{- else }}
 # Webpack/Vite: copy pre-built assets from node_build stage

--- a/internal/scanner/assets.go
+++ b/internal/scanner/assets.go
@@ -24,6 +24,11 @@ func (s *Scanner) DetectAssets() (*config.AssetsConfig, error) {
 	if s.hasAssetMapper() {
 		assetsConfig.BuildTool = "assetmapper"
 		assetsConfig.OutputDir = "public/assets"
+		// symfonycasts/tailwind-bundle: tailwind:build must run before
+		// asset-map:compile or the site deploys without CSS
+		if composer, err := s.ParseComposer(); err == nil && composer.HasPackage("symfonycasts/tailwind-bundle") {
+			assetsConfig.Tailwind = true
+		}
 		return assetsConfig, nil
 	}
 
@@ -34,16 +39,17 @@ func (s *Scanner) DetectAssets() (*config.AssetsConfig, error) {
 		return assetsConfig, nil
 	}
 
-	// Detect build tool
-	if s.hasVite(packageJSON) {
-		assetsConfig.BuildTool = "npm"
+	// Detect build tool. BuildTool must follow the lockfile (pnpm/yarn/npm):
+	// a hardcoded npm with a pnpm-lock.yaml ships the wrong lockfile to prod.
+	if s.hasVite(packageJSON) || s.hasViteBundle() {
+		assetsConfig.BuildTool = s.detectPackageManager()
 		assetsConfig.BuildCommand = s.getBuildCommand(packageJSON)
 		assetsConfig.OutputDir = "public/build"
 		return assetsConfig, nil
 	}
 
 	if s.hasWebpackEncore(packageJSON) {
-		assetsConfig.BuildTool = "npm"
+		assetsConfig.BuildTool = s.detectPackageManager()
 		assetsConfig.BuildCommand = s.getBuildCommand(packageJSON)
 		assetsConfig.OutputDir = "public/build"
 		return assetsConfig, nil
@@ -120,6 +126,17 @@ func (s *Scanner) hasVite(pkg *PackageJSON) bool {
 	}
 
 	return false
+}
+
+// hasViteBundle checks for pentatrion/vite-bundle in composer.json (Vite
+// integration driven from the Symfony side, no vite dependency in
+// package.json required)
+func (s *Scanner) hasViteBundle() bool {
+	composer, err := s.ParseComposer()
+	if err != nil {
+		return false
+	}
+	return composer.HasPackage("pentatrion/vite-bundle")
 }
 
 // hasWebpackEncore checks if Webpack Encore is used

--- a/internal/scanner/composer.go
+++ b/internal/scanner/composer.go
@@ -63,12 +63,11 @@ func (s *Scanner) ParseComposer() (*ComposerResult, error) {
 		result.PHPVersion = defaultPHPVersion
 	}
 
-	// Check for Symfony
-	for pkg := range composer.Require {
-		if strings.HasPrefix(pkg, "symfony/") {
-			result.HasSymfony = true
-			break
-		}
+	// Check for Symfony: only symfony/framework-bundle proves a Symfony
+	// application — individual symfony/* components are pulled by Laravel
+	// and many other projects too
+	if _, ok := composer.Require["symfony/framework-bundle"]; ok {
+		result.HasSymfony = true
 	}
 
 	// Extract PHP extensions

--- a/internal/scanner/database.go
+++ b/internal/scanner/database.go
@@ -1,6 +1,7 @@
 package scanner
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,8 +45,8 @@ func getSQLiteDirectory(path string) string {
 }
 
 // DetectDatabase detects the database configuration from the project.
-// Returns the config, an optional warning message, and an error.
-func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
+// Returns the config, optional warning messages, and an error.
+func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, []string, error) {
 	dbConfig := &config.DatabaseConfig{}
 
 	// First, check doctrine.yaml for explicit driver
@@ -58,15 +59,21 @@ func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
 				managed := true
 				dbConfig.Managed = &managed
 			}
-			return dbConfig, "", nil
+			return dbConfig, nil, nil
 		}
 	}
 
-	// Check .env for DATABASE_URL
-	if env, err := s.GetEnvFile(".env"); err == nil {
+	// Check .env + .env.local for DATABASE_URL (.env.local overrides,
+	// as Symfony does at runtime — reading only .env silently detects
+	// the wrong database)
+	if env, err := s.GetMergedEnv(); err == nil {
 		if dbURL, ok := env["DATABASE_URL"]; ok {
 			driver, version := parseDBURL(dbURL)
 			if driver != "" {
+				var warnings []string
+				if w := s.envDivergenceWarning(driver); w != "" {
+					warnings = append(warnings, w)
+				}
 				dbConfig.Driver = driver
 				dbConfig.Version = version
 				// SQLite: extract path and don't set managed
@@ -76,7 +83,7 @@ func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
 					managed := true
 					dbConfig.Managed = &managed
 				}
-				return dbConfig, "", nil
+				return dbConfig, warnings, nil
 			}
 		}
 	}
@@ -84,7 +91,7 @@ func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
 	// Check composer.json for database packages
 	composer, err := s.ParseComposer()
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	// Detect from installed packages
@@ -102,16 +109,42 @@ func (s *Scanner) DetectDatabase() (*config.DatabaseConfig, string, error) {
 			dbConfig.Version = "16"
 			managed := true
 			dbConfig.Managed = &managed
-			return dbConfig, "no database driver explicitly configured, defaulting to PostgreSQL. Set DATABASE_URL in .env or configure doctrine.yaml to silence this warning", nil
+			return dbConfig, []string{"no database driver explicitly configured, defaulting to PostgreSQL. Set DATABASE_URL in .env or configure doctrine.yaml to silence this warning"}, nil
 		}
 		managed := true
 		dbConfig.Managed = &managed
-		return dbConfig, "", nil
+		return dbConfig, nil, nil
 	}
 
 	// No database detected
-	return nil, "", nil
+	return nil, nil, nil
 }
+
+// envDivergenceWarning returns a warning when .env and .env.local declare
+// DATABASE_URLs with different drivers (the .env.local one wins).
+func (s *Scanner) envDivergenceWarning(effectiveDriver string) string {
+	base, baseErr := s.GetEnvFile(".env")
+	local, localErr := s.GetEnvFile(".env.local")
+	if baseErr != nil || localErr != nil {
+		return ""
+	}
+	baseURL, okBase := base["DATABASE_URL"]
+	localURL, okLocal := local["DATABASE_URL"]
+	if !okBase || !okLocal {
+		return ""
+	}
+	baseDriver, _ := parseDBURL(baseURL)
+	localDriver, _ := parseDBURL(localURL)
+	if baseDriver != "" && localDriver != "" && baseDriver != localDriver {
+		return fmt.Sprintf("DATABASE_URL differs between .env (%s) and .env.local (%s): using .env.local (%s), which is what Symfony does at runtime",
+			baseDriver, localDriver, effectiveDriver)
+	}
+	return ""
+}
+
+// serverVersionRegex matches the serverVersion query parameter, including
+// MariaDB forms ("10.11.2-MariaDB", "mariadb-10.11.2").
+var serverVersionRegex = regexp.MustCompile(`serverversion=([a-z0-9.-]+)`)
 
 // parseDBURL extracts driver and version from DATABASE_URL
 func parseDBURL(url string) (string, string) {
@@ -119,21 +152,37 @@ func parseDBURL(url string) (string, string) {
 	url = strings.ToLower(url)
 
 	var driver string
-	if strings.HasPrefix(url, "postgresql://") || strings.HasPrefix(url, "postgres://") {
+	switch {
+	case strings.HasPrefix(url, "postgresql://"), strings.HasPrefix(url, "postgres://"), strings.HasPrefix(url, "pgsql://"):
 		driver = "pgsql"
-	} else if strings.HasPrefix(url, "mysql://") {
+	case strings.HasPrefix(url, "mariadb://"):
+		driver = "mariadb"
+	case strings.HasPrefix(url, "mysql://"), strings.HasPrefix(url, "mysql2://"):
 		driver = "mysql"
-	} else if strings.HasPrefix(url, "sqlite://") {
+	case strings.HasPrefix(url, "sqlite://"), strings.HasPrefix(url, "sqlite:"):
 		driver = "sqlite"
-	} else {
+	default:
 		return "", ""
 	}
 
-	// Try to extract version from serverVersion parameter
-	version := getDefaultVersion(driver)
-	re := regexp.MustCompile(`serverversion=([0-9.]+)`)
-	if matches := re.FindStringSubmatch(url); len(matches) > 1 {
-		version = matches[1]
+	// Try to extract version from serverVersion parameter. A MariaDB
+	// serverVersion silently produced a nonexistent mysql:X image before:
+	// detect it and switch to the mariadb driver/image.
+	version := ""
+	if matches := serverVersionRegex.FindStringSubmatch(url); len(matches) > 1 {
+		v := matches[1]
+		switch {
+		case strings.HasSuffix(v, "-mariadb"):
+			driver = "mariadb"
+			v = strings.TrimSuffix(v, "-mariadb")
+		case strings.HasPrefix(v, "mariadb-"):
+			driver = "mariadb"
+			v = strings.TrimPrefix(v, "mariadb-")
+		}
+		version = v
+	}
+	if version == "" {
+		version = getDefaultVersion(driver)
 	}
 
 	return driver, version
@@ -146,6 +195,8 @@ func getDefaultVersion(driver string) string {
 		return "16"
 	case "mysql":
 		return "8.0"
+	case "mariadb":
+		return "11"
 	case "sqlite":
 		return "3"
 	default:

--- a/internal/scanner/database_test.go
+++ b/internal/scanner/database_test.go
@@ -180,8 +180,8 @@ func TestDetectDatabase_FallbackWarning(t *testing.T) {
 	if dbConfig.Driver != "pgsql" {
 		t.Errorf("expected driver pgsql, got %q", dbConfig.Driver)
 	}
-	if warning == "" {
-		t.Error("expected warning for PostgreSQL fallback, got empty string")
+	if len(warning) == 0 {
+		t.Error("expected warning for PostgreSQL fallback, got none")
 	}
 }
 
@@ -212,7 +212,7 @@ func TestDetectDatabase_NoWarningExplicit(t *testing.T) {
 	if dbConfig == nil {
 		t.Fatal("expected database config, got nil")
 	}
-	if warning != "" {
+	if len(warning) != 0 {
 		t.Errorf("expected no warning for explicit DATABASE_URL, got %q", warning)
 	}
 }

--- a/internal/scanner/messenger.go
+++ b/internal/scanner/messenger.go
@@ -1,0 +1,89 @@
+package scanner
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// envPlaceholderRegex matches Symfony env placeholders like
+// '%env(MESSENGER_TRANSPORT_DSN)%' or '%env(resolve:MESSENGER_TRANSPORT_DSN)%'.
+var envPlaceholderRegex = regexp.MustCompile(`%env\(([A-Za-z0-9_:]+)\)%`)
+
+// messengerTransportInfo describes the async transports a worker must consume.
+type messengerTransportInfo struct {
+	// Transports to consume, sorted for deterministic output
+	Transports []string
+	UsesAMQP   bool
+	UsesRedis  bool
+}
+
+// detectMessengerTransports reads messenger.yaml and resolves each transport
+// DSN (through .env/.env.local for %env()% placeholders). The failure
+// transport and sync/in-memory transports are excluded: consuming them is
+// either wrong or impossible, and a wrong transport name means a
+// crash-looping worker under --restart unless-stopped.
+func (s *Scanner) detectMessengerTransports(env map[string]string) messengerTransportInfo {
+	info := messengerTransportInfo{}
+
+	mc, err := s.GetMessengerConfig()
+	if err != nil {
+		return info
+	}
+
+	failure := mc.Framework.Messenger.FailureTransport
+
+	names := make([]string, 0, len(mc.Framework.Messenger.Transports))
+	for name := range mc.Framework.Messenger.Transports {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		if name == failure {
+			continue
+		}
+		dsn := resolveTransportDSN(mc.Framework.Messenger.Transports[name], env)
+		if strings.HasPrefix(dsn, "sync://") || strings.HasPrefix(dsn, "in-memory://") {
+			continue
+		}
+		info.Transports = append(info.Transports, name)
+		switch {
+		case strings.HasPrefix(dsn, "amqp://"), strings.HasPrefix(dsn, "amqps://"):
+			info.UsesAMQP = true
+		case strings.HasPrefix(dsn, "redis://"), strings.HasPrefix(dsn, "rediss://"):
+			info.UsesRedis = true
+		}
+	}
+
+	return info
+}
+
+// resolveTransportDSN extracts the DSN from a transport definition (plain
+// string or map with a dsn key) and resolves %env()% placeholders against
+// the merged project env.
+func resolveTransportDSN(transport interface{}, env map[string]string) string {
+	var dsn string
+	switch v := transport.(type) {
+	case string:
+		dsn = v
+	case map[string]interface{}:
+		if d, ok := v["dsn"].(string); ok {
+			dsn = d
+		}
+	}
+
+	if m := envPlaceholderRegex.FindStringSubmatch(dsn); len(m) > 1 {
+		key := m[1]
+		// Strip env processors (resolve:, default::, ...) — the variable
+		// name is the last segment
+		if idx := strings.LastIndex(key, ":"); idx != -1 {
+			key = key[idx+1:]
+		}
+		if val, ok := env[key]; ok {
+			dsn = val
+		}
+	}
+
+	return dsn
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 )
@@ -45,24 +46,48 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	}
 
 	// Detect database
-	dbConfig, dbWarning, err := s.DetectDatabase()
+	dbConfig, dbWarnings, err := s.DetectDatabase()
 	if err == nil && dbConfig != nil {
 		result.Database = *dbConfig
 	}
-	if dbWarning != "" {
-		result.Warnings = append(result.Warnings, dbWarning)
-	}
+	result.Warnings = append(result.Warnings, dbWarnings...)
 
 	// Detect assets
 	assetsConfig, err := s.DetectAssets()
 	if err == nil && assetsConfig != nil {
 		result.Assets = *assetsConfig
+		if assetsConfig.Tailwind {
+			result.Warnings = append(result.Warnings,
+				"symfonycasts/tailwind-bundle detected: tailwind:build will run before asset-map:compile (otherwise the site deploys without CSS)")
+		}
 	}
 
 	// Detect Symfony components
 	result.HasDoctrine = s.HasDoctrine()
 	result.HasMessenger = s.HasMessenger()
 	result.HasMailer = s.HasMailer()
+	result.HasScheduler = composer.HasPackage("symfony/scheduler")
+
+	// Resolve the real Messenger transports instead of guessing "async":
+	// a wrong transport name means a crash-looping worker in production
+	var messengerInfo messengerTransportInfo
+	if result.HasMessenger {
+		env, _ := s.GetMergedEnv()
+		messengerInfo = s.detectMessengerTransports(env)
+		result.MessengerTransports = messengerInfo.Transports
+		if len(messengerInfo.Transports) > 0 {
+			result.Warnings = append(result.Warnings,
+				fmt.Sprintf("Messenger: worker will consume transports [%s] (read from messenger.yaml)",
+					strings.Join(messengerInfo.Transports, ", ")))
+		} else {
+			result.Warnings = append(result.Warnings,
+				"messenger.yaml found but no async transport to consume: no worker container will run")
+		}
+	}
+	if result.HasScheduler {
+		result.Warnings = append(result.Warnings,
+			"symfony/scheduler detected: a worker will consume scheduler_default so scheduled tasks actually run in production")
+	}
 	// api-platform/core (v2/v3) or api-platform/symfony (v4 split packages)
 	result.HasAPIPlatform = composer.HasAnyPackage("api-platform/core", "api-platform/symfony")
 
@@ -76,7 +101,7 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	}
 
 	// Add required extensions based on detected features
-	result.PHPExtensions = s.enhanceExtensions(result.PHPExtensions, result)
+	result.PHPExtensions = s.enhanceExtensions(result.PHPExtensions, result, composer, messengerInfo)
 
 	return result, nil
 }
@@ -123,8 +148,20 @@ func (s *Scanner) HasMailer() bool {
 	return false
 }
 
+// packageExtensionHints maps composer packages (exact name or prefix ending
+// with "/") to the PHP extensions they need at runtime. Every inference is
+// announced through a scanner warning: correct or announced, never silent.
+var packageExtensionHints = []struct {
+	pkg  string // exact package name, or prefix when ending with "/"
+	exts []string
+}{
+	{"liip/imagine-bundle", []string{"gd"}},
+	{"snc/redis-bundle", []string{"redis"}},
+	{"phpoffice/", []string{"gd", "zip"}},
+}
+
 // enhanceExtensions adds required PHP extensions based on detected features
-func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResult) []string {
+func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResult, composer *ComposerResult, messengerInfo messengerTransportInfo) []string {
 	extMap := make(map[string]bool)
 	for _, ext := range extensions {
 		extMap[ext] = true
@@ -139,6 +176,34 @@ func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResu
 		}
 	}
 
+	// Infer extensions from installed packages (announced)
+	if composer != nil {
+		for _, hint := range packageExtensionHints {
+			matched := ""
+			if strings.HasSuffix(hint.pkg, "/") {
+				for pkg := range composer.Packages {
+					if strings.HasPrefix(pkg, hint.pkg) {
+						matched = pkg
+						break
+					}
+				}
+			} else if composer.HasPackage(hint.pkg) {
+				matched = hint.pkg
+			}
+			if matched == "" {
+				continue
+			}
+			for _, ext := range hint.exts {
+				if !extMap[ext] {
+					extensions = append(extensions, ext)
+					extMap[ext] = true
+					result.Warnings = append(result.Warnings,
+						fmt.Sprintf("adding PHP extension %s (required by %s)", ext, matched))
+				}
+			}
+		}
+	}
+
 	// Add database-specific extension. DetectDatabase already canonicalizes
 	// the driver via config.NormalizeDBDriver, so only the canonical forms
 	// (pgsql/mysql/sqlite) need handling here.
@@ -147,7 +212,7 @@ func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResu
 		if !extMap["pdo_pgsql"] {
 			extensions = append(extensions, "pdo_pgsql")
 		}
-	case "mysql":
+	case "mysql", "mariadb":
 		if !extMap["pdo_mysql"] {
 			extensions = append(extensions, "pdo_mysql")
 		}
@@ -157,9 +222,26 @@ func (s *Scanner) enhanceExtensions(extensions []string, result *config.ScanResu
 		}
 	}
 
-	// Add AMQP if Messenger is detected
-	if result.HasMessenger && !extMap["amqp"] {
+	// AMQP only when an amqp transport is actually configured — installing
+	// the extension for every messenger.yaml (present in each webapp
+	// skeleton) bloated images for nothing
+	if messengerInfo.UsesAMQP && !extMap["amqp"] {
 		extensions = append(extensions, "amqp")
+		extMap["amqp"] = true
+		result.Warnings = append(result.Warnings, "adding PHP extension amqp (amqp:// Messenger transport detected)")
+	}
+	if messengerInfo.UsesRedis && !extMap["redis"] {
+		extensions = append(extensions, "redis")
+		extMap["redis"] = true
+		result.Warnings = append(result.Warnings, "adding PHP extension redis (redis:// Messenger transport detected)")
+	}
+
+	// pcntl lets messenger:consume shut down gracefully on SIGTERM during
+	// deployments instead of dying mid-message
+	if result.HasMessenger && !extMap["pcntl"] {
+		extensions = append(extensions, "pcntl")
+		extMap["pcntl"] = true
+		result.Warnings = append(result.Warnings, "adding PHP extension pcntl (graceful Messenger worker shutdown)")
 	}
 
 	// Deduplicate while preserving order
@@ -204,11 +286,22 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 		}
 	}
 
-	// Auto-fill Messenger config if detected
-	if result.HasMessenger {
+	// Auto-fill Messenger config from the transports actually configured
+	// in messenger.yaml (never guess "async": a wrong transport name is a
+	// crash-looping worker)
+	if result.HasMessenger && len(result.MessengerTransports) > 0 {
 		cfg.Messenger = config.MessengerConfig{
 			Enabled:    true,
-			Transports: []string{"async"},
+			Transports: result.MessengerTransports,
+		}
+	}
+
+	// symfony/scheduler: its scheduler_default transport must be consumed
+	// or scheduled tasks silently never run
+	if result.HasScheduler {
+		cfg.Messenger.Enabled = true
+		if !contains(cfg.Messenger.Transports, "scheduler_default") {
+			cfg.Messenger.Transports = append(cfg.Messenger.Transports, "scheduler_default")
 		}
 	}
 

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -76,7 +76,7 @@ func TestEnhanceExtensions_Dedup(t *testing.T) {
 
 	// Input with duplicates: pdo_pgsql appears in composer AND would be added by enhanceExtensions
 	input := []string{"intl", "opcache", "zip", "pdo_pgsql", "intl", "zip"}
-	got := s.enhanceExtensions(input, result)
+	got := s.enhanceExtensions(input, result, nil, messengerTransportInfo{})
 
 	// Check no duplicates
 	seen := make(map[string]bool)
@@ -274,5 +274,298 @@ func TestScan_NoFrankenPHPRuntime_WorkerDisabled(t *testing.T) {
 	cfg := s.ToProjectConfig(result, "myapp")
 	if cfg.FrankenPHP.Worker {
 		t.Error("worker mode must stay opt-in without the runtime package")
+	}
+}
+
+// --- Issue #59: smarter detection ---
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const minimalSymfonyComposer = `{"require": {"php": ">=8.3", "symfony/framework-bundle": "^7.1"}}`
+
+func TestGetMergedEnv_EnvLocalOverrides(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, ".env", "DATABASE_URL=postgresql://app:x@127.0.0.1:5432/app?serverVersion=16\nAPP_ENV=dev\n")
+	writeFile(t, dir, ".env.local", "DATABASE_URL=mysql://app:x@127.0.0.1:3306/app?serverVersion=8.0\n")
+
+	env, err := New(dir).GetMergedEnv()
+	if err != nil {
+		t.Fatalf("GetMergedEnv: %v", err)
+	}
+	if !strings.HasPrefix(env["DATABASE_URL"], "mysql://") {
+		t.Errorf(".env.local must override .env, got %q", env["DATABASE_URL"])
+	}
+	if env["APP_ENV"] != "dev" {
+		t.Errorf(".env values not overridden must survive, got %q", env["APP_ENV"])
+	}
+}
+
+func TestDetectDatabase_EnvLocalOverridesEnv_WithWarning(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", minimalSymfonyComposer)
+	writeFile(t, dir, ".env", "DATABASE_URL=postgresql://app:x@127.0.0.1:5432/app?serverVersion=16\n")
+	writeFile(t, dir, ".env.local", "DATABASE_URL=mysql://app:x@127.0.0.1:3306/app?serverVersion=8.0\n")
+
+	db, warnings, err := New(dir).DetectDatabase()
+	if err != nil {
+		t.Fatalf("DetectDatabase: %v", err)
+	}
+	if db == nil || db.Driver != "mysql" {
+		t.Fatalf("expected mysql from .env.local, got %+v", db)
+	}
+	found := false
+	for _, w := range warnings {
+		if strings.Contains(w, ".env.local") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a divergence warning mentioning .env.local, got %v", warnings)
+	}
+}
+
+func TestParseDBURL_MariaDBAndAltSchemes(t *testing.T) {
+	tests := []struct {
+		url         string
+		wantDriver  string
+		wantVersion string
+	}{
+		{"mysql://app:x@db:3306/app?serverVersion=10.11.2-MariaDB", "mariadb", "10.11.2"},
+		{"mysql://app:x@db:3306/app?serverVersion=mariadb-10.6", "mariadb", "10.6"},
+		{"mariadb://app:x@db:3306/app", "mariadb", "11"},
+		{"mysql2://app:x@db:3306/app?serverVersion=8.0", "mysql", "8.0"},
+		{"pgsql://app:x@db:5432/app", "pgsql", "16"},
+		{"postgresql://app:x@db:5432/app?serverVersion=16", "pgsql", "16"},
+	}
+	for _, tt := range tests {
+		driver, version := parseDBURL(tt.url)
+		if driver != tt.wantDriver || version != tt.wantVersion {
+			t.Errorf("parseDBURL(%q) = (%q, %q), want (%q, %q)", tt.url, driver, version, tt.wantDriver, tt.wantVersion)
+		}
+	}
+}
+
+func TestScan_InferredExtensionsAnnounced(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1",
+			"liip/imagine-bundle": "^2.12",
+			"phpoffice/phpspreadsheet": "^2.0"
+		}
+	}`)
+
+	result, err := New(dir).Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	for _, want := range []string{"gd", "zip"} {
+		found := false
+		for _, ext := range result.PHPExtensions {
+			if ext == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("expected inferred extension %q, got %v", want, result.PHPExtensions)
+		}
+	}
+	warned := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "gd") {
+			warned = true
+		}
+	}
+	if !warned {
+		t.Errorf("inferred extensions must be announced, warnings: %v", result.Warnings)
+	}
+}
+
+func TestScan_MessengerTransportsFromYaml(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", minimalSymfonyComposer)
+	writeFile(t, dir, ".env", "MESSENGER_TRANSPORT_DSN=doctrine://default\n")
+	writeFile(t, dir, "config/packages/messenger.yaml", `
+framework:
+    messenger:
+        failure_transport: failed
+        transports:
+            async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            failed: 'doctrine://default?queue_name=failed'
+            sync_bus: 'sync://'
+        routing:
+            App\Message\Foo: async
+`)
+
+	s := New(dir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	cfg := s.ToProjectConfig(result, "myapp")
+	if len(cfg.Messenger.Transports) != 1 || cfg.Messenger.Transports[0] != "async" {
+		t.Errorf("expected only [async] (no failed, no sync), got %v", cfg.Messenger.Transports)
+	}
+	// doctrine transport: no amqp extension
+	for _, ext := range result.PHPExtensions {
+		if ext == "amqp" {
+			t.Errorf("amqp extension must not be added for a doctrine transport, got %v", result.PHPExtensions)
+		}
+	}
+	// pcntl for graceful worker shutdown
+	foundPcntl := false
+	for _, ext := range result.PHPExtensions {
+		if ext == "pcntl" {
+			foundPcntl = true
+		}
+	}
+	if !foundPcntl {
+		t.Errorf("expected pcntl for messenger graceful shutdown, got %v", result.PHPExtensions)
+	}
+}
+
+func TestScan_MessengerAMQPTransport(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", minimalSymfonyComposer)
+	writeFile(t, dir, ".env", "MESSENGER_TRANSPORT_DSN=amqp://guest:guest@rabbitmq:5672/%2f/messages\n")
+	writeFile(t, dir, "config/packages/messenger.yaml", `
+framework:
+    messenger:
+        transports:
+            async: '%env(MESSENGER_TRANSPORT_DSN)%'
+`)
+
+	result, err := New(dir).Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	found := false
+	for _, ext := range result.PHPExtensions {
+		if ext == "amqp" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected amqp extension for amqp transport, got %v", result.PHPExtensions)
+	}
+}
+
+func TestScan_SchedulerAddsTransport(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1",
+			"symfony/scheduler": "^7.1"
+		}
+	}`)
+
+	s := New(dir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !result.HasScheduler {
+		t.Error("expected HasScheduler")
+	}
+	cfg := s.ToProjectConfig(result, "myapp")
+	if !cfg.Messenger.Enabled {
+		t.Error("scheduler requires a running messenger worker")
+	}
+	found := false
+	for _, tr := range cfg.Messenger.Transports {
+		if tr == "scheduler_default" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected scheduler_default transport, got %v", cfg.Messenger.Transports)
+	}
+}
+
+func TestDetectAssets_ViteWithPnpm(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", minimalSymfonyComposer)
+	writeFile(t, dir, "package.json", `{"scripts": {"build": "vite build"}, "devDependencies": {"vite": "^5.0"}}`)
+	writeFile(t, dir, "pnpm-lock.yaml", "lockfileVersion: 9\n")
+
+	assets, err := New(dir).DetectAssets()
+	if err != nil {
+		t.Fatalf("DetectAssets: %v", err)
+	}
+	if assets.BuildTool != "pnpm" {
+		t.Errorf("BuildTool must follow the lockfile (pnpm), got %q", assets.BuildTool)
+	}
+	if !strings.HasPrefix(assets.BuildCommand, "pnpm ") {
+		t.Errorf("BuildCommand must use pnpm, got %q", assets.BuildCommand)
+	}
+}
+
+func TestDetectAssets_PentatrionViteBundle(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1",
+			"pentatrion/vite-bundle": "^8.0"
+		}
+	}`)
+	writeFile(t, dir, "package.json", `{"scripts": {"build": "vite build"}}`)
+
+	assets, err := New(dir).DetectAssets()
+	if err != nil {
+		t.Fatalf("DetectAssets: %v", err)
+	}
+	if assets.BuildTool == "" || assets.BuildTool == "assetmapper" {
+		t.Errorf("pentatrion/vite-bundle must trigger a JS build, got %q", assets.BuildTool)
+	}
+}
+
+func TestDetectAssets_TailwindBundle(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "composer.json", `{
+		"require": {
+			"php": ">=8.3",
+			"symfony/framework-bundle": "^7.1",
+			"symfonycasts/tailwind-bundle": "^0.6"
+		}
+	}`)
+	writeFile(t, dir, "importmap.php", "<?php return [];\n")
+
+	assets, err := New(dir).DetectAssets()
+	if err != nil {
+		t.Fatalf("DetectAssets: %v", err)
+	}
+	if assets.BuildTool != "assetmapper" {
+		t.Fatalf("expected assetmapper, got %q", assets.BuildTool)
+	}
+	if !assets.Tailwind {
+		t.Error("expected Tailwind to be detected (site would deploy without CSS)")
+	}
+}
+
+func TestIsSymfonyProject_RequiresFrameworkBundle(t *testing.T) {
+	dir := t.TempDir()
+	// A Laravel project pulls symfony/console transitively
+	writeFile(t, dir, "composer.json", `{
+		"require": {
+			"php": ">=8.3",
+			"laravel/framework": "^11.0",
+			"symfony/console": "^7.0"
+		}
+	}`)
+
+	if New(dir).IsSymfonyProject() {
+		t.Error("a project without symfony/framework-bundle must not be detected as Symfony")
 	}
 }

--- a/internal/scanner/symfony.go
+++ b/internal/scanner/symfony.go
@@ -70,7 +70,8 @@ func (s *Scanner) GetDoctrineConfig() (*DoctrineConfig, error) {
 type MessengerConfig struct {
 	Framework struct {
 		Messenger struct {
-			Transports map[string]interface{} `yaml:"transports"`
+			FailureTransport string                 `yaml:"failure_transport"`
+			Transports       map[string]interface{} `yaml:"transports"`
 		} `yaml:"messenger"`
 	} `yaml:"framework"`
 }
@@ -89,6 +90,29 @@ func (s *Scanner) GetMessengerConfig() (*MessengerConfig, error) {
 	}
 
 	return &config, nil
+}
+
+// GetMergedEnv reads .env then overlays .env.local, following the Symfony
+// convention: .env.local holds the machine-specific values and overrides
+// .env. Missing files are tolerated; an error is returned only when neither
+// file exists.
+func (s *Scanner) GetMergedEnv() (map[string]string, error) {
+	merged := make(map[string]string)
+
+	base, baseErr := s.GetEnvFile(".env")
+	for k, v := range base {
+		merged[k] = v
+	}
+
+	local, localErr := s.GetEnvFile(".env.local")
+	for k, v := range local {
+		merged[k] = v
+	}
+
+	if baseErr != nil && localErr != nil {
+		return merged, baseErr
+	}
+	return merged, nil
 }
 
 // GetEnvFile reads and parses a .env file


### PR DESCRIPTION
## Summary

Closes the "silently wrong detection" class (umbrella #59). Principle applied throughout: **every inference is either correct or announced** through the existing `result.Warnings` → `PrintWarning` channel.

## Changes

1. **`.env.local`**: `DATABASE_URL` read from `.env` + `.env.local` merged (`.env.local` wins, matching Symfony runtime); explicit warning when the two files disagree on the driver
2. **MariaDB**: full support — `mariadb:X` image (a `serverVersion=10.11.2-MariaDB` used to produce the nonexistent `mysql:10.11.2` tag), `healthcheck.sh --connect --innodb_initialized`, `mariadb-dump` for pre-migration backups, generated URL `mysql://…serverVersion=X-MariaDB` as Doctrine expects; `mariadb://`, `mysql2://`, `pgsql://` schemes recognized; compose dev/prod branches
3. **Inferred PHP extensions** (each announced): `liip/imagine-bundle`→gd, `snc/redis-bundle`→redis, `phpoffice/*`→gd+zip; `pcntl` with Messenger (graceful shutdown); `amqp`/`redis` only when a matching transport DSN is actually configured (no more amqp on every webapp skeleton)
4. **Tailwind + AssetMapper**: `tailwind:build --minify` before `asset-map:compile` — the site deployed **without CSS** silently before
5. **Messenger transports**: `GetMessengerConfig()` finally called; transports read from `messenger.yaml`, `%env()%` DSNs resolved through merged env; failure/sync transports excluded; no more hardcoded `async` (a wrong transport name = crash-looping worker)
6. **symfony/scheduler**: `scheduler_default` consumed so scheduled tasks actually run
7. **BuildTool follows the lockfile** (pnpm/yarn/npm) in the vite/encore paths; `pentatrion/vite-bundle` recognized
8. **Laravel false positive**: `IsSymfonyProject` now requires `symfony/framework-bundle` (any `symfony/*` component passed before)
9. **Config validated on load**: every project-loading command (deploy included) rejects an invalid hand-edited `frankendeploy.yaml`; global config parsed with `KnownFields(true)` like the project config

## Test Plan

- TDD: 15 new tests across scanner/generator/config (merge env, divergence warning, MariaDB URL forms, inferred extensions, real transports + amqp/doctrine cases, scheduler, pnpm lockfile, vite-bundle, tailwind ordering in Dockerfile, Laravel false positive, mariadb compose, global KnownFields)
- `make pre-commit` green
- **Real-world**: `init` on a MariaDB+scheduler+imagine fixture — divergence warning printed, `mariadb 10.11.2` detected, transports `[async, scheduler_default]`, gd/pcntl announced; `build` output validated with `docker compose config` (prod+dev)
- **Live non-regression on the VPS**: full blue-green deploy of the demo app with the branch binary — green, worker mode still active

## Related Issue

Closes #59

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g6xzbLBxeu81U1LYNbg3P