### PR TITLE
feat(server): detect OS in server setup and fail clearly on unsupported distros

### DIFF
--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/mail"
 	"strconv"
 	"strings"
 
@@ -308,19 +309,19 @@ func autoTryKeys(serverCfg *config.ServerConfig, keys []ssh.SSHKeyInfo) *ssh.SSH
 // port is allowed before ufw is enabled: never enable the firewall without
 // having allowed the port(s) SSH is reachable on, or the user gets locked
 // out of their own server. Invalid ports (<= 0) are filtered out.
-func buildFirewallCommands(sshPorts []int) []string {
-	cmds := make([]string, 0, len(sshPorts)+3)
+func buildFirewallCommands(sshPorts []int) []setupCommand {
+	cmds := make([]setupCommand, 0, len(sshPorts)+3)
 	seen := make(map[int]bool)
 	for _, port := range sshPorts {
 		if port > 0 && !seen[port] {
 			seen[port] = true
-			cmds = append(cmds, fmt.Sprintf("sudo ufw allow %d/tcp || true", port))
+			cmds = append(cmds, setupCommand{cmd: fmt.Sprintf("sudo ufw allow %d/tcp", port), allowFailure: true})
 		}
 	}
 	cmds = append(cmds,
-		"sudo ufw allow 80/tcp || true",
-		"sudo ufw allow 443/tcp || true",
-		"sudo ufw --force enable || true",
+		setupCommand{cmd: "sudo ufw allow 80/tcp", allowFailure: true},
+		setupCommand{cmd: "sudo ufw allow 443/tcp", allowFailure: true},
+		setupCommand{cmd: "sudo ufw --force enable", allowFailure: true},
 	)
 	return cmds
 }
@@ -337,28 +338,37 @@ func runServerSetup(cmd *cobra.Command, args []string) error {
 	client := conn.Client
 
 	PrintSuccess("Connected to %s", conn.Server.Host)
+
+	// Validate inputs and remote environment before changing anything
+	if err := validateSetupEmail(setupEmail); err != nil {
+		return err
+	}
+	if err := preflightServerSetup(ctx, client); err != nil {
+		return err
+	}
+
 	PrintInfo("Setting up server for FrankenDeploy...")
 
 	// Step 1: System update and prerequisites
 	PrintInfo("[1/5] Installing prerequisites...")
-	prereqCommands := []string{
-		"sudo apt-get update -qq",
-		"sudo apt-get install -y -qq curl ca-certificates",
+	prereqCommands := []setupCommand{
+		{cmd: "sudo apt-get update -qq"},
+		{cmd: "sudo apt-get install -y -qq curl ca-certificates"},
 	}
-	if err := runCommandsWithProgress(ctx, client, prereqCommands); err != nil {
+	if err := runSetupCommands(ctx, client, prereqCommands); err != nil {
 		return err
 	}
 
 	// Step 2: Install and configure Fail2ban
 	PrintInfo("[2/5] Installing Fail2ban...")
-	fail2banCommands := []string{
+	fail2banCommands := []setupCommand{
 		// Install Fail2ban
-		"sudo apt-get install -y -qq fail2ban",
+		{cmd: "sudo apt-get install -y -qq fail2ban"},
 		// Enable and start Fail2ban
-		"sudo systemctl enable fail2ban",
-		"sudo systemctl start fail2ban",
+		{cmd: "sudo systemctl enable fail2ban"},
+		{cmd: "sudo systemctl start fail2ban"},
 	}
-	if err := runCommandsWithProgress(ctx, client, fail2banCommands); err != nil {
+	if err := runSetupCommands(ctx, client, fail2banCommands); err != nil {
 		return err
 	}
 
@@ -385,31 +395,32 @@ findtime = 600
 
 	// Step 3: Install Docker
 	PrintInfo("[3/5] Installing Docker...")
-	dockerCommands := []string{
-		// Install Docker if not present
-		"which docker || (curl -fsSL https://get.docker.com | sudo sh)",
-		// Add user to docker group
-		"sudo usermod -aG docker $USER || true",
+	dockerCommands := []setupCommand{
+		// Install Docker if not present. A failed install must FAIL the
+		// setup (it silently passed before because of the "|| " heuristic).
+		{cmd: "which docker || (curl -fsSL https://get.docker.com | sudo sh)"},
+		// Add user to docker group (root has no $USER group need)
+		{cmd: "sudo usermod -aG docker $USER", allowFailure: true},
 		// Enable and start Docker
-		"sudo systemctl enable docker",
-		"sudo systemctl start docker",
+		{cmd: "sudo systemctl enable docker"},
+		{cmd: "sudo systemctl start docker"},
 	}
-	if err := runCommandsWithProgress(ctx, client, dockerCommands); err != nil {
+	if err := runSetupCommands(ctx, client, dockerCommands); err != nil {
 		return err
 	}
 
 	// Step 4: Create directory structure and Docker network
 	PrintInfo("[4/5] Configuring FrankenDeploy...")
-	structureCommands := []string{
+	structureCommands := []setupCommand{
 		// Create directory structure
-		fmt.Sprintf("sudo mkdir -p %s", constants.AppsDir),
-		fmt.Sprintf("sudo mkdir -p %s/apps", constants.CaddyDir),
-		fmt.Sprintf("sudo mkdir -p %s/logs", constants.CaddyDir),
-		fmt.Sprintf("sudo chown -R $USER:$USER %s", constants.BasePath),
-		// Create Docker network for apps
-		fmt.Sprintf("docker network create %s 2>/dev/null || true", constants.NetworkName),
+		{cmd: fmt.Sprintf("sudo mkdir -p %s", constants.AppsDir)},
+		{cmd: fmt.Sprintf("sudo mkdir -p %s/apps", constants.CaddyDir)},
+		{cmd: fmt.Sprintf("sudo mkdir -p %s/logs", constants.CaddyDir)},
+		{cmd: fmt.Sprintf("sudo chown -R $USER:$USER %s", constants.BasePath)},
+		// Create Docker network for apps (exists on re-run)
+		{cmd: fmt.Sprintf("docker network create %s", constants.NetworkName), allowFailure: true},
 	}
-	if err := runCommandsWithProgress(ctx, client, structureCommands); err != nil {
+	if err := runSetupCommands(ctx, client, structureCommands); err != nil {
 		return err
 	}
 
@@ -420,10 +431,15 @@ findtime = 600
 		return fmt.Errorf("failed to generate Caddy config: %w", err)
 	}
 
-	// Upload Caddyfile
-	uploadCaddyCmd := fmt.Sprintf(`cat > %s/Caddyfile << 'CADDYEOF'
+	// Upload Caddyfile (random heredoc delimiter: the user-provided email
+	// flows into this config)
+	delim, err := security.GenerateHeredocDelimiter("CADDYEOF")
+	if err != nil {
+		return fmt.Errorf("failed to generate delimiter: %w", err)
+	}
+	uploadCaddyCmd := fmt.Sprintf(`cat > %s/Caddyfile << '%s'
 %s
-CADDYEOF`, constants.CaddyDir, mainConfig)
+%s`, constants.CaddyDir, delim, mainConfig, delim)
 	if _, err := client.Exec(ctx, uploadCaddyCmd); err != nil {
 		return fmt.Errorf("failed to upload Caddyfile: %w", err)
 	}
@@ -444,7 +460,7 @@ CADDYEOF`, constants.CaddyDir, mainConfig)
 			sshPorts = append(sshPorts, port)
 		}
 	}
-	if err := runCommandsWithProgress(ctx, client, buildFirewallCommands(sshPorts)); err != nil {
+	if err := runSetupCommands(ctx, client, buildFirewallCommands(sshPorts)); err != nil {
 		return err
 	}
 
@@ -506,18 +522,103 @@ CADDYEOF`, constants.CaddyDir, mainConfig)
 	return nil
 }
 
-// runCommandsWithProgress executes a list of commands with error handling
-func runCommandsWithProgress(ctx context.Context, client *ssh.Client, commands []string) error {
+// setupCommand is a remote command with an explicit failure policy. The old
+// substring heuristics ("|| " or "2>/dev/null" meant never-failing) let a
+// failed Docker install pass silently.
+type setupCommand struct {
+	cmd          string
+	allowFailure bool
+}
+
+// runSetupCommands executes setup commands, failing fast unless a command
+// explicitly allows failure.
+func runSetupCommands(ctx context.Context, client *ssh.Client, commands []setupCommand) error {
 	for _, command := range commands {
-		PrintVerbose("  > %s", command)
-		result, err := client.Exec(ctx, command)
+		PrintVerbose("  > %s", command.cmd)
+		result, err := client.Exec(ctx, command.cmd)
 		if err != nil {
 			return fmt.Errorf("command failed: %w", err)
 		}
-		// Allow commands with || true or || to fail gracefully
-		if result.ExitCode != 0 && !strings.Contains(command, "|| true") && !strings.Contains(command, "|| ") && !strings.Contains(command, "2>/dev/null") {
-			return fmt.Errorf("command %q failed: %w", command, result.Err())
+		if result.ExitCode != 0 && !command.allowFailure {
+			return fmt.Errorf("command %q failed: %w", command.cmd, result.Err())
 		}
+	}
+	return nil
+}
+
+// checkOSSupported parses /etc/os-release content and returns an explicit
+// error on distributions without apt-get. The setup previously failed with
+// an opaque "command failed: sudo apt-get update" on Rocky/Alma/Fedora/Arch.
+func checkOSSupported(osRelease string) error {
+	fields := map[string]string{}
+	for _, line := range strings.Split(osRelease, "\n") {
+		key, value, found := strings.Cut(strings.TrimSpace(line), "=")
+		if !found {
+			continue
+		}
+		fields[key] = strings.Trim(value, `"`)
+	}
+
+	supported := map[string]bool{"ubuntu": true, "debian": true}
+	if supported[fields["ID"]] {
+		return nil
+	}
+	for _, like := range strings.Fields(fields["ID_LIKE"]) {
+		if supported[like] {
+			return nil
+		}
+	}
+
+	detected := fields["PRETTY_NAME"]
+	if detected == "" {
+		detected = fields["ID"]
+	}
+	if detected == "" {
+		detected = "unknown"
+	}
+	return fmt.Errorf("unsupported Linux distribution: %s.\n"+
+		"frankendeploy server setup uses apt-get and currently supports Debian and Ubuntu (and derivatives).\n"+
+		"On other distributions, install Docker manually and re-run setup, or open an issue: https://github.com/yoanbernabeu/frankendeploy/issues", detected)
+}
+
+// validateSetupEmail validates the Let's Encrypt email before setup starts:
+// a typo would otherwise only surface at the first certificate issuance.
+func validateSetupEmail(email string) error {
+	if email == "" {
+		return fmt.Errorf("--email is required (used for Let's Encrypt certificates)")
+	}
+	addr, err := mail.ParseAddress(email)
+	if err != nil || addr.Address != email {
+		return fmt.Errorf("invalid --email %q: expected a plain address like you@example.com", email)
+	}
+	return nil
+}
+
+// preflightServerSetup verifies the remote environment before changing
+// anything: supported OS and usable sudo.
+func preflightServerSetup(ctx context.Context, client *ssh.Client) error {
+	// OS check
+	result, err := client.Exec(ctx, "cat /etc/os-release")
+	if err != nil || result.ExitCode != 0 {
+		return fmt.Errorf("cannot read /etc/os-release to identify the Linux distribution")
+	}
+	if err := checkOSSupported(result.Stdout); err != nil {
+		return err
+	}
+
+	// sudo check: every setup command relies on non-interactive sudo
+	result, err = client.Exec(ctx, "id -u")
+	if err != nil {
+		return fmt.Errorf("cannot check remote user: %w", err)
+	}
+	if strings.TrimSpace(result.Stdout) == "0" {
+		return nil // root does not need sudo rights
+	}
+	result, err = client.Exec(ctx, "sudo -n true")
+	if err != nil || result.ExitCode != 0 {
+		return fmt.Errorf("passwordless sudo is required for server setup.\n" +
+			"Grant it with: echo \"$USER ALL=(ALL) NOPASSWD:ALL\" | sudo tee /etc/sudoers.d/$USER\n" +
+			"(or run setup as root)")
 	}
 	return nil
 }

--- a/internal/cmd/server_test.go
+++ b/internal/cmd/server_test.go
@@ -5,10 +5,19 @@ import (
 	"testing"
 )
 
+// joinSetupCommands flattens setup commands for substring assertions.
+func joinSetupCommands(cmds []setupCommand) string {
+	lines := make([]string, len(cmds))
+	for i, c := range cmds {
+		lines[i] = c.cmd
+	}
+	return strings.Join(lines, "\n")
+}
+
 func TestBuildFirewallCommands_CustomSSHPort(t *testing.T) {
 	cmds := buildFirewallCommands([]int{3022})
 
-	joined := strings.Join(cmds, "\n")
+	joined := joinSetupCommands(cmds)
 	if !strings.Contains(joined, "sudo ufw allow 3022/tcp") {
 		t.Errorf("expected the configured SSH port 3022 to be allowed, got:\n%s", joined)
 	}
@@ -21,7 +30,7 @@ func TestBuildFirewallCommands_MultiplePortsDeduplicated(t *testing.T) {
 	// Configured port + server-side detected port (gateway/NAT case), with a duplicate
 	cmds := buildFirewallCommands([]int{3022, 22, 3022})
 
-	joined := strings.Join(cmds, "\n")
+	joined := joinSetupCommands(cmds)
 	if !strings.Contains(joined, "allow 3022/tcp") || !strings.Contains(joined, "allow 22/tcp") {
 		t.Errorf("expected both SSH ports to be allowed, got:\n%s", joined)
 	}
@@ -34,7 +43,7 @@ func TestBuildFirewallCommands_MultiplePortsDeduplicated(t *testing.T) {
 func TestBuildFirewallCommands_HTTPPortsAndEnableLast(t *testing.T) {
 	cmds := buildFirewallCommands([]int{22})
 
-	joined := strings.Join(cmds, "\n")
+	joined := joinSetupCommands(cmds)
 	for _, want := range []string{"allow 80/tcp", "allow 443/tcp"} {
 		if !strings.Contains(joined, want) {
 			t.Errorf("expected %q in firewall commands, got:\n%s", want, joined)
@@ -42,12 +51,12 @@ func TestBuildFirewallCommands_HTTPPortsAndEnableLast(t *testing.T) {
 	}
 	// The enable must come last: every allow runs before the firewall goes up.
 	last := cmds[len(cmds)-1]
-	if !strings.Contains(last, "ufw --force enable") {
-		t.Errorf("expected 'ufw --force enable' to be the last command, got %q", last)
+	if !strings.Contains(last.cmd, "ufw --force enable") {
+		t.Errorf("expected 'ufw --force enable' to be the last command, got %q", last.cmd)
 	}
 	for _, cmd := range cmds[:len(cmds)-1] {
-		if strings.Contains(cmd, "enable") {
-			t.Errorf("enable found before the last position: %q", cmd)
+		if strings.Contains(cmd.cmd, "enable") {
+			t.Errorf("enable found before the last position: %q", cmd.cmd)
 		}
 	}
 }
@@ -57,11 +66,52 @@ func TestBuildFirewallCommands_InvalidPortsFiltered(t *testing.T) {
 	// least the valid port must still be allowed before enabling.
 	cmds := buildFirewallCommands([]int{0, -1, 2222})
 
-	joined := strings.Join(cmds, "\n")
+	joined := joinSetupCommands(cmds)
 	if strings.Contains(joined, "allow 0/tcp") || strings.Contains(joined, "allow -1/tcp") {
 		t.Errorf("invalid ports must be filtered, got:\n%s", joined)
 	}
 	if !strings.Contains(joined, "allow 2222/tcp") {
 		t.Errorf("expected valid port 2222 to be allowed, got:\n%s", joined)
+	}
+}
+
+// --- Issue #62: OS detection and explicit failures ---
+
+func TestCheckOSSupported(t *testing.T) {
+	tests := []struct {
+		name      string
+		osRelease string
+		wantErr   bool
+	}{
+		{"ubuntu", "ID=ubuntu\nID_LIKE=debian\nPRETTY_NAME=\"Ubuntu 24.04.3 LTS\"\n", false},
+		{"debian", "ID=debian\nPRETTY_NAME=\"Debian GNU/Linux 12\"\n", false},
+		{"raspbian (ID_LIKE)", "ID=raspbian\nID_LIKE=debian\n", false},
+		{"linuxmint (ID_LIKE multi)", "ID=linuxmint\nID_LIKE=\"ubuntu debian\"\n", false},
+		{"rocky", "ID=\"rocky\"\nID_LIKE=\"rhel centos fedora\"\nPRETTY_NAME=\"Rocky Linux 9\"\n", true},
+		{"fedora", "ID=fedora\n", true},
+		{"arch", "ID=arch\n", true},
+		{"empty", "", true},
+	}
+	for _, tt := range tests {
+		err := checkOSSupported(tt.osRelease)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("%s: checkOSSupported() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+		if err != nil && !strings.Contains(err.Error(), "Ubuntu") {
+			t.Errorf("%s: the error must list supported distributions, got: %v", tt.name, err)
+		}
+	}
+}
+
+func TestValidateSetupEmail(t *testing.T) {
+	for _, valid := range []string{"user@example.com", "first.last+tag@sub.domain.org"} {
+		if err := validateSetupEmail(valid); err != nil {
+			t.Errorf("validateSetupEmail(%q) unexpected error: %v", valid, err)
+		}
+	}
+	for _, invalid := range []string{"", "not-an-email", "user@", "@example.com", "user @example.com"} {
+		if err := validateSetupEmail(invalid); err == nil {
+			t.Errorf("validateSetupEmail(%q) must fail (a typo only surfaces at the Let's Encrypt failure otherwise)", invalid)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`server setup` now verifies the remote environment **before changing anything** and fails with actionable messages, instead of an opaque "command failed: sudo apt-get update" on non-Debian distros or a silent pass on a failed Docker install.

## Changes

- **OS preflight**: `/etc/os-release` parsed (ID + ID_LIKE); Debian/Ubuntu and derivatives supported, everything else fails immediately listing what is supported and pointing to the issue tracker
- **sudo preflight**: `sudo -n true` for non-root users, with the NOPASSWD one-liner in the error message; root passes directly
- **Explicit `allowFailure`**: new `setupCommand{cmd, allowFailure}` type replaces the substring heuristics (`|| ` / `2>/dev/null` were treated as never-failing) — a failed `curl | sh` Docker install now aborts the setup
- **`--email` validated upfront** (`net/mail.ParseAddress`): a typo used to surface only at the first Let's Encrypt issuance
- **Random heredoc delimiter** for the Caddyfile upload (the user-provided email flows into it), replacing the static `CADDYEOF`

## Test Plan

- TDD: `checkOSSupported` table (ubuntu, debian, ID_LIKE derivatives, rocky/fedora/arch/empty → error listing distros), `validateSetupEmail` valid/invalid table; firewall tests adapted to the new type
- `make pre-commit` green
- **Live on the VPS (Ubuntu 24.04, root)**: full `server setup` re-run green (preflights pass, idempotent), demo app still HTTP 200 after the Caddy restart; invalid `--email` and missing `--email` rejected before any connection to the server touches anything

## Related Issue

Closes #62

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g6xzbLBxeu81U1LYNbg3P