### PR TITLE
refactor(deploy): extract orchestration into a testable pipeline

### DIFF
--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,7 +15,6 @@ import (
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
 	"github.com/yoanbernabeu/frankendeploy/internal/deploy"
-	"github.com/yoanbernabeu/frankendeploy/internal/generator"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
 )
@@ -166,7 +163,7 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	if projectCfg.Database.Driver != "" && projectCfg.Database.IsManaged() {
 		PrintInfo("Setting up managed database...")
 		var err error
-		databaseURL, err = deployManagedDatabase(ctx, client, projectCfg, remoteAppPath)
+		databaseURL, err = deploy.DeployManagedDatabase(ctx, client, projectCfg, remoteAppPath, cmdLogger{})
 		if err != nil {
 			return fmt.Errorf("database setup failed: %w", err)
 		}
@@ -176,150 +173,83 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 	// Blue-green deployment: start new container with temp name, health check, then swap
 	state := deploy.NewDeployState(projectCfg.Name)
 
-	// Step 4: Prepare release directories and shared volumes
-	PrintInfo("Preparing release...")
-	state.Phase = deploy.PhasePrepareRelease
-	if err := prepareRelease(ctx, client, projectCfg, remoteAppPath, deployTag); err != nil {
-		return fmt.Errorf("deployment failed: %w", err)
-	}
-
-	// Check if old container exists (for swap phase)
-	if oldResult, err := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=^%s$", projectCfg.Name)); err == nil && oldResult != nil {
-		state.OldContainerExists = strings.TrimSpace(oldResult.Stdout) != ""
-	}
-
-	// Step 5: Start new container with temporary name (old container still running)
-	PrintInfo("Starting new version (blue-green)...")
-	state.Phase = deploy.PhaseStartNewContainer
-	if err := startNewContainer(ctx, client, projectCfg, imageName, remoteAppPath, deployTag, databaseURL, state.TempContainerName); err != nil {
-		return fmt.Errorf("deployment failed: %w", err)
-	}
-
-	// Step 6: Run pre-deploy hooks on the NEW container
-	hasMigrationHook := deploy.HasMigrationHook(projectCfg.Deploy.Hooks.PreDeploy)
-	migrationAttempted := false
-	var dbBackupPath string
-	if len(projectCfg.Deploy.Hooks.PreDeploy) > 0 {
-		// Step 6a: Automatic database backup before any migration. Migrations
-		// run while the old code still serves traffic: if anything fails
-		// afterwards, the container rollback does NOT roll the schema back —
-		// the dump is the only safety net.
-		if hasMigrationHook && projectCfg.Database.IsManaged() && databaseURL != "" {
-			PrintInfo("Backing up database before migration...")
-			backupPath, err := deploy.BackupManagedDatabase(ctx, client, projectCfg, databaseURL, deployTag)
-			if err != nil {
-				if !deployForce {
-					PrintWarning("Database backup failed, rolling back...")
-					rollbackNewContainer(ctx, client, state)
-					return fmt.Errorf("database backup failed (use --force to deploy without a backup): %w", err)
-				}
-				PrintWarning("Database backup failed but continuing (--force): %v", err)
-			} else {
-				dbBackupPath = backupPath
-				PrintSuccess("Database backup: %s", backupPath)
+	// Steps 4-11: blue-green orchestration (extracted to internal/deploy,
+	// tested per failure scenario in orchestrator_test.go)
+	steps := deploy.Steps{
+		PrepareRelease: func() error {
+			return prepareRelease(ctx, client, projectCfg, remoteAppPath, deployTag)
+		},
+		OldContainerExists: func() bool {
+			if oldResult, err := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=^%s$", projectCfg.Name)); err == nil && oldResult != nil {
+				return strings.TrimSpace(oldResult.Stdout) != ""
 			}
-		}
-
-		PrintInfo("Running pre-deploy hooks...")
-		state.Phase = deploy.PhasePreDeployHooks
-		migrationAttempted = hasMigrationHook
-		if err := runDeployHooks(ctx, client, state.TempContainerName, projectCfg.Deploy.Hooks.PreDeploy); err != nil {
-			if !deployForce {
-				PrintWarning("Pre-deploy hooks failed, rolling back...")
-				rollbackNewContainer(ctx, client, state)
-				if hasMigrationHook {
-					warnDatabaseMigrationRollback("The migration may have been partially applied (non-transactional DDL on MySQL/MariaDB leaves a partial schema).", dbBackupPath)
-				}
-				return fmt.Errorf("pre-deploy hooks failed: %w", err)
-			}
-			PrintWarning("Pre-deploy hooks failed but continuing (--force)")
-		}
-
-		// Check for empty migrations if migration hook was run
-		if hasMigrationHook {
+			return false
+		},
+		StartNewContainer: func() error {
+			return startNewContainer(ctx, client, projectCfg, imageName, remoteAppPath, deployTag, databaseURL, state.TempContainerName)
+		},
+		BackupDatabase: func() (string, error) {
+			return deploy.BackupManagedDatabase(ctx, client, projectCfg, databaseURL, deployTag)
+		},
+		RunPreDeployHooks: func() error {
+			return runDeployHooks(ctx, client, state.TempContainerName, projectCfg.Deploy.Hooks.PreDeploy)
+		},
+		CheckMigrationState: func() {
 			checkAndWarnMigrationState(ctx, client, state.TempContainerName)
-		}
-	}
-
-	// Step 7: Health check on the NEW container (old still running = zero downtime)
-	if deploySkipHealthcheck {
-		PrintWarning("Health check skipped (--skip-healthcheck)")
-	} else {
-		PrintInfo("Running health check...")
-		state.Phase = deploy.PhaseHealthCheck
-		if err := runHealthCheckOnContainer(ctx, client, projectCfg, state.TempContainerName); err != nil {
+		},
+		HealthCheck: func() error {
+			return runHealthCheckOnContainer(ctx, client, projectCfg, state.TempContainerName)
+		},
+		ShowContainerLogs: func() {
 			showContainerLogs(ctx, client, state.TempContainerName)
-			if !deployForce {
-				PrintWarning("Health check failed, rolling back...")
-				rollbackNewContainer(ctx, client, state)
-				if migrationAttempted {
-					warnDatabaseMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
-				}
-				return fmt.Errorf("deployment failed health check: %w", err)
+		},
+		SwapContainers: func(oldExists bool) error {
+			return swapContainers(ctx, client, projectCfg.Name, remoteAppPath, deployTag, state.TempContainerName, oldExists)
+		},
+		DeployWorkers: func() error {
+			return deployMessengerWorkers(ctx, client, projectCfg, imageName, remoteAppPath, databaseURL)
+		},
+		RunPostDeployHooks: func() error {
+			return runDeployHooks(ctx, client, projectCfg.Name, projectCfg.Deploy.Hooks.PostDeploy)
+		},
+		CaddyAppConfigExists: func() bool {
+			return caddyAppConfigExists(ctx, client, projectCfg.Name)
+		},
+		UpdateCaddy: func() error {
+			return updateCaddyConfig(ctx, client, projectCfg)
+		},
+		Cleanup: func() {
+			cleanupOldReleases(ctx, client, remoteAppPath, projectCfg.Deploy.KeepReleases)
+			// Prune images whose tag left the retention window: each deploy
+			// leaves a full image behind, and a small VPS fills up after a few
+			// dozen deploys
+			if removed, err := deploy.PruneOldImages(ctx, client, projectCfg.Name, remoteAppPath); err != nil {
+				PrintVerbose("Could not prune old images: %v", err)
+			} else if len(removed) > 0 {
+				PrintInfo("Removed %d old image(s): %s", len(removed), strings.Join(removed, ", "))
 			}
-			PrintWarning("Health check failed but continuing (--force)")
-		} else {
-			PrintSuccess("Health check passed")
-		}
+		},
+		RollbackNewContainer: func(st *deploy.DeployState) {
+			rollbackNewContainer(ctx, client, st)
+		},
+		WarnMigrationRollback: warnDatabaseMigrationRollback,
 	}
 
-	// Step 8: Swap containers (rename old away, rename new → final, stop old, update symlink)
-	PrintInfo("Swapping containers...")
-	state.Phase = deploy.PhaseSwapContainers
-	if err := swapContainers(ctx, client, projectCfg.Name, remoteAppPath, deployTag, state.TempContainerName, state.OldContainerExists); err != nil {
-		rollbackNewContainer(ctx, client, state)
-		if migrationAttempted {
-			warnDatabaseMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
-		}
-		return fmt.Errorf("swap failed: %w", err)
+	opts := deploy.Options{
+		Force:              deployForce,
+		SkipHealthcheck:    deploySkipHealthcheck,
+		HasPreDeployHooks:  len(projectCfg.Deploy.Hooks.PreDeploy) > 0,
+		HasMigrationHook:   deploy.HasMigrationHook(projectCfg.Deploy.Hooks.PreDeploy),
+		BackupEligible:     projectCfg.Database.IsManaged() && databaseURL != "",
+		HasPostDeployHooks: len(projectCfg.Deploy.Hooks.PostDeploy) > 0,
+		MessengerEnabled:   projectCfg.Messenger.Enabled,
+		Domain:             projectCfg.Deploy.Domain,
+		Logger:             cmdLogger{},
 	}
 
-	// Step 8b: Deploy Messenger worker if enabled
-	if projectCfg.Messenger.Enabled {
-		PrintInfo("Starting Messenger worker...")
-		if err := deployMessengerWorkers(ctx, client, projectCfg, imageName, remoteAppPath, databaseURL); err != nil {
-			PrintWarning("Failed to start Messenger worker: %v", err)
-		} else {
-			PrintSuccess("Messenger worker started")
-		}
+	if err := deploy.RunPipeline(state, steps, opts); err != nil {
+		return err
 	}
-
-	// Step 9: Run post_deploy hooks
-	state.Phase = deploy.PhasePostDeployHooks
-	if len(projectCfg.Deploy.Hooks.PostDeploy) > 0 {
-		PrintInfo("Running post-deploy hooks...")
-		if err := runDeployHooks(ctx, client, projectCfg.Name, projectCfg.Deploy.Hooks.PostDeploy); err != nil {
-			PrintWarning("Post-deploy hooks failed: %v", err)
-		}
-	}
-
-	// Step 10: Update Caddy config. On the app's FIRST public exposure this is
-	// THE condition for reachability: failing must fail the deploy instead of
-	// printing a success message with an unreachable https URL. On later
-	// deploys the existing Caddy config still routes to the swapped container,
-	// so a reload failure only warrants a warning.
-	firstExposure := projectCfg.Deploy.Domain != "" && !caddyAppConfigExists(ctx, client, projectCfg.Name)
-	PrintInfo("Updating reverse proxy...")
-	if err := updateCaddyConfig(ctx, client, projectCfg); err != nil {
-		if firstExposure {
-			return fmt.Errorf("reverse proxy configuration failed — the application is running on the server but NOT publicly reachable: %w", err)
-		}
-		PrintWarning("Failed to update Caddy: %v", err)
-	}
-
-	// Step 11: Cleanup old releases
-	state.Phase = deploy.PhaseCleanup
-	PrintInfo("Cleaning up old releases...")
-	cleanupOldReleases(ctx, client, remoteAppPath, projectCfg.Deploy.KeepReleases)
-
-	// Prune images whose tag left the retention window: each deploy leaves a
-	// full image behind, and a small VPS fills up after a few dozen deploys
-	if removed, err := deploy.PruneOldImages(ctx, client, projectCfg.Name, remoteAppPath); err != nil {
-		PrintVerbose("Could not prune old images: %v", err)
-	} else if len(removed) > 0 {
-		PrintInfo("Removed %d old image(s): %s", len(removed), strings.Join(removed, ", "))
-	}
-	state.Phase = deploy.PhaseDone
 
 	PrintSuccess("Deployment complete!")
 	fmt.Println()
@@ -974,113 +904,6 @@ func deployMessengerWorkers(ctx context.Context, client ssh.Executor, cfg *confi
 	}
 
 	return nil
-}
-
-// deployManagedDatabase creates and manages a database container for the app
-func deployManagedDatabase(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, appPath string) (string, error) {
-	dbContainerName := fmt.Sprintf("%s-db", cfg.Name)
-	dbName := strings.ReplaceAll(cfg.Name, "-", "_")
-	credentialsFile := filepath.Join(appPath, "shared", ".db_credentials")
-
-	// Get driver info from registry (single source of truth)
-	info, err := generator.GetDBDriverInfo(cfg.Database.Driver)
-	if err != nil {
-		return "", fmt.Errorf("unsupported database driver for managed mode: %s", cfg.Database.Driver)
-	}
-
-	// Check if database container already exists and is running
-	checkResult, checkErr := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=%s", dbContainerName))
-	if checkErr == nil && strings.TrimSpace(checkResult.Stdout) != "" {
-		// Container exists, read existing credentials
-		credResult, credErr := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", credentialsFile))
-		if credErr == nil && credResult.ExitCode == 0 && credResult.Stdout != "" {
-			PrintVerbose("Using existing database container")
-			return strings.TrimSpace(credResult.Stdout), nil
-		}
-	}
-
-	// Generate credentials
-	dbUser := cfg.Name
-	dbPassword, err := generateRandomPassword(24)
-	if err != nil {
-		return "", err
-	}
-
-	// Use configured version or registry default
-	version := cfg.Database.Version
-	if version == "" {
-		version = info.DefaultVersion
-	}
-
-	// Build database configuration from registry
-	dockerImage := info.FullImage(version)
-	dockerEnv := info.BuildEnvArgs(
-		security.ShellEscape(dbUser),
-		security.ShellEscape(dbPassword),
-		security.ShellEscape(dbName),
-	)
-	databaseURL := info.BuildDatabaseURL(dbUser, dbPassword, dbContainerName, dbName, version)
-
-	// Stop and remove existing container if exists (for recreation)
-	stopAndRemoveContainer(ctx, client, dbContainerName)
-
-	// Create database container with persistent volume
-	dbRunCmd := fmt.Sprintf(`docker run -d --name %s \
-		--network %s \
-		--restart unless-stopped \
-		%s \
-		%s \
-		-v %s-data:%s \
-		%s`,
-		dbContainerName,
-		constants.NetworkName,
-		constants.DockerLogOptions,
-		dockerEnv,
-		dbContainerName,
-		info.DataVolumePath,
-		dockerImage)
-
-	result, err := client.Exec(ctx, dbRunCmd)
-	if err != nil {
-		return "", fmt.Errorf("failed to start database container: %w", err)
-	}
-	if err := result.Err(); err != nil {
-		return "", fmt.Errorf("failed to start database container: %w", err)
-	}
-
-	// Save credentials to file
-	if _, err := client.Exec(ctx, fmt.Sprintf("echo %s > %s", security.ShellEscape(databaseURL), credentialsFile)); err != nil {
-		return "", fmt.Errorf("failed to save database credentials: %w", err)
-	}
-	if _, err := client.Exec(ctx, fmt.Sprintf("chmod 600 %s", credentialsFile)); err != nil {
-		PrintWarning("Could not set permissions on credentials file: %v", err)
-	}
-
-	// Wait for database to be ready
-	PrintVerbose("Waiting for database to be ready...")
-	for i := 0; i < 30; i++ {
-		healthCmd := info.BuildHealthCmd(
-			dbContainerName,
-			security.ShellEscape(dbUser),
-			security.ShellEscape(dbPassword),
-		)
-		checkResult, _ := client.Exec(ctx, healthCmd)
-		if checkResult != nil && checkResult.ExitCode == 0 {
-			break
-		}
-		time.Sleep(1 * time.Second)
-	}
-
-	return databaseURL, nil
-}
-
-// generateRandomPassword generates a secure random password
-func generateRandomPassword(length int) (string, error) {
-	b := make([]byte, length/2)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("failed to generate random password: %w", err)
-	}
-	return hex.EncodeToString(b), nil
 }
 
 // runEnvPreflightCheck verifies required environment variables before deployment

--- a/internal/cmd/logging.go
+++ b/internal/cmd/logging.go
@@ -1,0 +1,8 @@
+package cmd
+
+// cmdLogger adapts the cmd package printers to the deploy.Logger interface.
+type cmdLogger struct{}
+
+func (cmdLogger) Info(format string, args ...interface{})    { PrintInfo(format, args...) }
+func (cmdLogger) Success(format string, args ...interface{}) { PrintSuccess(format, args...) }
+func (cmdLogger) Warning(format string, args ...interface{}) { PrintWarning(format, args...) }

--- a/internal/deploy/database.go
+++ b/internal/deploy/database.go
@@ -1,0 +1,203 @@
+package deploy
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/generator"
+	"github.com/yoanbernabeu/frankendeploy/internal/security"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// DBReadinessAttempts is how many 1s attempts the readiness wait makes.
+var DBReadinessAttempts = 30
+
+// DeployManagedDatabase ensures the managed database container exists and
+// returns its DATABASE_URL.
+//
+// Credential safety: postgres/mysql/mariadb images only apply the *_PASSWORD
+// env vars when the data directory is EMPTY. Recreating the container with
+// freshly generated credentials while the data volume survives (VPS reboot,
+// container crash, lost .db_credentials) would save a DATABASE_URL that the
+// database never accepted — auth errors everywhere. So:
+//   - existing container (running or stopped) + credentials file → reuse
+//     (start the container if needed);
+//   - data volume exists but the credentials file is gone → fail explicitly
+//     instead of silently generating a password the database will ignore;
+//   - nothing exists → create container + volume with fresh credentials.
+func DeployManagedDatabase(ctx context.Context, client ssh.Executor, cfg *config.ProjectConfig, appPath string, log Logger) (string, error) {
+	if log == nil {
+		log = NopLogger{}
+	}
+
+	dbContainerName := fmt.Sprintf("%s-db", cfg.Name)
+	dbVolumeName := fmt.Sprintf("%s-data", dbContainerName)
+	dbName := strings.ReplaceAll(cfg.Name, "-", "_")
+	credentialsFile := filepath.Join(appPath, "shared", ".db_credentials")
+
+	// Get driver info from registry (single source of truth)
+	info, err := generator.GetDBDriverInfo(cfg.Database.Driver)
+	if err != nil {
+		return "", fmt.Errorf("unsupported database driver for managed mode: %s", cfg.Database.Driver)
+	}
+
+	// Read saved credentials (empty when the file is missing)
+	savedURL := ""
+	if credResult, credErr := client.Exec(ctx, fmt.Sprintf("cat %s 2>/dev/null", credentialsFile)); credErr == nil && credResult.ExitCode == 0 {
+		savedURL = strings.TrimSpace(credResult.Stdout)
+	}
+
+	// Any existing container (running or not)? -a is essential: after a VPS
+	// reboot without --restart, or a crash, the container exists but is
+	// stopped — recreating it with new credentials would corrupt the setup.
+	containerExists := false
+	containerRunning := false
+	if result, err := client.Exec(ctx, fmt.Sprintf("docker ps -aq -f name=^%s$", dbContainerName)); err == nil {
+		containerExists = strings.TrimSpace(result.Stdout) != ""
+	}
+	if containerExists {
+		if result, err := client.Exec(ctx, fmt.Sprintf("docker ps -q -f name=^%s$", dbContainerName)); err == nil {
+			containerRunning = strings.TrimSpace(result.Stdout) != ""
+		}
+	}
+
+	if containerExists && savedURL != "" {
+		if !containerRunning {
+			log.Info("Database container is stopped, starting it...")
+			result, err := client.Exec(ctx, fmt.Sprintf("docker start %s", dbContainerName))
+			if err != nil {
+				return "", fmt.Errorf("failed to start existing database container: %w", err)
+			}
+			if err := result.Err(); err != nil {
+				return "", fmt.Errorf("failed to start existing database container: %w", err)
+			}
+			if err := waitForDatabase(ctx, client, info, dbContainerName, savedURL); err != nil {
+				return "", err
+			}
+		}
+		return savedURL, nil
+	}
+
+	// Data volume without credentials: generating a new password would be
+	// ignored by the database (non-empty datadir) while the saved URL claims
+	// it — fail explicitly instead.
+	volumeExists := false
+	if result, err := client.Exec(ctx, fmt.Sprintf("docker volume ls -q -f name=^%s$", dbVolumeName)); err == nil {
+		volumeExists = strings.TrimSpace(result.Stdout) != ""
+	}
+	if volumeExists && savedURL == "" {
+		return "", fmt.Errorf("database volume %s exists but %s is missing: the existing data keeps its old password, so regenerating credentials would break authentication.\n"+
+			"Either restore the credentials file, or remove the old data to start fresh:\n"+
+			"  docker rm -f %s && docker volume rm %s",
+			dbVolumeName, credentialsFile, dbContainerName, dbVolumeName)
+	}
+	if containerExists && savedURL == "" {
+		// Container without volume and without credentials: safe to recreate
+		log.Warning("Existing database container has no saved credentials, recreating it...")
+	}
+
+	// Fresh setup: generate credentials
+	dbUser := cfg.Name
+	dbPassword, err := generateRandomPassword(24)
+	if err != nil {
+		return "", err
+	}
+
+	// Use configured version or registry default
+	version := cfg.Database.Version
+	if version == "" {
+		version = info.DefaultVersion
+	}
+
+	dockerImage := info.FullImage(version)
+	dockerEnv := info.BuildEnvArgs(
+		security.ShellEscape(dbUser),
+		security.ShellEscape(dbPassword),
+		security.ShellEscape(dbName),
+	)
+	databaseURL := info.BuildDatabaseURL(dbUser, dbPassword, dbContainerName, dbName, version)
+
+	// Remove any leftover container before recreation
+	_, _ = client.Exec(ctx, fmt.Sprintf("docker stop %s 2>/dev/null || true", dbContainerName))
+	_, _ = client.Exec(ctx, fmt.Sprintf("docker rm %s 2>/dev/null || true", dbContainerName))
+
+	// Create database container with persistent volume
+	dbRunCmd := fmt.Sprintf(`docker run -d --name %s \
+		--network %s \
+		--restart unless-stopped \
+		%s \
+		%s \
+		-v %s:%s \
+		%s`,
+		dbContainerName,
+		constants.NetworkName,
+		constants.DockerLogOptions,
+		dockerEnv,
+		dbVolumeName,
+		info.DataVolumePath,
+		dockerImage)
+
+	result, err := client.Exec(ctx, dbRunCmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to start database container: %w", err)
+	}
+	if err := result.Err(); err != nil {
+		return "", fmt.Errorf("failed to start database container: %w", err)
+	}
+
+	// Save credentials to file
+	if _, err := client.Exec(ctx, fmt.Sprintf("echo %s > %s", security.ShellEscape(databaseURL), credentialsFile)); err != nil {
+		return "", fmt.Errorf("failed to save database credentials: %w", err)
+	}
+	if _, err := client.Exec(ctx, fmt.Sprintf("chmod 600 %s", credentialsFile)); err != nil {
+		log.Warning("Could not set permissions on credentials file: %v", err)
+	}
+
+	log.Info("Waiting for database to be ready...")
+	if err := waitForDatabase(ctx, client, info, dbContainerName, databaseURL); err != nil {
+		return "", err
+	}
+
+	return databaseURL, nil
+}
+
+// waitForDatabase polls the driver health command until the database accepts
+// connections. A database that never becomes ready fails the deploy
+// explicitly (the silent continue meant migrations exploded later with a
+// confusing connection error).
+func waitForDatabase(ctx context.Context, client ssh.Executor, info generator.DBDriverInfo, containerName, databaseURL string) error {
+	user, password, _, err := parseDatabaseURL(databaseURL)
+	if err != nil {
+		return fmt.Errorf("cannot parse database URL for readiness check: %w", err)
+	}
+	for i := 0; i < DBReadinessAttempts; i++ {
+		healthCmd := info.BuildHealthCmd(
+			containerName,
+			security.ShellEscape(user),
+			security.ShellEscape(password),
+		)
+		checkResult, _ := client.Exec(ctx, healthCmd)
+		if checkResult != nil && checkResult.ExitCode == 0 {
+			return nil
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return fmt.Errorf("database %s did not become ready after %d seconds — check its logs: docker logs %s",
+		containerName, DBReadinessAttempts, containerName)
+}
+
+// generateRandomPassword generates a secure random password.
+func generateRandomPassword(length int) (string, error) {
+	b := make([]byte, length/2)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate random password: %w", err)
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/deploy/database_test.go
+++ b/internal/deploy/database_test.go
@@ -1,0 +1,161 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+func managedPgTestConfig() *config.ProjectConfig {
+	managed := true
+	cfg := &config.ProjectConfig{Name: "myapp"}
+	cfg.Database = config.DatabaseConfig{Driver: "pgsql", Version: "16", Managed: &managed}
+	return cfg
+}
+
+const savedTestURL = "postgresql://myapp:oldpass@myapp-db:5432/myapp?serverVersion=16&charset=utf8"
+
+// dbMock builds a MockExecutor scripted per command pattern.
+func dbMock(responses map[string]ssh.ExecResult) *ssh.MockExecutor {
+	return &ssh.MockExecutor{
+		ExecFunc: func(_ context.Context, command string) (*ssh.ExecResult, error) {
+			for pattern, result := range responses {
+				if strings.Contains(command, pattern) {
+					r := result
+					return &r, nil
+				}
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+}
+
+func TestDeployManagedDatabase_ReusesRunningContainerCredentials(t *testing.T) {
+	mock := dbMock(map[string]ssh.ExecResult{
+		"cat /opt/frankendeploy/apps/myapp/shared/.db_credentials": {Stdout: savedTestURL + "\n", ExitCode: 0},
+		"docker ps -aq": {Stdout: "abc123\n", ExitCode: 0},
+		"docker ps -q":  {Stdout: "abc123\n", ExitCode: 0},
+	})
+
+	url, err := DeployManagedDatabase(context.Background(), mock, managedPgTestConfig(), "/opt/frankendeploy/apps/myapp", nil)
+	if err != nil {
+		t.Fatalf("DeployManagedDatabase: %v", err)
+	}
+	if url != savedTestURL {
+		t.Errorf("expected saved URL to be reused, got %q", url)
+	}
+	for _, cmd := range mock.Commands {
+		if strings.Contains(cmd, "docker run") {
+			t.Errorf("must not recreate a running container with saved credentials: %s", cmd)
+		}
+	}
+}
+
+func TestDeployManagedDatabase_StartsStoppedContainerAndReusesCredentials(t *testing.T) {
+	// VPS rebooted: container exists but is NOT running. The old code only
+	// checked `docker ps -q`, regenerated a password the datadir ignores,
+	// and saved a wrong URL.
+	mock := dbMock(map[string]ssh.ExecResult{
+		"cat /opt/frankendeploy/apps/myapp/shared/.db_credentials": {Stdout: savedTestURL + "\n", ExitCode: 0},
+		"docker ps -aq":  {Stdout: "abc123\n", ExitCode: 0},
+		"docker ps -q -": {Stdout: "", ExitCode: 0}, // not running
+		"pg_isready":     {ExitCode: 0},
+	})
+
+	url, err := DeployManagedDatabase(context.Background(), mock, managedPgTestConfig(), "/opt/frankendeploy/apps/myapp", nil)
+	if err != nil {
+		t.Fatalf("DeployManagedDatabase: %v", err)
+	}
+	if url != savedTestURL {
+		t.Errorf("expected saved URL, got %q", url)
+	}
+	started := false
+	for _, cmd := range mock.Commands {
+		if strings.Contains(cmd, "docker start myapp-db") {
+			started = true
+		}
+		if strings.Contains(cmd, "docker run") {
+			t.Errorf("must docker start, not recreate: %s", cmd)
+		}
+	}
+	if !started {
+		t.Error("expected the stopped container to be started")
+	}
+}
+
+func TestDeployManagedDatabase_VolumeWithoutCredentialsFailsExplicitly(t *testing.T) {
+	mock := dbMock(map[string]ssh.ExecResult{
+		"cat /opt/frankendeploy/apps/myapp/shared/.db_credentials": {ExitCode: 1},
+		"docker ps -aq":    {Stdout: "", ExitCode: 0},
+		"docker volume ls": {Stdout: "myapp-db-data\n", ExitCode: 0},
+	})
+
+	_, err := DeployManagedDatabase(context.Background(), mock, managedPgTestConfig(), "/opt/frankendeploy/apps/myapp", nil)
+	if err == nil {
+		t.Fatal("a data volume without credentials must fail explicitly (regenerated password would be ignored by the datadir)")
+	}
+	if !strings.Contains(err.Error(), "docker volume rm") {
+		t.Errorf("the error must explain how to recover, got: %v", err)
+	}
+	for _, cmd := range mock.Commands {
+		if strings.Contains(cmd, "docker run") {
+			t.Errorf("must not create a container over an orphaned volume: %s", cmd)
+		}
+	}
+}
+
+func TestDeployManagedDatabase_FreshSetupCreatesAndSaves(t *testing.T) {
+	mock := dbMock(map[string]ssh.ExecResult{
+		"cat /opt/frankendeploy/apps/myapp/shared/.db_credentials": {ExitCode: 1},
+		"docker ps -aq":    {Stdout: "", ExitCode: 0},
+		"docker volume ls": {Stdout: "", ExitCode: 0},
+		"pg_isready":       {ExitCode: 0},
+	})
+
+	url, err := DeployManagedDatabase(context.Background(), mock, managedPgTestConfig(), "/opt/frankendeploy/apps/myapp", nil)
+	if err != nil {
+		t.Fatalf("DeployManagedDatabase: %v", err)
+	}
+	if !strings.HasPrefix(url, "postgresql://myapp:") {
+		t.Errorf("expected a fresh postgresql URL, got %q", url)
+	}
+	var ran, saved bool
+	for _, cmd := range mock.Commands {
+		if strings.Contains(cmd, "docker run") && strings.Contains(cmd, "postgres:16-alpine") {
+			ran = true
+		}
+		if strings.Contains(cmd, ".db_credentials") && strings.HasPrefix(cmd, "echo ") {
+			saved = true
+		}
+	}
+	if !ran {
+		t.Error("expected a docker run with the postgres image")
+	}
+	if !saved {
+		t.Error("expected credentials to be saved")
+	}
+}
+
+func TestDeployManagedDatabase_ReadinessTimeoutFails(t *testing.T) {
+	old := DBReadinessAttempts
+	DBReadinessAttempts = 2
+	defer func() { DBReadinessAttempts = old }()
+
+	mock := dbMock(map[string]ssh.ExecResult{
+		"cat /opt/frankendeploy/apps/myapp/shared/.db_credentials": {ExitCode: 1},
+		"docker ps -aq":    {Stdout: "", ExitCode: 0},
+		"docker volume ls": {Stdout: "", ExitCode: 0},
+		"pg_isready":       {ExitCode: 1}, // never ready
+	})
+
+	_, err := DeployManagedDatabase(context.Background(), mock, managedPgTestConfig(), "/opt/frankendeploy/apps/myapp", nil)
+	if err == nil {
+		t.Fatal("a database that never becomes ready must fail the deploy (the silent continue exploded later in migrations)")
+	}
+	if !strings.Contains(err.Error(), "docker logs") {
+		t.Errorf("the error must point at the container logs, got: %v", err)
+	}
+}

--- a/internal/deploy/orchestrator.go
+++ b/internal/deploy/orchestrator.go
@@ -1,0 +1,223 @@
+package deploy
+
+import "fmt"
+
+// Logger abstracts user-facing output so the orchestration can live outside
+// the cmd package and be tested without printing.
+type Logger interface {
+	Info(format string, args ...interface{})
+	Success(format string, args ...interface{})
+	Warning(format string, args ...interface{})
+}
+
+// NopLogger discards all output (tests).
+type NopLogger struct{}
+
+func (NopLogger) Info(string, ...interface{})    {}
+func (NopLogger) Success(string, ...interface{}) {}
+func (NopLogger) Warning(string, ...interface{}) {}
+
+// Steps holds the injectable operations of a blue-green deployment. Each
+// field is provided by the caller (production wiring in cmd/deploy.go, fakes
+// in tests): the orchestration below decides ordering, rollback and
+// force/skip semantics — the exact logic that was previously untestable
+// inside a 1000-line runDeploy.
+type Steps struct {
+	// PrepareRelease creates release directories and shared volumes.
+	PrepareRelease func() error
+	// OldContainerExists reports whether the app container currently runs.
+	OldContainerExists func() bool
+	// StartNewContainer starts the new version under a temporary name.
+	StartNewContainer func() error
+	// BackupDatabase dumps the managed database and returns the backup path.
+	BackupDatabase func() (string, error)
+	// RunPreDeployHooks runs pre_deploy hooks on the NEW container.
+	RunPreDeployHooks func() error
+	// CheckMigrationState warns about pending/empty migrations (informational).
+	CheckMigrationState func()
+	// HealthCheck probes the NEW container.
+	HealthCheck func() error
+	// ShowContainerLogs prints the new container logs after a failed health check.
+	ShowContainerLogs func()
+	// SwapContainers promotes the new container to the live name.
+	SwapContainers func(oldExists bool) error
+	// DeployWorkers starts the Messenger worker container.
+	DeployWorkers func() error
+	// RunPostDeployHooks runs post_deploy hooks on the live container.
+	RunPostDeployHooks func() error
+	// CaddyAppConfigExists reports whether the app already has a Caddy config.
+	CaddyAppConfigExists func() bool
+	// UpdateCaddy writes the app Caddy config and reloads the proxy.
+	UpdateCaddy func() error
+	// Cleanup removes old releases and images (best-effort).
+	Cleanup func()
+	// RollbackNewContainer removes the temporary container after a failure.
+	RollbackNewContainer func(state *DeployState)
+	// WarnMigrationRollback explains that a rollback does NOT undo the schema.
+	WarnMigrationRollback func(situation, backupPath string)
+}
+
+// Options carries the deployment decisions the orchestration needs.
+type Options struct {
+	Force             bool
+	SkipHealthcheck   bool
+	HasPreDeployHooks bool
+	HasMigrationHook  bool
+	// BackupEligible is true for a managed database with a known URL.
+	BackupEligible     bool
+	HasPostDeployHooks bool
+	MessengerEnabled   bool
+	Domain             string
+	Logger             Logger
+}
+
+// RunPipeline executes the blue-green deployment orchestration: prepare →
+// start temp container → pre-deploy hooks (with automatic DB backup) →
+// health check → swap → workers → post-deploy hooks → Caddy → cleanup.
+// Failure semantics:
+//   - backup/pre-hooks/health failures roll back the temp container and abort
+//     (unless --force);
+//   - a swap failure rolls back and aborts (force does not apply: a failed
+//     swap means the old container is still, or again, serving);
+//   - worker/post-hooks failures only warn;
+//   - a Caddy failure aborts on the app's FIRST public exposure (the app
+//     would be running but unreachable), warns otherwise.
+func RunPipeline(state *DeployState, steps Steps, opts Options) error {
+	log := opts.Logger
+	if log == nil {
+		log = NopLogger{}
+	}
+
+	// Step 4: Prepare release directories and shared volumes
+	log.Info("Preparing release...")
+	state.Phase = PhasePrepareRelease
+	if err := steps.PrepareRelease(); err != nil {
+		return fmt.Errorf("deployment failed: %w", err)
+	}
+
+	// Check if old container exists (for swap phase)
+	state.OldContainerExists = steps.OldContainerExists()
+
+	// Step 5: Start new container with temporary name (old still running)
+	log.Info("Starting new version (blue-green)...")
+	state.Phase = PhaseStartNewContainer
+	if err := steps.StartNewContainer(); err != nil {
+		return fmt.Errorf("deployment failed: %w", err)
+	}
+
+	// Step 6: Pre-deploy hooks on the NEW container
+	migrationAttempted := false
+	var dbBackupPath string
+	if opts.HasPreDeployHooks {
+		// Step 6a: Automatic database backup before any migration. Migrations
+		// run while the old code still serves traffic: if anything fails
+		// afterwards, the container rollback does NOT roll the schema back —
+		// the dump is the only safety net.
+		if opts.HasMigrationHook && opts.BackupEligible {
+			log.Info("Backing up database before migration...")
+			backupPath, err := steps.BackupDatabase()
+			if err != nil {
+				if !opts.Force {
+					log.Warning("Database backup failed, rolling back...")
+					steps.RollbackNewContainer(state)
+					return fmt.Errorf("database backup failed (use --force to deploy without a backup): %w", err)
+				}
+				log.Warning("Database backup failed but continuing (--force): %v", err)
+			} else {
+				dbBackupPath = backupPath
+				log.Success("Database backup: %s", backupPath)
+			}
+		}
+
+		log.Info("Running pre-deploy hooks...")
+		state.Phase = PhasePreDeployHooks
+		migrationAttempted = opts.HasMigrationHook
+		if err := steps.RunPreDeployHooks(); err != nil {
+			if !opts.Force {
+				log.Warning("Pre-deploy hooks failed, rolling back...")
+				steps.RollbackNewContainer(state)
+				if opts.HasMigrationHook {
+					steps.WarnMigrationRollback("The migration may have been partially applied (non-transactional DDL on MySQL/MariaDB leaves a partial schema).", dbBackupPath)
+				}
+				return fmt.Errorf("pre-deploy hooks failed: %w", err)
+			}
+			log.Warning("Pre-deploy hooks failed but continuing (--force)")
+		}
+
+		if opts.HasMigrationHook {
+			steps.CheckMigrationState()
+		}
+	}
+
+	// Step 7: Health check on the NEW container (old still running = zero downtime)
+	if opts.SkipHealthcheck {
+		log.Warning("Health check skipped (--skip-healthcheck)")
+	} else {
+		log.Info("Running health check...")
+		state.Phase = PhaseHealthCheck
+		if err := steps.HealthCheck(); err != nil {
+			steps.ShowContainerLogs()
+			if !opts.Force {
+				log.Warning("Health check failed, rolling back...")
+				steps.RollbackNewContainer(state)
+				if migrationAttempted {
+					steps.WarnMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
+				}
+				return fmt.Errorf("deployment failed health check: %w", err)
+			}
+			log.Warning("Health check failed but continuing (--force)")
+		} else {
+			log.Success("Health check passed")
+		}
+	}
+
+	// Step 8: Swap containers
+	log.Info("Swapping containers...")
+	state.Phase = PhaseSwapContainers
+	if err := steps.SwapContainers(state.OldContainerExists); err != nil {
+		steps.RollbackNewContainer(state)
+		if migrationAttempted {
+			steps.WarnMigrationRollback("The database was already migrated during this deploy.", dbBackupPath)
+		}
+		return fmt.Errorf("swap failed: %w", err)
+	}
+
+	// Step 8b: Messenger worker
+	if opts.MessengerEnabled {
+		log.Info("Starting Messenger worker...")
+		if err := steps.DeployWorkers(); err != nil {
+			log.Warning("Failed to start Messenger worker: %v", err)
+		} else {
+			log.Success("Messenger worker started")
+		}
+	}
+
+	// Step 9: Post-deploy hooks (the new version is live: failures only warn)
+	state.Phase = PhasePostDeployHooks
+	if opts.HasPostDeployHooks {
+		log.Info("Running post-deploy hooks...")
+		if err := steps.RunPostDeployHooks(); err != nil {
+			log.Warning("Post-deploy hooks failed: %v", err)
+		}
+	}
+
+	// Step 10: Caddy. On the app's FIRST public exposure this is THE
+	// condition for reachability: failing must fail the deploy instead of
+	// printing a success message with an unreachable https URL.
+	firstExposure := opts.Domain != "" && !steps.CaddyAppConfigExists()
+	log.Info("Updating reverse proxy...")
+	if err := steps.UpdateCaddy(); err != nil {
+		if firstExposure {
+			return fmt.Errorf("reverse proxy configuration failed — the application is running on the server but NOT publicly reachable: %w", err)
+		}
+		log.Warning("Failed to update Caddy: %v", err)
+	}
+
+	// Step 11: Cleanup (best-effort)
+	state.Phase = PhaseCleanup
+	log.Info("Cleaning up old releases...")
+	steps.Cleanup()
+	state.Phase = PhaseDone
+
+	return nil
+}

--- a/internal/deploy/orchestrator_test.go
+++ b/internal/deploy/orchestrator_test.go
@@ -1,0 +1,290 @@
+package deploy
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeSteps builds a Steps where every operation succeeds and records its
+// name; individual tests override the operations they want to fail.
+type stepRecorder struct {
+	calls      []string
+	rolledBack bool
+	warnedMig  []string
+}
+
+func (r *stepRecorder) record(name string) { r.calls = append(r.calls, name) }
+
+func (r *stepRecorder) called(name string) bool {
+	for _, c := range r.calls {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+func makeSteps(r *stepRecorder) Steps {
+	return Steps{
+		PrepareRelease:       func() error { r.record("prepare"); return nil },
+		OldContainerExists:   func() bool { r.record("old-exists"); return true },
+		StartNewContainer:    func() error { r.record("start"); return nil },
+		BackupDatabase:       func() (string, error) { r.record("backup"); return "/backups/dump.sql.gz", nil },
+		RunPreDeployHooks:    func() error { r.record("pre-hooks"); return nil },
+		CheckMigrationState:  func() { r.record("migration-check") },
+		HealthCheck:          func() error { r.record("health"); return nil },
+		ShowContainerLogs:    func() { r.record("logs") },
+		SwapContainers:       func(oldExists bool) error { r.record("swap"); return nil },
+		DeployWorkers:        func() error { r.record("workers"); return nil },
+		RunPostDeployHooks:   func() error { r.record("post-hooks"); return nil },
+		CaddyAppConfigExists: func() bool { r.record("caddy-exists"); return true },
+		UpdateCaddy:          func() error { r.record("caddy"); return nil },
+		Cleanup:              func() { r.record("cleanup") },
+		RollbackNewContainer: func(state *DeployState) { r.record("rollback"); r.rolledBack = true },
+		WarnMigrationRollback: func(situation, backupPath string) {
+			r.record("warn-migration")
+			r.warnedMig = append(r.warnedMig, situation)
+		},
+	}
+}
+
+func fullOptions() Options {
+	return Options{
+		HasPreDeployHooks:  true,
+		HasMigrationHook:   true,
+		BackupEligible:     true,
+		HasPostDeployHooks: true,
+		MessengerEnabled:   true,
+		Domain:             "example.com",
+	}
+}
+
+func TestRunPipeline_HappyPathOrder(t *testing.T) {
+	r := &stepRecorder{}
+	state := NewDeployState("myapp")
+
+	if err := RunPipeline(state, makeSteps(r), fullOptions()); err != nil {
+		t.Fatalf("RunPipeline: %v", err)
+	}
+
+	want := []string{"prepare", "old-exists", "start", "backup", "pre-hooks", "migration-check", "health", "swap", "workers", "post-hooks", "caddy-exists", "caddy", "cleanup"}
+	got := strings.Join(r.calls, ",")
+	if got != strings.Join(want, ",") {
+		t.Errorf("unexpected step order:\n got %s\nwant %s", got, strings.Join(want, ","))
+	}
+	if state.Phase != PhaseDone {
+		t.Errorf("expected PhaseDone, got %s", state.Phase)
+	}
+}
+
+func TestRunPipeline_PrepareFailureAborts(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.PrepareRelease = func() error { return errors.New("disk full") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if r.called("start") {
+		t.Error("must not start a container after a failed prepare")
+	}
+}
+
+func TestRunPipeline_BackupFailureRollsBack(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.BackupDatabase = func() (string, error) { return "", errors.New("dump failed") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("expected backup error mentioning --force, got %v", err)
+	}
+	if !r.rolledBack {
+		t.Error("temp container must be rolled back after a failed backup")
+	}
+	if r.called("pre-hooks") {
+		t.Error("pre-deploy hooks (migrations!) must not run without a backup")
+	}
+}
+
+func TestRunPipeline_BackupFailureForceContinues(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.BackupDatabase = func() (string, error) { return "", errors.New("dump failed") }
+	opts := fullOptions()
+	opts.Force = true
+
+	if err := RunPipeline(NewDeployState("myapp"), steps, opts); err != nil {
+		t.Fatalf("--force must continue after a failed backup, got %v", err)
+	}
+	if !r.called("swap") {
+		t.Error("expected the deploy to reach the swap with --force")
+	}
+}
+
+func TestRunPipeline_PreHookFailureRollsBackAndWarnsMigration(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.RunPreDeployHooks = func() error { return errors.New("migration exploded") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !r.rolledBack {
+		t.Error("expected rollback")
+	}
+	if len(r.warnedMig) == 0 || !strings.Contains(r.warnedMig[0], "partially applied") {
+		t.Errorf("expected the partial-migration warning, got %v", r.warnedMig)
+	}
+	if r.called("health") {
+		t.Error("health check must not run after failed pre-hooks")
+	}
+}
+
+func TestRunPipeline_HealthFailureShowsLogsAndRollsBack(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.HealthCheck = func() error { return errors.New("503") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !r.called("logs") {
+		t.Error("container logs must be shown on health check failure")
+	}
+	if !r.rolledBack {
+		t.Error("expected rollback")
+	}
+	// Migration already ran: the user must be told the schema is not rolled back
+	if len(r.warnedMig) == 0 || !strings.Contains(r.warnedMig[0], "already migrated") {
+		t.Errorf("expected the already-migrated warning, got %v", r.warnedMig)
+	}
+	if r.called("swap") {
+		t.Error("must not swap after a failed health check")
+	}
+}
+
+func TestRunPipeline_SkipHealthcheck(t *testing.T) {
+	r := &stepRecorder{}
+	opts := fullOptions()
+	opts.SkipHealthcheck = true
+
+	if err := RunPipeline(NewDeployState("myapp"), makeSteps(r), opts); err != nil {
+		t.Fatalf("RunPipeline: %v", err)
+	}
+	if r.called("health") {
+		t.Error("health check must be skipped with --skip-healthcheck")
+	}
+	if !r.called("swap") {
+		t.Error("swap must still happen")
+	}
+}
+
+func TestRunPipeline_HealthFailureForceContinues(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.HealthCheck = func() error { return errors.New("503") }
+	opts := fullOptions()
+	opts.Force = true
+
+	if err := RunPipeline(NewDeployState("myapp"), steps, opts); err != nil {
+		t.Fatalf("--force must continue after failed health check, got %v", err)
+	}
+	if r.rolledBack {
+		t.Error("no rollback with --force")
+	}
+	if !r.called("swap") {
+		t.Error("expected swap with --force")
+	}
+}
+
+func TestRunPipeline_SwapFailureRollsBack(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.SwapContainers = func(bool) error { return errors.New("rename failed") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil || !strings.Contains(err.Error(), "swap failed") {
+		t.Fatalf("expected swap error, got %v", err)
+	}
+	if !r.rolledBack {
+		t.Error("expected rollback after swap failure")
+	}
+	if r.called("caddy") {
+		t.Error("Caddy must not be updated after a failed swap")
+	}
+}
+
+func TestRunPipeline_WorkerAndPostHookFailuresOnlyWarn(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.DeployWorkers = func() error { return errors.New("worker boom") }
+	steps.RunPostDeployHooks = func() error { return errors.New("hook boom") }
+
+	if err := RunPipeline(NewDeployState("myapp"), steps, fullOptions()); err != nil {
+		t.Fatalf("worker/post-hook failures must not fail the deploy, got %v", err)
+	}
+	if !r.called("cleanup") {
+		t.Error("cleanup must still run")
+	}
+}
+
+func TestRunPipeline_CaddyFailureFirstExposureAborts(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.CaddyAppConfigExists = func() bool { return false } // first exposure
+	steps.UpdateCaddy = func() error { return errors.New("reload failed") }
+
+	err := RunPipeline(NewDeployState("myapp"), steps, fullOptions())
+	if err == nil || !strings.Contains(err.Error(), "NOT publicly reachable") {
+		t.Fatalf("first-exposure Caddy failure must fail the deploy, got %v", err)
+	}
+}
+
+func TestRunPipeline_CaddyFailureLaterDeployOnlyWarns(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.UpdateCaddy = func() error { return errors.New("reload failed") }
+	// CaddyAppConfigExists returns true: existing config still routes traffic
+
+	if err := RunPipeline(NewDeployState("myapp"), makePatchedSteps(steps), fullOptions()); err != nil {
+		t.Fatalf("Caddy failure on a later deploy must only warn, got %v", err)
+	}
+}
+
+// makePatchedSteps is an identity helper keeping the test above readable.
+func makePatchedSteps(s Steps) Steps { return s }
+
+func TestRunPipeline_NoDomainNeverFirstExposure(t *testing.T) {
+	r := &stepRecorder{}
+	steps := makeSteps(r)
+	steps.CaddyAppConfigExists = func() bool { return false }
+	steps.UpdateCaddy = func() error { return errors.New("reload failed") }
+	opts := fullOptions()
+	opts.Domain = ""
+
+	if err := RunPipeline(NewDeployState("myapp"), steps, opts); err != nil {
+		t.Fatalf("without a domain a Caddy failure must only warn, got %v", err)
+	}
+}
+
+func TestRunPipeline_NoHooksSkipsBackupAndHooks(t *testing.T) {
+	r := &stepRecorder{}
+	opts := fullOptions()
+	opts.HasPreDeployHooks = false
+	opts.HasPostDeployHooks = false
+	opts.MessengerEnabled = false
+
+	if err := RunPipeline(NewDeployState("myapp"), makeSteps(r), opts); err != nil {
+		t.Fatalf("RunPipeline: %v", err)
+	}
+	for _, forbidden := range []string{"backup", "pre-hooks", "post-hooks", "workers"} {
+		if r.called(forbidden) {
+			t.Errorf("step %q must not run without hooks/messenger", forbidden)
+		}
+	}
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 // ─── Validation: DockerfileData ──────────────────────────────────────────────
@@ -1632,5 +1633,87 @@ func TestDockerfile_NoTailwindWithoutBundle(t *testing.T) {
 	}
 	if strings.Contains(out, "tailwind:build") {
 		t.Errorf("tailwind:build must not appear without the bundle:\n%s", out)
+	}
+}
+
+// --- Issue #61: generated artifacts must parse ---
+
+func fullFeaturedConfig() *config.ProjectConfig {
+	managed := true
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP: config.PHPConfig{
+			Version:    "8.3",
+			Extensions: []string{"intl", "opcache", "pdo_pgsql"},
+			IniValues:  []string{"memory_limit=256M"},
+		},
+		Assets: config.AssetsConfig{BuildTool: "assetmapper", OutputDir: "public/assets", Tailwind: true},
+	}
+	cfg.FrankenPHP.Worker = true
+	cfg.Database = config.DatabaseConfig{Driver: "pgsql", Version: "16", Managed: &managed}
+	cfg.Messenger = config.MessengerConfig{Enabled: true, Transports: []string{"async"}}
+	cfg.Mailer = config.MailerConfig{Enabled: true}
+	cfg.Deploy.Domain = "myapp.example.com"
+	cfg.Deploy.HealthcheckPath = "/health"
+	cfg.Deploy.MemoryLimit = "512m"
+	cfg.Deploy.CPULimit = "1.5"
+	cfg.Env.Prod = map[string]string{"TRUSTED_PROXIES": "127.0.0.1"}
+	cfg.Env.Dev = map[string]string{"APP_DEBUG": "1"}
+	return cfg
+}
+
+func TestGeneratedComposeFilesParseAsYAML(t *testing.T) {
+	gen := NewComposeGenerator(fullFeaturedConfig())
+
+	for name, generate := range map[string]func() (string, error){
+		"compose.yaml":      gen.GenerateDev,
+		"compose.prod.yaml": gen.GenerateProd,
+	} {
+		out, err := generate()
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		var parsed map[string]interface{}
+		if err := yaml.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Errorf("%s is not valid YAML: %v\n%s", name, err, out)
+		}
+		if _, ok := parsed["services"]; !ok {
+			t.Errorf("%s: missing services key", name)
+		}
+	}
+}
+
+func TestGeneratedComposeFilesParseAsYAML_AllDrivers(t *testing.T) {
+	for _, driver := range []string{"pgsql", "mysql", "mariadb", "sqlite"} {
+		cfg := fullFeaturedConfig()
+		managed := driver != "sqlite"
+		cfg.Database = config.DatabaseConfig{Driver: driver, Version: "", Managed: &managed}
+		if driver == "sqlite" {
+			cfg.Database.Managed = nil
+			cfg.Database.Path = "var/data.db"
+		}
+		if driver != "" {
+			info, err := GetDBDriverInfo(driver)
+			if err == nil {
+				cfg.Database.Version = info.DefaultVersion
+			} else {
+				cfg.Database.Version = "3"
+			}
+		}
+
+		gen := NewComposeGenerator(cfg)
+		for name, generate := range map[string]func() (string, error){
+			"dev":  gen.GenerateDev,
+			"prod": gen.GenerateProd,
+		} {
+			out, err := generate()
+			if err != nil {
+				t.Fatalf("%s/%s: %v", driver, name, err)
+			}
+			var parsed map[string]interface{}
+			if err := yaml.Unmarshal([]byte(out), &parsed); err != nil {
+				t.Errorf("%s/%s is not valid YAML: %v", driver, name, err)
+			}
+		}
 	}
 }

--- a/internal/generator/templates/compose-dev.tmpl
+++ b/internal/generator/templates/compose-dev.tmpl
@@ -19,13 +19,21 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     environment:
+      # Defaults below are only emitted when not overridden in env.dev:
+      # a duplicated mapping key is invalid YAML
+{{- if not (index .Env.Dev "SERVER_NAME") }}
       # SECURITY: Use non-privileged port {{ appPort }} for non-root execution
       # Never default to the production domain here: Caddy would attempt real
       # Let's Encrypt issuance from the local machine
       SERVER_NAME: "${SERVER_NAME:-localhost, :{{ appPort }}}"
+{{- end }}
+{{- if not (index .Env.Dev "APP_ENV") }}
       APP_ENV: dev
+{{- end }}
+{{- if not (index .Env.Dev "APP_DEBUG") }}
       APP_DEBUG: "1"
-{{- if .Database.Driver }}
+{{- end }}
+{{- if and .Database.Driver (not (index .Env.Dev "DATABASE_URL")) }}
       DATABASE_URL: "{{ yamlEscape .DatabaseURL }}"
 {{- end }}
 {{- if .Env.Dev }}

--- a/internal/generator/templates/compose-prod.tmpl
+++ b/internal/generator/templates/compose-prod.tmpl
@@ -17,9 +17,17 @@ services:
     expose:
       - "{{ appPort }}"
     environment:
+      # Defaults below are only emitted when not overridden in env.prod:
+      # a duplicated mapping key is invalid YAML
+{{- if not (index .Env.Prod "SERVER_NAME") }}
       SERVER_NAME: ":{{ appPort }}"
+{{- end }}
+{{- if not (index .Env.Prod "APP_ENV") }}
       APP_ENV: prod
+{{- end }}
+{{- if not (index .Env.Prod "APP_DEBUG") }}
       APP_DEBUG: "0"
+{{- end }}
 {{- if .Database.Driver }}
       # DATABASE_URL: Set via .env.local on the server
 {{- end }}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -336,11 +336,9 @@ func (s *Scanner) generateDefaultHooks(result *config.ScanResult) config.Hooks {
 			"php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration")
 	}
 
-	// Always add cache warmup for Symfony
-	if result.IsSymfony {
-		hooks.PostDeploy = append(hooks.PostDeploy,
-			"php bin/console cache:warmup")
-	}
+	// No default cache:warmup post_deploy hook: the cache is already warmed
+	// at image build time (Dockerfile runs cache:warmup), and a post-deploy
+	// warmup would run on the LIVE container after the swap.
 
 	return hooks
 }


### PR DESCRIPTION
## Summary

The blue-green orchestration leaves `runDeploy` (1084 lines, zero orchestration tests) and becomes `deploy.RunPipeline` with injectable steps — the failure semantics (rollback triggering, `--force`, `--skip-healthcheck`, first-exposure Caddy) are now unit-tested. Includes the managed-database credentials bug fix.

## Changes

- **`internal/deploy/orchestrator.go`**: `RunPipeline(state, Steps, Options)` — faithful extraction of steps 4–11; `DeployState`/phases are now actually driven (they were decorative). `cmd/deploy.go` wires its existing step functions as closures.
- **14 orchestrator tests**: step ordering; rollback on backup/pre-hook/health/swap failures; `--force` continuing after backup/health failures; `--skip-healthcheck`; worker/post-hook failures only warning; first-exposure Caddy failure aborting vs later deploys warning; migration schema-not-rolled-back warnings.
- **`DeployManagedDatabase` extracted + fixed** (5 tests):
  - stopped container (VPS reboot/crash) with saved credentials → `docker start` + reuse — previously recreated with a **new** password that postgres/mysql ignore when the datadir exists (saved URL wrong, auth errors everywhere)
  - orphaned data volume without credentials file → explicit failure with recovery commands
  - readiness wait now fails the deploy after 30 s instead of continuing silently into exploding migrations
- **Default `cache:warmup` post_deploy hook removed** (scanner): warmed at build time since the Dockerfile hardening; the hook ran on the LIVE container after the swap.
- **Golden tests**: generated compose files must `yaml.Unmarshal` for pgsql/mysql/mariadb/sqlite — **caught a real bug**: duplicated mapping keys (`APP_DEBUG`…) when overridden via `env.dev`/`env.prod`; template defaults are now emitted only when not overridden (user precedence preserved).

Not done here (kept out deliberately): Cobra flags as mutated globals (pure churn, no behavior change) — can be a follow-up.

## Test Plan

- `make pre-commit` green (802 tests, race detection)
- **Live nominal deploy on the VPS**: green, worker mode intact
- **Live failure path**: deploy with a broken `healthcheck_path` → health timeout after the 90 s window → "rolling back" → exit 1 with a clear error; the previous version still serves (HTTP 200), no orphaned `demo-new` container, `current` symlink untouched

## Related Issue

Closes #61

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g6xzbLBxeu81U1LYNbg3P