### PR TITLE
feat(worker): support the native FrankenPHP runner of symfony/runtime >= 7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **FrankenPHP worker mode works with the native Symfony runtime**: `symfony/runtime` >= 7.4 ships the worker runner itself, so `init` auto-enables worker mode on it, `build` no longer demands `runtime/frankenphp-symfony`, and the generated Caddyfile only forces `APP_RUNTIME` for the legacy package (with the native runtime that override pointed to a missing class) - @yoanbernabeu
+
 ## [0.13.0] - 2026-08-28
 
 This release closes the full production-readiness audit (24/24 issues): FrankenPHP worker mode, a `doctor` preflight command, pure-Go SFTP transfers, and a deployment pipeline whose failure paths are actually tested. Every change was validated live on a real VPS, including the rollback path (deliberately broken health check → previous version kept serving).

--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -38,8 +38,9 @@ php:
 frankenphp:
   # Worker mode: boots the Symfony kernel once and keeps it in memory
   # between requests (significant latency improvement).
-  # Requires the runtime/frankenphp-symfony composer package.
-  # Auto-enabled by 'frankendeploy init' when the package is detected.
+  # Requires symfony/runtime >= 7.4 (native worker runner) or the
+  # runtime/frankenphp-symfony composer package.
+  # Auto-enabled by 'frankendeploy init' when either is detected.
   worker: true
 
 # Database Configuration (optional)
@@ -186,10 +187,11 @@ frankenphp:
 
 Requirements and constraints:
 
-- The `runtime/frankenphp-symfony` composer package must be installed (`composer require runtime/frankenphp-symfony`). `frankendeploy build` fails with a clear message if it is missing.
+- A FrankenPHP worker runtime must be installed: `symfony/runtime` >= 7.4 ships the worker runner natively (nothing to add on a recent Symfony), older apps can use the `runtime/frankenphp-symfony` package. `frankendeploy build` fails with a clear message if neither is present.
+- The generated Caddyfile only forces `APP_RUNTIME` for `runtime/frankenphp-symfony`; with the native runtime, Symfony selects the worker runner itself.
 - **The application must be stateless**: any static property or service state survives between requests. Symfony services are reset automatically, but hand-written static caches are not.
 - Memory leaks surface as automatic worker restarts (FrankenPHP restarts workers hitting their memory limit).
-- `frankendeploy init` enables it automatically (with a warning) when the package is detected. Opt out with `worker: false`.
+- `frankendeploy init` enables it automatically (with a warning) when a worker runtime is detected. Opt out with `worker: false`.
 - Worker mode applies to **production only** — the dev environment keeps classic mode for easier debugging.
 
 When enabled, `frankendeploy build` generates a `Caddyfile` at the project root that is baked into the production image.

--- a/internal/cmd/build.go
+++ b/internal/cmd/build.go
@@ -46,8 +46,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("configuration validation failed: %w", errors)
 	}
 
-	// Worker mode requires the FrankenPHP Symfony runtime: without it the
-	// container would crash-loop at boot (APP_RUNTIME points to a missing class)
+	// Worker mode requires a FrankenPHP worker runtime: without one the
+	// container would crash-loop at boot (no runner handles the worker loop)
 	if cfg.FrankenPHP.Worker {
 		if err := checkWorkerRuntime(); err != nil {
 			return err
@@ -105,16 +105,18 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// checkWorkerRuntime verifies that runtime/frankenphp-symfony is present in
-// composer.json before generating worker-mode artifacts.
+// checkWorkerRuntime verifies that composer.json ships a FrankenPHP worker
+// runtime (symfony/runtime >= 7.4, or runtime/frankenphp-symfony) before
+// generating worker-mode artifacts.
 func checkWorkerRuntime() error {
 	comp, err := scanner.New(".").ParseComposer()
 	if err != nil {
 		return fmt.Errorf("frankenphp.worker is enabled but composer.json cannot be read: %w", err)
 	}
-	if !comp.HasPackage("runtime/frankenphp-symfony") {
-		return fmt.Errorf("frankenphp.worker is enabled but runtime/frankenphp-symfony is missing from composer.json.\n" +
-			"Install it with: composer require runtime/frankenphp-symfony\n" +
+	if !comp.HasFrankenPHPWorkerRuntime() {
+		return fmt.Errorf("frankenphp.worker is enabled but composer.json has no FrankenPHP worker runtime: " +
+			"symfony/runtime >= 7.4 (ships the worker runner natively) or runtime/frankenphp-symfony is required.\n" +
+			"Upgrade with: composer require symfony/runtime:^7.4\n" +
 			"Or disable worker mode: set frankenphp.worker: false in frankendeploy.yaml")
 	}
 	return nil

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -19,8 +19,9 @@ type ProjectConfig struct {
 type FrankenPHPConfig struct {
 	// Worker enables FrankenPHP worker mode in production: the Symfony
 	// kernel is booted once and kept in memory between requests.
-	// Requires the runtime/frankenphp-symfony composer package and a
-	// stateless application (no static state shared between requests).
+	// Requires symfony/runtime >= 7.4 (native worker runner) or the
+	// runtime/frankenphp-symfony package, and a stateless application
+	// (no static state shared between requests).
 	Worker bool `yaml:"worker,omitempty"`
 }
 
@@ -181,8 +182,8 @@ type ScanResult struct {
 	HasMessenger   bool
 	HasMailer      bool
 	HasAPIPlatform bool
-	// HasFrankenPHPRuntime is true when runtime/frankenphp-symfony is in
-	// composer.json, making the app eligible for FrankenPHP worker mode.
+	// HasFrankenPHPRuntime is true when the app can boot in FrankenPHP
+	// worker mode: symfony/runtime >= 7.4 or runtime/frankenphp-symfony.
 	HasFrankenPHPRuntime bool
 	// HasScheduler is true when symfony/scheduler is installed: its
 	// scheduler_* transports must be consumed or scheduled tasks

--- a/internal/generator/dockerfile.go
+++ b/internal/generator/dockerfile.go
@@ -1,6 +1,7 @@
 package generator
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -77,6 +78,24 @@ func hasPreloadFile() bool {
 	return err == nil && !info.IsDir()
 }
 
+// hasLegacyFrankenPHPRuntime reports whether composer.json (in the current
+// directory, like hasPreloadFile) requires runtime/frankenphp-symfony, the
+// only runtime that needs the APP_RUNTIME override in the worker Caddyfile.
+func hasLegacyFrankenPHPRuntime() bool {
+	data, err := os.ReadFile("composer.json")
+	if err != nil {
+		return false
+	}
+	var composer struct {
+		Require map[string]string `json:"require"`
+	}
+	if err := json.Unmarshal(data, &composer); err != nil {
+		return false
+	}
+	_, ok := composer.Require["runtime/frankenphp-symfony"]
+	return ok
+}
+
 // WriteDockerfile writes the Dockerfile to the specified path
 func (g *DockerfileGenerator) WriteDockerfile(path string) error {
 	if path == "" {
@@ -121,12 +140,20 @@ func (g *DockerfileGenerator) WriteDockerignore(path string) error {
 // CaddyfileData holds data for the app Caddyfile template (worker mode).
 type CaddyfileData struct {
 	Name string
+	// LegacyRuntime is true when the app relies on runtime/frankenphp-symfony,
+	// whose Runtime class must be forced through APP_RUNTIME. With
+	// symfony/runtime >= 7.4 the worker runner is picked automatically and the
+	// override would point to a class that does not exist.
+	LegacyRuntime bool
 }
 
 // GenerateCaddyfile generates the app-level Caddyfile enabling FrankenPHP
 // worker mode. Only relevant when config frankenphp.worker is true.
 func (g *DockerfileGenerator) GenerateCaddyfile() (string, error) {
-	return g.loader.Execute("caddyfile.tmpl", CaddyfileData{Name: g.config.Name})
+	return g.loader.Execute("caddyfile.tmpl", CaddyfileData{
+		Name:          g.config.Name,
+		LegacyRuntime: hasLegacyFrankenPHPRuntime(),
+	})
 }
 
 // WriteCaddyfile writes the app Caddyfile to the specified path.

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1,6 +1,8 @@
 package generator
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -1535,7 +1537,6 @@ func TestGenerateCaddyfile_WorkerBlock(t *testing.T) {
 	for _, want := range []string{
 		"worker {",
 		"file ./public/index.php",
-		`env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime`,
 		"{$SERVER_NAME:localhost}",
 		"php_server",
 		"{$FRANKENPHP_CONFIG}",
@@ -1544,6 +1545,34 @@ func TestGenerateCaddyfile_WorkerBlock(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("generated Caddyfile missing %q:\n%s", want, out)
 		}
+	}
+	// symfony/runtime >= 7.4 selects the worker runner itself: forcing the
+	// legacy Runtime class would point to a missing class
+	if strings.Contains(out, "APP_RUNTIME") {
+		t.Errorf("generated Caddyfile must not force APP_RUNTIME without runtime/frankenphp-symfony:\n%s", out)
+	}
+}
+
+func TestGenerateCaddyfile_LegacyRuntimeForcesAppRuntime(t *testing.T) {
+	dir := t.TempDir()
+	composer := `{"require": {"symfony/framework-bundle": "^7.1", "runtime/frankenphp-symfony": "^0.2"}}`
+	if err := os.WriteFile(filepath.Join(dir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	cfg := &config.ProjectConfig{
+		Name: "myapp",
+		PHP:  config.PHPConfig{Version: "8.3"},
+	}
+	cfg.FrankenPHP.Worker = true
+
+	out, err := NewDockerfileGenerator(cfg).GenerateCaddyfile()
+	if err != nil {
+		t.Fatalf("GenerateCaddyfile: %v", err)
+	}
+	if !strings.Contains(out, `env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime`) {
+		t.Errorf("generated Caddyfile must force APP_RUNTIME for runtime/frankenphp-symfony:\n%s", out)
 	}
 }
 

--- a/internal/generator/templates/caddyfile.tmpl
+++ b/internal/generator/templates/caddyfile.tmpl
@@ -12,7 +12,9 @@
 	frankenphp {
 		worker {
 			file ./public/index.php
+{{- if .LegacyRuntime }}
 			env APP_RUNTIME Runtime\FrankenPhpSymfony\Runtime
+{{- end }}
 		}
 
 		{$FRANKENPHP_CONFIG}

--- a/internal/scanner/composer.go
+++ b/internal/scanner/composer.go
@@ -29,6 +29,50 @@ type ComposerResult struct {
 	Packages          map[string]string
 }
 
+const (
+	// legacyFrankenPHPRuntimePackage is the historical way to run Symfony in
+	// FrankenPHP worker mode, superseded by symfony/runtime 7.4.
+	legacyFrankenPHPRuntimePackage = "runtime/frankenphp-symfony"
+	symfonyRuntimePackage          = "symfony/runtime"
+)
+
+// composerVersionRegex captures the first MAJOR.MINOR of a composer constraint
+var composerVersionRegex = regexp.MustCompile(`(\d+)\.(\d+)`)
+
+// HasLegacyFrankenPHPRuntime reports whether the app ships
+// runtime/frankenphp-symfony. That package needs the APP_RUNTIME override in
+// the generated Caddyfile; the native runtime does not.
+func (c *ComposerResult) HasLegacyFrankenPHPRuntime() bool {
+	return c.HasPackage(legacyFrankenPHPRuntimePackage)
+}
+
+// HasNativeFrankenPHPRuntime reports whether symfony/runtime is recent enough
+// (>= 7.4) to embed the FrankenPHP worker runner itself: since that version
+// SymfonyRuntime picks FrankenPhpWorkerRunner whenever the server sets
+// FRANKENPHP_WORKER, without any extra package or APP_RUNTIME override.
+func (c *ComposerResult) HasNativeFrankenPHPRuntime() bool {
+	return constraintAtLeast(c.GetPackageVersion(symfonyRuntimePackage), 7, 4)
+}
+
+// HasFrankenPHPWorkerRuntime reports whether the app can boot in FrankenPHP
+// worker mode at all, through either runtime.
+func (c *ComposerResult) HasFrankenPHPWorkerRuntime() bool {
+	return c.HasLegacyFrankenPHPRuntime() || c.HasNativeFrankenPHPRuntime()
+}
+
+// constraintAtLeast reads the first MAJOR.MINOR of a composer constraint
+// ("^7.4", "8.1.*", ">=7.4 <9") and compares it to the given minimum. A
+// constraint without an explicit version ("*", "dev-main") is not trusted.
+func constraintAtLeast(constraint string, major, minor int) bool {
+	m := composerVersionRegex.FindStringSubmatch(constraint)
+	if m == nil {
+		return false
+	}
+	maj, _ := strconv.Atoi(m[1])
+	mn, _ := strconv.Atoi(m[2])
+	return maj > major || (maj == major && mn >= minor)
+}
+
 // ParseComposer parses the composer.json file
 func (s *Scanner) ParseComposer() (*ComposerResult, error) {
 	composerPath := filepath.Join(s.projectPath, "composer.json")

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -91,11 +91,16 @@ func (s *Scanner) Scan() (*config.ScanResult, error) {
 	// api-platform/core (v2/v3) or api-platform/symfony (v4 split packages)
 	result.HasAPIPlatform = composer.HasAnyPackage("api-platform/core", "api-platform/symfony")
 
-	// FrankenPHP worker mode eligibility (runtime/frankenphp-symfony)
-	result.HasFrankenPHPRuntime = composer.HasPackage("runtime/frankenphp-symfony")
+	// FrankenPHP worker mode eligibility: symfony/runtime >= 7.4 ships the
+	// worker runner natively, runtime/frankenphp-symfony is the historical way
+	result.HasFrankenPHPRuntime = composer.HasFrankenPHPWorkerRuntime()
 	if result.HasFrankenPHPRuntime {
+		source := "symfony/runtime >= 7.4"
+		if composer.HasLegacyFrankenPHPRuntime() {
+			source = "runtime/frankenphp-symfony"
+		}
 		result.Warnings = append(result.Warnings,
-			"runtime/frankenphp-symfony detected: enabling FrankenPHP worker mode (frankenphp.worker: true in frankendeploy.yaml). "+
+			source+" detected: enabling FrankenPHP worker mode (frankenphp.worker: true in frankendeploy.yaml). "+
 				"Worker mode keeps the Symfony kernel in memory between requests — the app must be stateless. "+
 				"Set frankenphp.worker: false to opt out")
 	}
@@ -272,7 +277,7 @@ func (s *Scanner) ToProjectConfig(result *config.ScanResult, name string) *confi
 		cfg.Deploy.HealthcheckPath = "/api"
 	}
 
-	// Enable FrankenPHP worker mode when the app ships the runtime package
+	// Enable FrankenPHP worker mode when the app ships a worker runtime
 	// (announced via a scanner warning — never silent)
 	if result.HasFrankenPHPRuntime {
 		cfg.FrankenPHP.Worker = true

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -251,6 +251,87 @@ func TestScan_FrankenPHPRuntime_EnablesWorker(t *testing.T) {
 	}
 }
 
+func TestScan_NativeSymfonyRuntime_EnablesWorker(t *testing.T) {
+	tempDir := t.TempDir()
+	composer := `{
+		"require": {
+			"php": ">=8.4",
+			"symfony/framework-bundle": "8.1.*",
+			"symfony/runtime": "8.1.*"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tempDir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(tempDir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if !result.HasFrankenPHPRuntime {
+		t.Error("expected HasFrankenPHPRuntime to be true with symfony/runtime >= 7.4")
+	}
+	if !s.ToProjectConfig(result, "myapp").FrankenPHP.Worker {
+		t.Error("expected FrankenPHP.Worker to be enabled with symfony/runtime >= 7.4")
+	}
+
+	foundWarning := false
+	for _, w := range result.Warnings {
+		if strings.Contains(w, "symfony/runtime >= 7.4 detected") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected a warning naming symfony/runtime, got: %v", result.Warnings)
+	}
+}
+
+func TestScan_OldSymfonyRuntime_WorkerDisabled(t *testing.T) {
+	tempDir := t.TempDir()
+	composer := `{
+		"require": {
+			"php": ">=8.2",
+			"symfony/framework-bundle": "^7.3",
+			"symfony/runtime": "^7.3"
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tempDir, "composer.json"), []byte(composer), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s := New(tempDir)
+	result, err := s.Scan()
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.HasFrankenPHPRuntime {
+		t.Error("expected HasFrankenPHPRuntime to be false with symfony/runtime < 7.4")
+	}
+}
+
+func TestConstraintAtLeast(t *testing.T) {
+	cases := []struct {
+		constraint string
+		want       bool
+	}{
+		{"^7.4", true},
+		{"7.4.*", true},
+		{"8.1.*", true},
+		{">=7.4 <9.0", true},
+		{"^7.3", false},
+		{"6.4.*", false},
+		{"*", false},
+		{"dev-main", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := constraintAtLeast(c.constraint, 7, 4); got != c.want {
+			t.Errorf("constraintAtLeast(%q, 7, 4) = %v, want %v", c.constraint, got, c.want)
+		}
+	}
+}
+
 func TestScan_NoFrankenPHPRuntime_WorkerDisabled(t *testing.T) {
 	tempDir := t.TempDir()
 	composer := `{


### PR DESCRIPTION
## Description

Since Symfony 7.4, `symfony/runtime` ships `FrankenPhpWorkerRunner` and selects it itself whenever FrankenPHP sets `FRANKENPHP_WORKER`. The `runtime/frankenphp-symfony` package is no longer needed on a recent Symfony.

FrankenDeploy still required that package: `init` did not enable worker mode without it, `build` refused `frankenphp.worker: true`, and the generated Caddyfile forced `APP_RUNTIME` to `Runtime\FrankenPhpSymfony\Runtime`, a class that does not exist without the package (the container would crash-loop).

This PR makes worker mode work with the native runtime:

- **scanner**: worker mode is eligible with `symfony/runtime` >= 7.4 or the legacy package; the `init` warning names which runtime was detected
- **build**: the preflight accepts either runtime, with an upgrade hint instead of the old "install runtime/frankenphp-symfony"
- **generator**: the Caddyfile only forces `APP_RUNTIME` when the legacy package is present
- docs (`config/project.md`) and changelog updated

## Related Issue

Found while enabling worker mode on a Symfony 8.1 / API Platform 4 app deployed with FrankenDeploy.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and fixed any issues
- [x] I have run `make test` and all tests pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [x] My commits follow the conventional commit format

## Testing

1. `go test -race ./...`: 799 tests pass. New tests cover `symfony/runtime` 8.1.* (worker enabled, warning names the native runtime), `symfony/runtime` ^7.3 (disabled), the constraint parser, and the Caddyfile with and without the legacy package.
2. Live: a Symfony 8.1 app with `symfony/runtime 8.1.*` and no `runtime/frankenphp-symfony`, `frankenphp.worker: true`. Before: `build` refused. After: `build` generates a Caddyfile without `APP_RUNTIME`, the app deploys and serves in worker mode (checked with `FRANKENPHP_WORKER` in the container and a load test before/after).

## Additional Notes

Apps still on `runtime/frankenphp-symfony` are unaffected: same detection, same Caddyfile as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
