### PR TITLE
ci(release): verify the Homebrew tap token before publishing anything

### DIFF
--- a/.github/workflows/check-tap-token.yml
+++ b/.github/workflows/check-tap-token.yml
@@ -1,0 +1,28 @@
+name: Check Homebrew tap token
+
+# Manual check that the GH_PAT secret can update the Homebrew formula, to run
+# after rotating the token and before tagging a release.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: GH_PAT can push to homebrew-tap
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the Homebrew tap token
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The GH_PAT secret is empty. Create a fine-grained PAT with Contents: read and write on yoanbernabeu/homebrew-tap and store it as GH_PAT."
+            exit 1
+          fi
+          if ! gh api repos/yoanbernabeu/homebrew-tap --jq '.permissions.push' | grep -q true; then
+            echo "::error::GH_PAT cannot push to yoanbernabeu/homebrew-tap (invalid, expired, or missing the Contents: write permission)."
+            exit 1
+          fi
+          echo "GH_PAT can push to yoanbernabeu/homebrew-tap."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,23 @@ jobs:
         with:
           go-version: "1.21"
 
+      # Fail before anything is published: a bad GH_PAT used to surface only
+      # after the GitHub release and its assets existed, leaving the Homebrew
+      # formula stale and the run impossible to replay cleanly.
+      - name: Check the Homebrew tap token
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::The GH_PAT secret is empty. Create a fine-grained PAT with Contents: read and write on yoanbernabeu/homebrew-tap and store it as GH_PAT."
+            exit 1
+          fi
+          if ! gh api repos/yoanbernabeu/homebrew-tap --jq '.permissions.push' | grep -q true; then
+            echo "::error::GH_PAT cannot push to yoanbernabeu/homebrew-tap (invalid, expired, or missing the Contents: write permission)."
+            exit 1
+          fi
+          echo "GH_PAT can push to yoanbernabeu/homebrew-tap."
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Description

The v0.14.0 release published its GitHub assets, then failed on the Homebrew formula with a 401 from an invalid `GH_PAT`, leaving the tap stale and the run impossible to replay cleanly.

- The release workflow now checks that `GH_PAT` can push to `yoanbernabeu/homebrew-tap` **before** GoReleaser runs, so a bad token fails the run before anything is published.
- A manual workflow, *Check Homebrew tap token*, allows checking a freshly rotated token without tagging a release.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My commits follow the conventional commit format

## Testing

Run the *Check Homebrew tap token* workflow after rotating `GH_PAT`; it must pass before the next tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)