### PR TITLE
fix(caddy): drop the active health check from the generated reverse proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **No more active health check in the generated reverse proxy**: Caddy probed the live container every 30 s with a 5 s timeout, and with a single upstream a failed probe turned every request into a 503 "no upstreams available" for the next 30 s. It already bit once with API-only apps returning 404 on `/` (#69) and again under load, where the probe queued behind real requests and cut all traffic while the application was merely slow. The deploy-time health check, run before the traffic switch, remains the one that protects production - @yoanbernabeu
+- **No more active health check in the generated reverse proxy**: Caddy probed the live container every 30 s with a 5 s timeout, and with a single upstream a failed probe turned every request into a 503 "no upstreams available" for the next 30 s. It already bit once with API-only apps returning 404 on `/` (#69) and again under load, where the probe queued behind real requests and cut all traffic while the application was merely slow. The deploy-time health check, run before the traffic switch, remains the one that protects production. Per-request timeouts replace the probe (5 s dial, 60 s response headers): a frozen container ends in a 504 for the affected request, never in an endless wait, while other requests keep flowing - @yoanbernabeu
 
 ## [0.14.0] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **No more active health check in the generated reverse proxy**: Caddy probed the live container every 30 s with a 5 s timeout, and with a single upstream a failed probe turned every request into a 503 "no upstreams available" for the next 30 s. It already bit once with API-only apps returning 404 on `/` (#69) and again under load, where the probe queued behind real requests and cut all traffic while the application was merely slow. The deploy-time health check, run before the traffic switch, remains the one that protects production - @yoanbernabeu
+
 ## [0.14.0] - 2026-09-02
 
 FrankenPHP worker mode no longer depends on the deprecated `runtime/frankenphp-symfony` package: any Symfony 7.4+ app is eligible out of the box, and the generated Caddyfile no longer forces a runtime class that would not exist. Found and validated live while preparing a Symfony 8.1 / API Platform 4 demo for API Platform Con 2026: on a 2 vCPU VPS the same load test went from 23 to 53 requests per second served, p95 from 5.5 s to 0.83 s.

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -107,7 +107,9 @@ deploy:
   healthcheck_path: /health
 ```
 
-The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used by Caddy's active health checks on the running container **and by the Docker `HEALTHCHECK` baked into the generated image**, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
+The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used **by the Docker `HEALTHCHECK` baked into the generated image**, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
+
+The reverse proxy deliberately runs **no active health check** on the live container: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow application into a 503 for every visitor. The health check that protects production is the one run before the traffic switch.
 
 The check window is generous by default (90 seconds — a cold Symfony container needs time for opcache warmup and database wait) and tunable:
 

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -109,7 +109,7 @@ deploy:
 
 The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used **by the Docker `HEALTHCHECK` baked into the generated image**, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
 
-The reverse proxy deliberately runs **no active health check** on the live container: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow application into a 503 for every visitor. The health check that protects production is the one run before the traffic switch.
+The reverse proxy deliberately runs **no active health check** on the live container: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow application into a 503 for every visitor. The health check that protects production is the one run before the traffic switch. Per-request timeouts apply instead (5 s to connect, 60 s for the response headers): a container that accepts connections but never answers costs the affected visitor a 504, not an endless wait.
 
 The check window is generous by default (90 seconds — a cold Symfony container needs time for opcache warmup and database wait) and tunable:
 

--- a/internal/caddy/config.go
+++ b/internal/caddy/config.go
@@ -24,29 +24,18 @@ type AppConfig struct {
 	Name   string
 	Domain string
 	Port   int
-	// HealthPath is the URL probed by Caddy's active health check.
-	// It must match the application's healthcheck path: an API-only app
-	// returns 404 on "/", which would mark the upstream unhealthy and
-	// turn every request into a 503.
-	HealthPath string
 }
 
 // GenerateAppConfig generates Caddy config for an application
 func (g *ConfigGenerator) GenerateAppConfig(app AppConfig) (string, error) {
-	if err := security.ValidateHealthPath(app.HealthPath); err != nil {
-		return "", fmt.Errorf("invalid health path: %w", err)
-	}
-	if app.HealthPath == "" {
-		app.HealthPath = "/"
-	}
-
 	tmpl := `# {{ .Name }}
 {{ .Domain }} {
-    reverse_proxy {{ .Name }}:{{ .Port }} {
-        health_uri {{ .HealthPath }}
-        health_interval 30s
-        health_timeout 5s
-    }
+    # No active health check, on purpose: with a single upstream there is
+    # nothing to fail over to, and a probe that times out under load turns a
+    # slow application into a 503 for everyone ("no upstreams available").
+    # The health check that protects production is the one run on the new
+    # container before traffic is switched to it.
+    reverse_proxy {{ .Name }}:{{ .Port }}
 
     encode zstd gzip
 
@@ -113,10 +102,9 @@ import /config/apps/*.caddy
 func AppConfigFromProject(cfg *config.ProjectConfig, domain string) AppConfig {
 	port, _ := strconv.Atoi(constants.AppPort)
 	return AppConfig{
-		Name:       cfg.Name,
-		Domain:     domain,
-		Port:       port,
-		HealthPath: cfg.Deploy.HealthcheckPath,
+		Name:   cfg.Name,
+		Domain: domain,
+		Port:   port,
 	}
 }
 

--- a/internal/caddy/config.go
+++ b/internal/caddy/config.go
@@ -35,7 +35,16 @@ func (g *ConfigGenerator) GenerateAppConfig(app AppConfig) (string, error) {
     # slow application into a 503 for everyone ("no upstreams available").
     # The health check that protects production is the one run on the new
     # container before traffic is switched to it.
-    reverse_proxy {{ .Name }}:{{ .Port }}
+    #
+    # Per-request timeouts instead: a container that accepts connections but
+    # never answers costs each visitor at most 60s and a 504, not an endless
+    # wait, and the other requests keep flowing.
+    reverse_proxy {{ .Name }}:{{ .Port }} {
+        transport http {
+            dial_timeout 5s
+            response_header_timeout 60s
+        }
+    }
 
     encode zstd gzip
 

--- a/internal/caddy/config_test.go
+++ b/internal/caddy/config_test.go
@@ -55,8 +55,12 @@ func TestGenerateAppConfig_NoActiveHealthCheck(t *testing.T) {
 			t.Errorf("generated config must not contain %q:\n%s", forbidden, out)
 		}
 	}
-	if !strings.Contains(out, "reverse_proxy myapp:8080\n") {
-		t.Errorf("expected a bare reverse_proxy directive:\n%s", out)
+	// Per-request timeouts replace the probe: a frozen container must end in
+	// a 504 for the affected request, never in an endless wait.
+	for _, want := range []string{"reverse_proxy myapp:8080 {", "transport http {", "dial_timeout 5s", "response_header_timeout 60s"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("generated config missing %q:\n%s", want, out)
+		}
 	}
 }
 

--- a/internal/caddy/config_test.go
+++ b/internal/caddy/config_test.go
@@ -35,27 +35,12 @@ func TestGenerateAppConfig_DoesNotEmitTLSInternal(t *testing.T) {
 	}
 }
 
-// TestGenerateAppConfig_UsesConfiguredHealthPath guards against the live 503
-// found in production: Caddy's active health check probed a hardcoded "/",
-// got 404 from an API-only app, marked the upstream unhealthy, and every
-// request failed with "no upstreams available".
-func TestGenerateAppConfig_UsesConfiguredHealthPath(t *testing.T) {
-	gen := NewConfigGenerator()
-	out, err := gen.GenerateAppConfig(AppConfig{
-		Name:       "myapp",
-		Domain:     "example.com",
-		Port:       8080,
-		HealthPath: "/api",
-	})
-	if err != nil {
-		t.Fatalf("GenerateAppConfig: %v", err)
-	}
-	if !strings.Contains(out, "health_uri /api") {
-		t.Errorf("expected 'health_uri /api' in generated config:\n%s", out)
-	}
-}
-
-func TestGenerateAppConfig_DefaultsHealthPathToRoot(t *testing.T) {
+// TestGenerateAppConfig_NoActiveHealthCheck guards against reintroducing
+// Caddy's active health check. With a single upstream it cannot route around
+// anything, and it has caused two production outages: a probe on "/" getting
+// 404 from an API-only app, then a probe timing out under load, both turning
+// every request into a 503 "no upstreams available".
+func TestGenerateAppConfig_NoActiveHealthCheck(t *testing.T) {
 	gen := NewConfigGenerator()
 	out, err := gen.GenerateAppConfig(AppConfig{
 		Name:   "myapp",
@@ -65,33 +50,22 @@ func TestGenerateAppConfig_DefaultsHealthPathToRoot(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GenerateAppConfig: %v", err)
 	}
-	if !strings.Contains(out, "health_uri /") {
-		t.Errorf("expected 'health_uri /' as default:\n%s", out)
-	}
-}
-
-func TestGenerateAppConfig_RejectsInvalidHealthPath(t *testing.T) {
-	gen := NewConfigGenerator()
-	for _, path := range []string{"no-leading-slash", "/api\nmalicious {", "/api/../../etc"} {
-		_, err := gen.GenerateAppConfig(AppConfig{
-			Name:       "myapp",
-			Domain:     "example.com",
-			Port:       8080,
-			HealthPath: path,
-		})
-		if err == nil {
-			t.Errorf("expected error for invalid health path %q", path)
+	for _, forbidden := range []string{"health_uri", "health_interval", "health_timeout"} {
+		if strings.Contains(out, forbidden) {
+			t.Errorf("generated config must not contain %q:\n%s", forbidden, out)
 		}
 	}
+	if !strings.Contains(out, "reverse_proxy myapp:8080\n") {
+		t.Errorf("expected a bare reverse_proxy directive:\n%s", out)
+	}
 }
 
-func TestAppConfigFromProject_CopiesHealthcheckPath(t *testing.T) {
+func TestAppConfigFromProject(t *testing.T) {
 	cfg := &config.ProjectConfig{Name: "myapp"}
-	cfg.Deploy.HealthcheckPath = "/api"
 
 	app := AppConfigFromProject(cfg, "example.com")
-	if app.HealthPath != "/api" {
-		t.Errorf("expected HealthPath /api, got %q", app.HealthPath)
+	if app.Name != "myapp" || app.Domain != "example.com" || app.Port == 0 {
+		t.Errorf("unexpected AppConfig: %+v", app)
 	}
 }
 


### PR DESCRIPTION
## Description

The generated `reverse_proxy` block probed the live container every 30 s on the healthcheck path with a 5 s timeout. With a single upstream, a failed probe has nothing to fail over to: Caddy answers 503 `no upstreams available` to every visitor until the next probe passes.

It already bit once with API-only apps returning 404 on `/` (#69, fixed by pointing the probe at the configured path). It bit again during a load test at 100 req/s on a 2 vCPU VPS: the probe queued behind real requests, timed out, and cut all traffic for 30 s cycles while the application was merely slow. 4 531 responses in 503, 56 % of the run, and zero errors in the application logs.

This PR removes the active health check. The health check that protects production is the one run on the new container **before** the traffic switch; it is untouched, as is the Docker `HEALTHCHECK` baked into the image.

## Related Issue

Follow-up of #69.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Documentation update

## Checklist

- [x] My code follows the project's code style
- [x] I have run `make lint` and fixed any issues
- [x] I have run `make test` and all tests pass
- [x] I have updated the documentation (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [x] My commits follow the conventional commit format

## Testing

1. `go test ./internal/...` passes; a new test guards against reintroducing `health_uri` / `health_interval` / `health_timeout`.
2. Live, before the fix: k6, 500 virtual users in a closed loop, 100 req/s, 56 % of requests in 503 from the front Caddy, none from the app.

## Additional Notes

Existing deployments pick the new block up at their next `deploy`, which rewrites the app's Caddy config and reloads Caddy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)