### PR TITLE
feat(deploy): one Docker network per application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **One Docker network per application**: every container of an app (app, worker, managed database) now runs on `frankendeploy-<app>`, created by the first deploy, with Caddy attached to it. Applications sharing a VPS no longer see each other's containers: a compromised app cannot reach another app's database. Installations deployed on the shared `frankendeploy` network migrate transparently on their next deploy, rollback or `env --reload` (the database container joins the app network, and leaves the shared one once the old app container is gone; an interrupted migration resumes on the next run). `app remove` deletes the network, `doctor` reports the isolation status of the app, and running out of Docker address pools (about 30 apps per host) fails with the `daemon.json` fix instead of a cryptic error (#96) - @yoanbernabeu
+
 ## [0.14.1] - 2026-09-02
 
 The generated reverse proxy no longer runs an active health check that could turn a slow application into a 503 for everyone; per-request timeouts take its place. Found with a 500-user load test on a 2 vCPU VPS: 56% of requests answered 503 by Caddy while the application itself had no error.

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -261,6 +261,12 @@ FrankenDeploy ensures zero downtime:
 
 If anything fails — including the swap itself — traffic stays on the old container.
 
+## Network Isolation
+
+Each application runs on its own Docker network, `frankendeploy-<app-name>`, with its worker and its managed database. Caddy is attached to every app network so it can reach `<app-name>:8080` by name; nothing else is. Two applications deployed on the same VPS cannot reach each other's containers, so a compromised app cannot talk to another app's database.
+
+The network is created by the first deploy. An application deployed before per-app networks existed is migrated transparently on its next deploy: the database container joins the app network, the new app container starts on it, and once the old container is stopped the database leaves the shared network. Every step checks the current state before acting, so a deploy interrupted in the middle completes on the next run. `frankendeploy doctor` reports the isolation status of the app.
+
 ## Managed Database
 
 With `database.managed: true` (the default for PostgreSQL/MySQL), each deployment ensures the database container is running and injects the generated `DATABASE_URL` into your application automatically. Credentials are created once and persist across deployments — you never have to set `DATABASE_URL` yourself.

--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -95,7 +95,7 @@ This command:
 2. Configures UFW firewall (HTTP/HTTPS + SSH — both your configured SSH port and the port the SSH daemon actually uses are allowed before the firewall is enabled, so a custom port or gateway setup can never lock you out)
 3. Installs and configures Fail2ban (SSH brute-force protection)
 4. Creates the FrankenDeploy directory structure
-5. Sets up the `frankendeploy` Docker network
+5. Sets up the `frankendeploy` Docker network (Caddy's home network)
 6. Deploys Caddy as a Docker container (reverse proxy)
 
 ### What Gets Created
@@ -115,35 +115,38 @@ This command:
 |-----------|---------|
 | `caddy` | Reverse proxy with automatic HTTPS |
 | `<app-name>` | Your deployed applications |
+| `<app-name>-worker` | Messenger worker (when enabled) |
+| `<app-name>-db` | Managed database (when enabled) |
 
-All containers are connected via the `frankendeploy` Docker network.
+### Docker Networks
+
+Each application gets its own network, `frankendeploy-<app-name>`, created by its first deploy. The app, its worker and its database run on it, and Caddy is attached to it so it can still reach `<app-name>:8080` by name. Applications sharing a VPS never see each other's containers: a compromised app cannot reach another app's database.
+
+The `frankendeploy` network created by `server setup` is Caddy's home network. Applications deployed before per-app networks existed are migrated on their next deploy (the database container is moved, never recreated), and `frankendeploy doctor` reports any container still left on the shared network.
+
+Docker's default address pools cover about 30 bridge networks per host, which is far beyond what a single VPS is meant to host. Past that, `deploy` fails with a clear message pointing to the `default-address-pools` setting of `/etc/docker/daemon.json`.
 
 ## Architecture
 
 ```
-                    ┌──────────────────────────────────────┐
-                    │               VPS                    │
-                    │                                      │
-  Internet          │   ┌────────────────────────────┐    │
-    │               │   │     Caddy (Docker)         │    │
-    │               │   │  ┌──────────────────────┐  │    │
-    ├── :443 ──────►│   │  │ Auto HTTPS (Let's    │  │    │
-    └── :80  ──────►│   │  │ Encrypt)             │  │    │
-                    │   │  └──────────────────────┘  │    │
-                    │   │              │             │    │
-                    │   │   import apps/*.caddy     │    │
-                    │   └──────────────┬─────────────┘    │
-                    │                  │                   │
-                    │     Docker Network: frankendeploy    │
-                    │                  │                   │
-                    │     ┌────────────┴────────────┐      │
-                    │     │                         │      │
-                    │  ┌──▼───┐    ┌──────┐    ┌───▼──┐   │
-                    │  │ App1 │    │ App2 │    │ App3 │   │
-                    │  │ :80  │    │ :80  │    │ :80  │   │
-                    │  └──────┘    └──────┘    └──────┘   │
-                    │                                      │
-                    └──────────────────────────────────────┘
+                    ┌────────────────────────────────────────────────────────────────────┐
+                    │                                VPS                                 │
+                    │                                                                    │
+  Internet          │   ┌────────────────────────────────────────────────────────────┐   │
+    │               │   │                       Caddy (Docker)                       │   │
+    ├── :443 ──────►│   │                 Auto HTTPS (Let's Encrypt)                 │   │
+    └── :80  ──────►│   │                    import apps/*.caddy                     │   │
+                    │   └─────────┬────────────────────┬────────────────────┬────────┘   │
+                    │             │                    │                    │            │
+                    │   ┌─────────▼────────┐ ┌─────────▼────────┐ ┌─────────▼────────┐   │
+                    │   │frankendeploy-app1│ │frankendeploy-app2│ │frankendeploy-app3│   │
+                    │   │ ┌──────┐ ┌────┐  │ │ ┌──────┐ ┌────┐  │ │ ┌──────┐         │   │
+                    │   │ │ app1 │ │ db │  │ │ │ app2 │ │ db │  │ │ │ app3 │         │   │
+                    │   │ │:8080 │ └────┘  │ │ │:8080 │ └────┘  │ │ │:8080 │         │   │
+                    │   │ └──────┘         │ │ └──────┘         │ │ └──────┘         │   │
+                    │   └──────────────────┘ └──────────────────┘ └──────────────────┘   │
+                    │    one isolated network per application, Caddy attached to each    │
+                    └────────────────────────────────────────────────────────────────────┘
 ```
 
 ## Verifying Setup
@@ -200,6 +203,8 @@ mkdir -p /opt/frankendeploy/{apps,caddy/apps,caddy/logs}
 ```bash
 docker network create frankendeploy
 ```
+
+This is Caddy's home network only: each application gets its own `frankendeploy-<app-name>` network, created automatically by its first deploy.
 
 ### Create Caddyfile
 ```bash

--- a/internal/cmd/app.go
+++ b/internal/cmd/app.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/frankendeploy/internal/config"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/deploy"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 )
 
@@ -200,6 +201,11 @@ func runAppRemove(cmd *cobra.Command, args []string) error {
 	// Remove Docker images
 	if _, err := conn.Client.Exec(ctx, fmt.Sprintf("docker images %s -q | xargs -r docker rmi 2>/dev/null || true", appName)); err != nil {
 		PrintVerbose("Could not remove Docker images: %v", err)
+	}
+
+	// Remove the app network (Caddy detached first)
+	if err := deploy.RemoveAppNetwork(ctx, conn.Client, appName); err != nil {
+		PrintVerbose("Could not remove app network: %v", err)
 	}
 
 	if appRemoveKeepData {

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -161,6 +161,15 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		PrintSuccess("Image transferred")
 	}
 
+	// Step 3a: Dedicated network for the app. Created on first deploy with
+	// Caddy attached to it; an installation deployed on the shared network
+	// migrates transparently (database attached here, detached from the
+	// shared network once the old container is gone).
+	PrintInfo("Preparing application network...")
+	if err := deploy.EnsureAppNetwork(ctx, client, projectCfg.Name, cmdLogger{}); err != nil {
+		return fmt.Errorf("network setup failed: %w", err)
+	}
+
 	// Step 3b: Deploy managed database if configured
 	var databaseURL string
 	if projectCfg.Database.Driver != "" && projectCfg.Database.IsManaged() {
@@ -211,6 +220,9 @@ func runDeploy(cmd *cobra.Command, args []string) error {
 		},
 		DeployWorkers: func() error {
 			return deployMessengerWorkers(ctx, client, projectCfg, imageName, remoteAppPath, databaseURL)
+		},
+		IsolateNetwork: func() {
+			deploy.DetachFromSharedNetwork(ctx, client, projectCfg.Name, cmdLogger{})
 		},
 		RunPostDeployHooks: func() error {
 			return runDeployHooks(ctx, client, projectCfg.Name, projectCfg.Deploy.Hooks.PostDeploy)
@@ -499,7 +511,7 @@ func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseU
 		%s%s \
 		%s \
 		%s \
-		%s`, containerName, constants.NetworkName, constants.ContainerUser, constants.DockerLogOptions, limits, envVars, volumeMounts, imageName)
+		%s`, containerName, constants.AppNetworkName(cfg.Name), constants.ContainerUser, constants.DockerLogOptions, limits, envVars, volumeMounts, imageName)
 }
 
 // readSavedDatabaseURL reads the DATABASE_URL persisted by a managed-database
@@ -919,7 +931,7 @@ func deployMessengerWorkers(ctx context.Context, client ssh.Executor, cfg *confi
 		%s \
 		%s \
 		php bin/console messenger:consume %s --time-limit=3600 --memory-limit=256M -vv`,
-		workerName, constants.NetworkName, constants.ContainerUser, constants.DockerLogOptions, envVars, volumeMounts, imageName, transportsArg)
+		workerName, constants.AppNetworkName(cfg.Name), constants.ContainerUser, constants.DockerLogOptions, envVars, volumeMounts, imageName, transportsArg)
 
 	result, err := client.Exec(ctx, workerCmd)
 	if err != nil {

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -158,7 +158,7 @@ func TestStartNewContainer_BuildsDockerRunCommand(t *testing.T) {
 	// Should issue a docker run with the expected flags
 	wantFragments := []string{
 		"docker run -d --name myapp-new",
-		"--network frankendeploy",
+		"--network frankendeploy-myapp",
 		"--restart unless-stopped",
 		"--user 1000:1000",
 		"-e SERVER_NAME=:8080",

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -28,6 +28,7 @@ Remote checks (over SSH):
 - 'frankendeploy' network present
 - Caddy reverse proxy container running
 - free disk space
+- inside a project: the app runs on its own isolated network
 
 DNS check (when a domain is configured or passed via --domain):
 - the domain resolves to the server's public IP — the #1 cause of
@@ -88,12 +89,16 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		checkDiskSpace(ctx, client),
 	)
 
+	// --- Project checks (only inside a project) ---
+	projectCfg, projectErr := config.LoadProjectConfig(GetConfigFile())
+	if projectErr == nil {
+		results = append(results, checkAppNetwork(ctx, client, projectCfg.Name))
+	}
+
 	// --- DNS check ---
 	domain := doctorDomain
-	if domain == "" {
-		if cfg, err := config.LoadProjectConfig(GetConfigFile()); err == nil {
-			domain = cfg.Deploy.Domain
-		}
+	if domain == "" && projectErr == nil {
+		domain = projectCfg.Deploy.Domain
 	}
 	if domain != "" {
 		serverIP := detectServerPublicIP(ctx, client, conn.Server.Host)
@@ -240,6 +245,62 @@ func checkDockerNetwork(ctx context.Context, client ssh.Executor) doctorResult {
 		}
 	}
 	return doctorResult{Name: "Docker network", OK: true, Detail: constants.NetworkName}
+}
+
+// checkAppNetwork verifies the app runs isolated on its own network: the
+// network exists, Caddy is attached to it, and no container of the app is
+// still on the shared network (a migration left unfinished).
+func checkAppNetwork(ctx context.Context, client ssh.Executor, appName string) doctorResult {
+	network := constants.AppNetworkName(appName)
+	name := "App network"
+
+	result, err := client.Exec(ctx, fmt.Sprintf("docker network inspect %s --format '{{.Name}}' 2>/dev/null", network))
+	if err != nil || result.ExitCode != 0 || strings.TrimSpace(result.Stdout) == "" {
+		return doctorResult{Name: name, OK: true, Warning: true, Detail: fmt.Sprintf("%s not created yet (created by the first deploy)", network)}
+	}
+
+	attached := func(container string) (onApp, onShared, exists bool) {
+		res, err := client.Exec(ctx, fmt.Sprintf(`docker inspect %s --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}} {{end}}' 2>/dev/null`, container))
+		if err != nil || res.ExitCode != 0 {
+			return false, false, false
+		}
+		for _, n := range strings.Fields(res.Stdout) {
+			switch n {
+			case network:
+				onApp = true
+			case constants.NetworkName:
+				onShared = true
+			}
+		}
+		return onApp, onShared, true
+	}
+
+	if onApp, _, exists := attached("caddy"); exists && !onApp {
+		return doctorResult{
+			Name:   name,
+			OK:     false,
+			Detail: fmt.Sprintf("Caddy is not attached to %s: the app is not reachable", network),
+			Advice: fmt.Sprintf("Run 'frankendeploy deploy <server>' again, or attach it manually:\n  docker network connect %s caddy", network),
+		}
+	}
+
+	var leftovers []string
+	for _, container := range []string{appName, appName + "-worker", appName + "-db"} {
+		if _, onShared, exists := attached(container); exists && onShared {
+			leftovers = append(leftovers, container)
+		}
+	}
+	if len(leftovers) > 0 {
+		return doctorResult{
+			Name:    name,
+			OK:      false,
+			Warning: true,
+			Detail:  fmt.Sprintf("still on the shared network %s: %s", constants.NetworkName, strings.Join(leftovers, ", ")),
+			Advice:  "Run 'frankendeploy deploy <server>' again to finish the migration to the per-app network.",
+		}
+	}
+
+	return doctorResult{Name: name, OK: true, Detail: fmt.Sprintf("%s (isolated)", network)}
 }
 
 // checkCaddyRunning verifies the Caddy front proxy container is up.

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -160,3 +160,45 @@ func TestDoctorDNS(t *testing.T) {
 		t.Fatal("expected failure when the domain does not resolve")
 	}
 }
+
+func TestDoctorAppNetwork(t *testing.T) {
+	inspectCaddy := "docker inspect caddy"
+	inspectDB := "docker inspect myapp-db"
+
+	notCreated := scriptedMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {ExitCode: 1},
+	})
+	res := checkAppNetwork(context.Background(), notCreated, "myapp")
+	if !res.OK || !res.Warning {
+		t.Errorf("a network not created yet is a warning, not a failure: %+v", res)
+	}
+
+	caddyMissing := scriptedMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+		inspectCaddy: {Stdout: "frankendeploy \n"},
+	})
+	res = checkAppNetwork(context.Background(), caddyMissing, "myapp")
+	if res.OK || !strings.Contains(res.Advice, "docker network connect frankendeploy-myapp caddy") {
+		t.Errorf("Caddy off the app network must fail with the connect command, got %+v", res)
+	}
+
+	leftover := scriptedMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+		inspectCaddy: {Stdout: "frankendeploy frankendeploy-myapp \n"},
+		inspectDB:    {Stdout: "frankendeploy frankendeploy-myapp \n"},
+	})
+	res = checkAppNetwork(context.Background(), leftover, "myapp")
+	if res.OK || !res.Warning || !strings.Contains(res.Detail, "myapp-db") {
+		t.Errorf("a container still on the shared network must be reported, got %+v", res)
+	}
+
+	isolated := scriptedMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+		inspectCaddy: {Stdout: "frankendeploy frankendeploy-myapp \n"},
+		inspectDB:    {Stdout: "frankendeploy-myapp \n"},
+	})
+	res = checkAppNetwork(context.Background(), isolated, "myapp")
+	if !res.OK || res.Warning {
+		t.Errorf("expected OK when isolated, got %+v", res)
+	}
+}

--- a/internal/cmd/env.go
+++ b/internal/cmd/env.go
@@ -440,6 +440,10 @@ func reloadContainer(ctx context.Context, client ssh.Executor, cfg *config.Proje
 	appPath := constants.AppBasePath(appName)
 	tempName := appName + "-new"
 
+	if err := deploy.EnsureAppNetwork(ctx, client, appName, cmdLogger{}); err != nil {
+		return fmt.Errorf("network setup failed: %w", err)
+	}
+
 	// Start new container with updated env (same command as deploy/rollback)
 	databaseURL := readSavedDatabaseURL(ctx, client, appPath)
 	if err := startNewContainer(ctx, client, cfg, imageName, appPath, "", databaseURL, tempName); err != nil {
@@ -470,6 +474,7 @@ func reloadContainer(ctx context.Context, client ssh.Executor, cfg *config.Proje
 		forceRemoveContainer(ctx, client, tempName)
 		return err
 	}
+	deploy.DetachFromSharedNetwork(ctx, client, appName, cmdLogger{})
 
 	return nil
 }

--- a/internal/cmd/rollback.go
+++ b/internal/cmd/rollback.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/deploy"
 	"github.com/yoanbernabeu/frankendeploy/internal/security"
 )
 
@@ -143,6 +144,10 @@ func runRollback(cmd *cobra.Command, args []string) error {
 	databaseURL := readSavedDatabaseURL(ctx, client, appPath)
 	tempName := appName + "-rollback"
 
+	if err := deploy.EnsureAppNetwork(ctx, client, appName, cmdLogger{}); err != nil {
+		return fmt.Errorf("network setup failed: %w", err)
+	}
+
 	if err := startNewContainer(ctx, client, cfg, imageName, appPath, targetRelease, databaseURL, tempName); err != nil {
 		return err
 	}
@@ -174,6 +179,8 @@ func runRollback(cmd *cobra.Command, args []string) error {
 			PrintWarning("Failed to roll back Messenger worker: %v", err)
 		}
 	}
+
+	deploy.DetachFromSharedNetwork(ctx, client, appName, cmdLogger{})
 
 	PrintSuccess("Rolled back to release %s", targetRelease)
 

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -20,7 +20,10 @@ const (
 	ContainerUID  = "1000"
 	ContainerGID  = "1000"
 	AppPort       = "8080"
-	NetworkName   = "frankendeploy"
+	// NetworkName is the shared network created by server setup. Caddy lives
+	// on it; applications do not (see AppNetworkName). It is kept for
+	// installations deployed before per-app networks existed.
+	NetworkName = "frankendeploy"
 )
 
 // Health check defaults
@@ -48,6 +51,14 @@ const (
 	// DockerLogOptions is the ready-to-use docker run fragment.
 	DockerLogOptions = "--log-driver json-file --log-opt max-size=" + LogMaxSize + " --log-opt max-file=" + LogMaxFile
 )
+
+// AppNetworkName returns the Docker network dedicated to an application.
+// Every container of the app (app, worker, database) runs on it, and Caddy
+// is attached to it at deploy time: applications sharing a VPS never see
+// each other's containers.
+func AppNetworkName(name string) string {
+	return NetworkName + "-" + name
+}
 
 // AppBasePath returns the base path for an application on the server.
 func AppBasePath(name string) string {

--- a/internal/deploy/database.go
+++ b/internal/deploy/database.go
@@ -137,7 +137,7 @@ func DeployManagedDatabase(ctx context.Context, client ssh.Executor, cfg *config
 		-v %s:%s \
 		%s`,
 		dbContainerName,
-		constants.NetworkName,
+		constants.AppNetworkName(cfg.Name),
 		constants.DockerLogOptions,
 		dockerEnv,
 		dbVolumeName,

--- a/internal/deploy/network.go
+++ b/internal/deploy/network.go
@@ -1,0 +1,162 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/constants"
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// caddyContainerName is the front proxy container started by server setup.
+const caddyContainerName = "caddy"
+
+// EnsureAppNetwork makes the application's dedicated Docker network ready to
+// receive containers: the network exists, the Caddy front proxy is attached
+// to it (so it can still reach <app>:8080 by name), and a managed database
+// created before per-app networks existed is attached too. Every step checks
+// the current state first, so the function is safe to call on every deploy,
+// rollback and env reload, and an interrupted migration resumes on the next
+// run.
+func EnsureAppNetwork(ctx context.Context, client ssh.Executor, appName string, log Logger) error {
+	if log == nil {
+		log = NopLogger{}
+	}
+	network := constants.AppNetworkName(appName)
+
+	if !networkExists(ctx, client, network) {
+		if err := createNetwork(ctx, client, network, appName); err != nil {
+			return err
+		}
+		log.Success("Created network %s", network)
+	}
+
+	// Caddy must reach the app: without the proxy on this network the app
+	// runs but nobody can reach it.
+	switch attached, err := attachContainer(ctx, client, caddyContainerName, network); {
+	case err != nil:
+		return fmt.Errorf("the Caddy front proxy could not join network %s: %w", network, err)
+	case !attached:
+		log.Warning("Caddy container not found: the application will not be reachable until 'frankendeploy server setup' is run")
+	}
+
+	// A managed database started on the shared network (before per-app
+	// networks) is reused, never recreated: bring it onto the app network so
+	// the new containers can reach it. It stays on the shared network until
+	// the old app container is gone (see DetachFromSharedNetwork).
+	if _, err := attachContainer(ctx, client, appName+"-db", network); err != nil {
+		return fmt.Errorf("the database container could not join network %s: %w", network, err)
+	}
+
+	return nil
+}
+
+// DetachFromSharedNetwork finishes the migration to the per-app network:
+// any container of the app still attached to the shared network is
+// disconnected from it, but only once it is attached to the app network, so
+// a container is never left without a network. Best-effort: a failure is
+// reported and retried by the next deploy.
+func DetachFromSharedNetwork(ctx context.Context, client ssh.Executor, appName string, log Logger) {
+	if log == nil {
+		log = NopLogger{}
+	}
+	network := constants.AppNetworkName(appName)
+
+	for _, container := range []string{appName, appName + "-worker", appName + "-db"} {
+		networks, exists := containerNetworks(ctx, client, container)
+		if !exists || !contains(networks, constants.NetworkName) || !contains(networks, network) {
+			continue
+		}
+		result, err := client.Exec(ctx, fmt.Sprintf("docker network disconnect %s %s", constants.NetworkName, container))
+		if err == nil {
+			err = result.Err()
+		}
+		if err != nil {
+			log.Warning("Could not detach %s from the shared network %s (will retry on next deploy): %v", container, constants.NetworkName, err)
+			continue
+		}
+		log.Info("Detached %s from the shared network %s", container, constants.NetworkName)
+	}
+}
+
+// RemoveAppNetwork detaches Caddy from the app network and removes it. Used
+// by app remove, after the app containers are gone. Best-effort.
+func RemoveAppNetwork(ctx context.Context, client ssh.Executor, appName string) error {
+	network := constants.AppNetworkName(appName)
+	if !networkExists(ctx, client, network) {
+		return nil
+	}
+	_, _ = client.Exec(ctx, fmt.Sprintf("docker network disconnect %s %s 2>/dev/null || true", network, caddyContainerName))
+	result, err := client.Exec(ctx, fmt.Sprintf("docker network rm %s", network))
+	if err != nil {
+		return err
+	}
+	return result.Err()
+}
+
+// networkExists reports whether a Docker network exists on the server.
+func networkExists(ctx context.Context, client ssh.Executor, network string) bool {
+	result, err := client.Exec(ctx, fmt.Sprintf("docker network inspect %s --format '{{.Name}}' 2>/dev/null", network))
+	return err == nil && result != nil && result.ExitCode == 0 && strings.TrimSpace(result.Stdout) != ""
+}
+
+// createNetwork creates the app network. The Docker default address pools
+// only cover about 30 bridge networks: past that, the error is explained
+// instead of surfacing a cryptic "non-overlapping IPv4 address pool".
+func createNetwork(ctx context.Context, client ssh.Executor, network, appName string) error {
+	result, err := client.Exec(ctx, fmt.Sprintf("docker network create --label frankendeploy.app=%s %s", appName, network))
+	if err != nil {
+		return fmt.Errorf("failed to create network %s: %w", network, err)
+	}
+	if result.ExitCode != 0 {
+		if strings.Contains(result.Stderr, "non-overlapping") {
+			return fmt.Errorf("failed to create network %s: Docker ran out of address pools for bridge networks (one per application).\n"+
+				"Remove networks of applications no longer deployed, or extend the pools in /etc/docker/daemon.json:\n"+
+				`  {"default-address-pools": [{"base": "10.200.0.0/16", "size": 24}]}`+"\n"+
+				"then restart Docker", network)
+		}
+		return fmt.Errorf("failed to create network %s: %s", network, strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+// attachContainer connects a container to a network unless it already is.
+// Returns false without error when the container does not exist.
+func attachContainer(ctx context.Context, client ssh.Executor, container, network string) (bool, error) {
+	networks, exists := containerNetworks(ctx, client, container)
+	if !exists {
+		return false, nil
+	}
+	if contains(networks, network) {
+		return true, nil
+	}
+	result, err := client.Exec(ctx, fmt.Sprintf("docker network connect %s %s", network, container))
+	if err != nil {
+		return false, err
+	}
+	if err := result.Err(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// containerNetworks lists the networks a container is attached to, from the
+// container side: unlike "docker network inspect", it also covers stopped
+// containers (a stopped managed database keeps its network configuration).
+func containerNetworks(ctx context.Context, client ssh.Executor, container string) ([]string, bool) {
+	result, err := client.Exec(ctx, fmt.Sprintf(`docker inspect %s --format '{{range $name, $_ := .NetworkSettings.Networks}}{{$name}} {{end}}' 2>/dev/null`, container))
+	if err != nil || result == nil || result.ExitCode != 0 {
+		return nil, false
+	}
+	return strings.Fields(result.Stdout), true
+}
+
+func contains(list []string, value string) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/deploy/network_test.go
+++ b/internal/deploy/network_test.go
@@ -1,0 +1,171 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/yoanbernabeu/frankendeploy/internal/ssh"
+)
+
+// networkMock scripts docker answers per command substring; unmatched
+// commands succeed silently.
+func networkMock(responses map[string]ssh.ExecResult) *ssh.MockExecutor {
+	return &ssh.MockExecutor{
+		ExecFunc: func(_ context.Context, command string) (*ssh.ExecResult, error) {
+			for pattern, result := range responses {
+				if strings.Contains(command, pattern) {
+					r := result
+					return &r, nil
+				}
+			}
+			return &ssh.ExecResult{ExitCode: 0}, nil
+		},
+	}
+}
+
+func hasExactCommand(commands []string, want string) bool {
+	for _, c := range commands {
+		if c == want {
+			return true
+		}
+	}
+	return false
+}
+
+func hasCommand(commands []string, fragment string) bool {
+	for _, c := range commands {
+		if strings.Contains(c, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnsureAppNetwork_CreatesNetworkAndAttachesCaddy(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {ExitCode: 1},
+		"docker inspect caddy":                       {Stdout: "frankendeploy \n"},
+		"docker inspect myapp-db":                    {ExitCode: 1}, // no managed database
+	})
+
+	if err := EnsureAppNetwork(context.Background(), mock, "myapp", nil); err != nil {
+		t.Fatalf("EnsureAppNetwork: %v", err)
+	}
+	if !hasCommand(mock.Commands, "docker network create --label frankendeploy.app=myapp frankendeploy-myapp") {
+		t.Errorf("expected the app network to be created, got %v", mock.Commands)
+	}
+	if !hasCommand(mock.Commands, "docker network connect frankendeploy-myapp caddy") {
+		t.Errorf("Caddy must be attached to the app network, got %v", mock.Commands)
+	}
+	if hasCommand(mock.Commands, "docker network connect frankendeploy-myapp myapp-db") {
+		t.Errorf("no database container: nothing to attach, got %v", mock.Commands)
+	}
+}
+
+func TestEnsureAppNetwork_IsIdempotent(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+		"docker inspect caddy":                       {Stdout: "frankendeploy frankendeploy-myapp \n"},
+		"docker inspect myapp-db":                    {Stdout: "frankendeploy-myapp \n"},
+	})
+
+	if err := EnsureAppNetwork(context.Background(), mock, "myapp", nil); err != nil {
+		t.Fatalf("EnsureAppNetwork: %v", err)
+	}
+	for _, forbidden := range []string{"docker network create", "docker network connect"} {
+		if hasCommand(mock.Commands, forbidden) {
+			t.Errorf("second run must change nothing, but ran %q: %v", forbidden, mock.Commands)
+		}
+	}
+}
+
+func TestEnsureAppNetwork_MigratesExistingDatabase(t *testing.T) {
+	// Database created before per-app networks: attached to the shared
+	// network only (even when stopped, docker inspect still lists it).
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+		"docker inspect caddy":                       {Stdout: "frankendeploy frankendeploy-myapp \n"},
+		"docker inspect myapp-db":                    {Stdout: "frankendeploy \n"},
+	})
+
+	if err := EnsureAppNetwork(context.Background(), mock, "myapp", nil); err != nil {
+		t.Fatalf("EnsureAppNetwork: %v", err)
+	}
+	if !hasCommand(mock.Commands, "docker network connect frankendeploy-myapp myapp-db") {
+		t.Errorf("the existing database must join the app network, got %v", mock.Commands)
+	}
+	if hasCommand(mock.Commands, "docker network disconnect") {
+		t.Errorf("the database must stay on the shared network until the old app container is gone, got %v", mock.Commands)
+	}
+}
+
+func TestEnsureAppNetwork_CaddyConnectFailureIsFatal(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp":       {Stdout: "frankendeploy-myapp\n"},
+		"docker inspect caddy":                             {Stdout: "frankendeploy \n"},
+		"docker network connect frankendeploy-myapp caddy": {ExitCode: 1, Stderr: "Error response from daemon: boom"},
+	})
+
+	err := EnsureAppNetwork(context.Background(), mock, "myapp", nil)
+	if err == nil || !strings.Contains(err.Error(), "Caddy") {
+		t.Fatalf("a proxy that cannot join the network must fail the deploy, got %v", err)
+	}
+}
+
+func TestEnsureAppNetwork_ExplainsAddressPoolExhaustion(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {ExitCode: 1},
+		"docker network create":                      {ExitCode: 1, Stderr: "Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network"},
+	})
+
+	err := EnsureAppNetwork(context.Background(), mock, "myapp", nil)
+	if err == nil || !strings.Contains(err.Error(), "default-address-pools") {
+		t.Fatalf("pool exhaustion must explain the daemon.json fix, got %v", err)
+	}
+}
+
+func TestDetachFromSharedNetwork_OnlyWhenOnBothNetworks(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker inspect myapp ":       {Stdout: "frankendeploy-myapp \n"},               // already migrated
+		"docker inspect myapp-worker": {ExitCode: 1},                                    // no worker
+		"docker inspect myapp-db":     {Stdout: "frankendeploy frankendeploy-myapp \n"}, // mid-migration
+	})
+
+	DetachFromSharedNetwork(context.Background(), mock, "myapp", nil)
+
+	if !hasCommand(mock.Commands, "docker network disconnect frankendeploy myapp-db") {
+		t.Errorf("the database must leave the shared network once on the app network, got %v", mock.Commands)
+	}
+	if hasExactCommand(mock.Commands, "docker network disconnect frankendeploy myapp") || hasCommand(mock.Commands, "docker network disconnect frankendeploy myapp-worker") {
+		t.Errorf("containers not on the shared network must be left alone, got %v", mock.Commands)
+	}
+}
+
+func TestDetachFromSharedNetwork_NeverLeavesContainerWithoutNetwork(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker inspect myapp-db": {Stdout: "frankendeploy \n"}, // not yet on the app network
+	})
+
+	DetachFromSharedNetwork(context.Background(), mock, "myapp", nil)
+
+	if hasCommand(mock.Commands, "docker network disconnect") {
+		t.Errorf("a container only on the shared network must not be disconnected, got %v", mock.Commands)
+	}
+}
+
+func TestRemoveAppNetwork(t *testing.T) {
+	mock := networkMock(map[string]ssh.ExecResult{
+		"docker network inspect frankendeploy-myapp": {Stdout: "frankendeploy-myapp\n"},
+	})
+
+	if err := RemoveAppNetwork(context.Background(), mock, "myapp"); err != nil {
+		t.Fatalf("RemoveAppNetwork: %v", err)
+	}
+	if !hasCommand(mock.Commands, "docker network disconnect frankendeploy-myapp caddy") {
+		t.Errorf("Caddy must be detached before removing the network, got %v", mock.Commands)
+	}
+	if !hasCommand(mock.Commands, "docker network rm frankendeploy-myapp") {
+		t.Errorf("the app network must be removed, got %v", mock.Commands)
+	}
+}

--- a/internal/deploy/orchestrator.go
+++ b/internal/deploy/orchestrator.go
@@ -43,6 +43,9 @@ type Steps struct {
 	SwapContainers func(oldExists bool) error
 	// DeployWorkers starts the Messenger worker container.
 	DeployWorkers func() error
+	// IsolateNetwork detaches the app containers from the shared network once
+	// the old container is gone (optional, best-effort).
+	IsolateNetwork func()
 	// RunPostDeployHooks runs post_deploy hooks on the live container.
 	RunPostDeployHooks func() error
 	// CaddyAppConfigExists reports whether the app already has a Caddy config.
@@ -190,6 +193,12 @@ func RunPipeline(state *DeployState, steps Steps, opts Options) error {
 		} else {
 			log.Success("Messenger worker started")
 		}
+	}
+
+	// Step 8c: the old container was the last one needing the shared
+	// network: finish the migration to the per-app network
+	if steps.IsolateNetwork != nil {
+		steps.IsolateNetwork()
 	}
 
 	// Step 9: Post-deploy hooks (the new version is live: failures only warn)

--- a/internal/deploy/orchestrator_test.go
+++ b/internal/deploy/orchestrator_test.go
@@ -37,6 +37,7 @@ func makeSteps(r *stepRecorder) Steps {
 		ShowContainerLogs:    func() { r.record("logs") },
 		SwapContainers:       func(oldExists bool) error { r.record("swap"); return nil },
 		DeployWorkers:        func() error { r.record("workers"); return nil },
+		IsolateNetwork:       func() { r.record("isolate-network") },
 		RunPostDeployHooks:   func() error { r.record("post-hooks"); return nil },
 		CaddyAppConfigExists: func() bool { r.record("caddy-exists"); return true },
 		UpdateCaddy:          func() error { r.record("caddy"); return nil },
@@ -68,7 +69,7 @@ func TestRunPipeline_HappyPathOrder(t *testing.T) {
 		t.Fatalf("RunPipeline: %v", err)
 	}
 
-	want := []string{"prepare", "old-exists", "start", "backup", "pre-hooks", "migration-check", "health", "swap", "workers", "post-hooks", "caddy-exists", "caddy", "cleanup"}
+	want := []string{"prepare", "old-exists", "start", "backup", "pre-hooks", "migration-check", "health", "swap", "workers", "isolate-network", "post-hooks", "caddy-exists", "caddy", "cleanup"}
 	got := strings.Join(r.calls, ",")
 	if got != strings.Join(want, ",") {
 		t.Errorf("unexpected step order:\n got %s\nwant %s", got, strings.Join(want, ","))


### PR DESCRIPTION
Closes #96

## Summary

- Every container of an app (app, worker, managed database) now runs on `frankendeploy-<app>`, created by the first deploy, with Caddy attached to it. Applications sharing a VPS no longer see each other's containers.
- Installations deployed on the shared `frankendeploy` network migrate transparently on their next `deploy`, `rollback` or `env --reload`: the database container joins the app network (never recreated), the new app container starts on it, and the database leaves the shared network once the old app container is gone. Every step checks the current state first, so an interrupted migration resumes on the next run.
- `app remove` deletes the network, `doctor` gets an **App network** check (not created yet / Caddy not attached / containers left on the shared network / isolated), and running out of Docker address pools fails with the `daemon.json` fix instead of a cryptic error.
- Docs: server setup (networks section, architecture diagram), deployment guide (network isolation), CHANGELOG.

## Live validation on the `prod` VPS (La Drache, drache.yoandev.co)

Exactly the migration scenario: `la-drache` and `la-drache-db` were on the shared network with Caddy.

```
ℹ️  Preparing application network...
✅ Created network frankendeploy-la-drache
ℹ️  Setting up managed database...
✅ Database ready: pgsql
...
✅ Health check passed
ℹ️  Swapping containers...
ℹ️  Detached la-drache-db from the shared network frankendeploy
...
✅ Deployment complete in 1m6s!
```

After the deploy:

| Container | Networks |
|---|---|
| `caddy` | `frankendeploy`, `frankendeploy-la-drache` |
| `la-drache` | `frankendeploy-la-drache` |
| `la-drache-db` | `frankendeploy-la-drache` |

Isolation proof with throwaway `alpine` containers:

```
--- from the shared network:
nc: bad address 'la-drache-db'   → UNREACHABLE
nc: bad address 'la-drache'      → APP-UNREACHABLE
--- from the app network:
REACHABLE / APP-REACHABLE
```

`frankendeploy doctor prod` → `✅ App network — frankendeploy-la-drache (isolated)`, `https://drache.yoandev.co/api` → HTTP 200 in 0.2 s, no downtime.

## Tests

- 806 tests pass (`go test ./...`), 9 new tests for `EnsureAppNetwork` / `DetachFromSharedNetwork` / `RemoveAppNetwork`, 1 for the `doctor` check, orchestrator step order updated
- `make lint` (golangci-lint v1.64.2, same as CI) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
