### PR TITLE
fix(doctor): only check the app network once Docker is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`doctor` no longer reports the app network on a bare server**: the App network check only runs once Docker is present (on a bare server every docker command failed for the same reason), and a network not created yet is reported as fine rather than as a warning, since the first deploy creates it - @yoanbernabeu
+
 ## [0.15.0] - 2026-09-02
 
 Applications sharing a VPS no longer share a Docker network: each one now gets its own, with Caddy attached to it, so a compromised app cannot reach another app's database. Validated live on a real installation deployed on the shared network (La Drache): migrated in one deploy, zero downtime, and from the shared network the database is not even resolvable any more.

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -80,18 +80,20 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	defer conn.Client.Close()
 	client := conn.Client
 
+	remoteDocker := checkRemoteDocker(ctx, client)
 	results = append(results,
 		doctorResult{Name: "SSH connection", OK: true, Detail: fmt.Sprintf("%s@%s:%d", conn.Server.User, conn.Server.Host, conn.Server.Port)},
 		checkRemoteSudo(ctx, client),
-		checkRemoteDocker(ctx, client),
+		remoteDocker,
 		checkDockerNetwork(ctx, client),
 		checkCaddyRunning(ctx, client),
 		checkDiskSpace(ctx, client),
 	)
 
-	// --- Project checks (only inside a project) ---
+	// --- Project checks (only inside a project, and only once Docker is
+	// there: on a bare server every docker command fails for the same reason)
 	projectCfg, projectErr := config.LoadProjectConfig(GetConfigFile())
-	if projectErr == nil {
+	if projectErr == nil && remoteDocker.OK {
 		results = append(results, checkAppNetwork(ctx, client, projectCfg.Name))
 	}
 
@@ -256,7 +258,8 @@ func checkAppNetwork(ctx context.Context, client ssh.Executor, appName string) d
 
 	result, err := client.Exec(ctx, fmt.Sprintf("docker network inspect %s --format '{{.Name}}' 2>/dev/null", network))
 	if err != nil || result.ExitCode != 0 || strings.TrimSpace(result.Stdout) == "" {
-		return doctorResult{Name: name, OK: true, Warning: true, Detail: fmt.Sprintf("%s not created yet (created by the first deploy)", network)}
+		// Nothing to fix: the first deploy creates it
+		return doctorResult{Name: name, OK: true, Detail: fmt.Sprintf("%s (created by the first deploy)", network)}
 	}
 
 	attached := func(container string) (onApp, onShared, exists bool) {

--- a/internal/cmd/doctor_test.go
+++ b/internal/cmd/doctor_test.go
@@ -169,8 +169,8 @@ func TestDoctorAppNetwork(t *testing.T) {
 		"docker network inspect frankendeploy-myapp": {ExitCode: 1},
 	})
 	res := checkAppNetwork(context.Background(), notCreated, "myapp")
-	if !res.OK || !res.Warning {
-		t.Errorf("a network not created yet is a warning, not a failure: %+v", res)
+	if !res.OK || res.Warning {
+		t.Errorf("a network not created yet is fine (the first deploy creates it), got %+v", res)
 	}
 
 	caddyMissing := scriptedMock(map[string]ssh.ExecResult{


### PR DESCRIPTION
Follow-up to #97.

- The **App network** check of `doctor` only runs once the Remote Docker check passed: on a bare server every docker command failed for the same reason, and the extra line was noise.
- A network not created yet is reported as fine (`✅ App network — frankendeploy-<app> (created by the first deploy)`) rather than as a warning: there is nothing to fix, the first deploy creates it. `doctor` on a freshly set up server is all green again.

Tests updated, 806 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
