### PR TITLE
docs: put the Homebrew install first in the README and the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,12 @@
 
 ## Installation
 
-**Linux/macOS:**
+**Homebrew (macOS/Linux):**
+```bash
+brew install yoanbernabeu/tap/frankendeploy
+```
+
+**Install script (Linux/macOS):**
 ```bash
 curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh
 ```

--- a/docs/src/content/docs/installation.md
+++ b/docs/src/content/docs/installation.md
@@ -3,9 +3,17 @@ title: Installation
 description: How to install FrankenDeploy on your system
 ---
 
-## Quick Install
+## Homebrew (macOS, Linux)
 
-The fastest way to install FrankenDeploy:
+The easiest way to install and keep FrankenDeploy up to date:
+
+```bash
+brew install yoanbernabeu/tap/frankendeploy
+```
+
+Later, `brew upgrade frankendeploy` follows the releases.
+
+## Install Script
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh
@@ -19,13 +27,6 @@ If you have Go 1.24+ installed:
 
 ```bash
 go install github.com/yoanbernabeu/frankendeploy/cmd/frankendeploy@latest
-```
-
-## Homebrew (macOS)
-
-```bash
-brew tap yoanbernabeu/tap
-brew install frankendeploy
 ```
 
 ## Manual Download


### PR DESCRIPTION
The tap has shipped a formula since 0.14.0 (`yoanbernabeu/homebrew-tap`, updated by GoReleaser on every release), but the README never mentioned it and the docs listed it third, labelled macOS only.

- README: `brew install yoanbernabeu/tap/frankendeploy` first, then the install script, then `go install`
- Docs: Homebrew section first (macOS, Linux), with `brew upgrade` mentioned; install script and Go follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
