### PR TITLE
docs: full review of the hand-written documentation against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,15 @@
 
 ## Features
 
-- **Zero config** — Auto-detects PHP version, extensions, database, and assets
+- **Zero config** — Auto-detects PHP version, extensions, database, assets, Messenger, worker mode
 - **One command deploy** — `frankendeploy deploy prod` and you're live
 - **Automatic HTTPS** — Let's Encrypt certificates via Caddy
-- **Zero downtime** — Rolling deployments with health checks
-- **Instant rollback** — `frankendeploy rollback prod` if something goes wrong
-- **Local dev included** — Same Docker setup for dev and prod
+- **Zero downtime** — Blue-green deployments with health checks; a failed deploy never takes the site down
+- **Managed database** — PostgreSQL, MySQL or MariaDB container, credentials injected, backup before every migration
+- **Instant rollback** — `frankendeploy rollback prod`, with the same health check as a deploy
+- **Server preparation** — Docker, firewall, Fail2ban, Caddy, and `frankendeploy doctor` to check everything before you deploy
+- **Isolated apps** — Several apps on one VPS, each on its own Docker network
+- **Local dev included** — Same Docker image for dev and prod
 
 ## Installation
 
@@ -56,17 +59,21 @@ go install github.com/yoanbernabeu/frankendeploy/cmd/frankendeploy@latest
 
 ```bash
 # In your Symfony project
-frankendeploy init                                    # Analyze & configure
+frankendeploy init --domain my-app.com                # Analyze & configure
 
-# Setup your server (one-time)
+# Prepare your server (one-time)
 frankendeploy server add prod user@my-vps.com
 frankendeploy server setup prod --email you@email.com
+frankendeploy doctor prod                             # Server, DNS, all good?
+
+# Production secrets (DATABASE_URL is handled for you with a managed database)
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
 
 # Deploy
 frankendeploy deploy prod                             # That's it
 ```
 
-Your app is now live at `https://your-domain.com` with automatic HTTPS.
+Your app is now live at `https://my-app.com` with automatic HTTPS.
 
 ## Why FrankenDeploy?
 
@@ -86,20 +93,23 @@ Stop paying $20+/month for PaaS when a $5 VPS handles more traffic than you'll e
 
 | Command | Description |
 |---------|-------------|
-| `init` | Analyze project and generate config |
-| `build` | Generate Dockerfile and compose files |
-| `dev up/down/logs` | Local development environment |
-| `server add/setup/list` | Manage deployment servers |
-| `deploy` | Deploy to production |
-| `rollback` | Revert to previous release |
-| `logs` | View application logs |
-| `exec` / `shell` | Run commands in container |
-| `env set/get/list` | Manage environment variables |
+| `init` | Analyze the project and generate `frankendeploy.yaml` |
+| `build` | Generate the Dockerfile and compose files |
+| `dev up/down/logs/restart` | Local development environment |
+| `server add/setup/list/status/set/remove` | Manage deployment servers |
+| `doctor` | Check the local machine, the server and the DNS before a deploy |
+| `deploy` | Blue-green deployment |
+| `rollback` | Go back to a previous release |
+| `app list/status/remove` | Manage the applications deployed on a server |
+| `env set/get/list/remove/push/pull` | Manage production environment variables |
+| `logs` | Application and worker logs |
+| `exec` / `shell` | Run a command or open a shell in the container |
 
 ## Documentation
 
-- **[Getting Started](https://yoanbernabeu.github.io/frankendeploy/getting-started/)** — First deployment walkthrough
-- **[Configuration](https://yoanbernabeu.github.io/frankendeploy/guides/configuration/)** — All YAML options explained
+- **[Quick Start](https://yoanbernabeu.github.io/frankendeploy/quickstart/)** — First deployment walkthrough
+- **[frankendeploy.yaml reference](https://yoanbernabeu.github.io/frankendeploy/config/project/)** — Every option explained
+- **[Deployment guide](https://yoanbernabeu.github.io/frankendeploy/guides/deployment/)** — Health checks, hooks, backups, CI/CD
 - **[CLI Reference](https://yoanbernabeu.github.io/frankendeploy/commands/frankendeploy/)** — Every command documented
 
 ## Contributing

--- a/docs/src/content/docs/config/global.md
+++ b/docs/src/content/docs/config/global.md
@@ -1,139 +1,112 @@
 ---
 title: Global Configuration
-description: Configure FrankenDeploy globally
+description: Where servers are declared, and how to manage them
 ---
 
 ## Location
 
-Global configuration is stored at:
+The global configuration stores your servers. It lives **outside your projects**, in the user configuration directory of your system:
 
-```
-~/.config/frankendeploy/config.yaml
-```
+| System | Path |
+|--------|------|
+| macOS | `~/Library/Application Support/frankendeploy/config.yaml` |
+| Linux | `~/.config/frankendeploy/config.yaml` (or `$XDG_CONFIG_HOME/frankendeploy/config.yaml`) |
+| Windows | `%AppData%\frankendeploy\config.yaml` |
 
-This file stores server configurations that are shared across all your projects.
+It is created by the first `frankendeploy server add`. In CI, declare the server in the job with `frankendeploy server add ... --skip-test`.
+
+Two files, two roles: `frankendeploy.yaml` in the project describes the **application** and is versioned; the global config describes your **machines** and never leaves your computer.
 
 ## Structure
 
 ```yaml
-# Default settings for new servers
+# Defaults for new servers
 default_user: deploy
 default_port: 22
 
-# Configured servers
+# SSH connection timeout in seconds (optional, default: 30)
+ssh_timeout: 30
+
 servers:
-  production:
-    host: prod.example.com
+  prod:
+    host: 203.0.113.42
     user: deploy
     port: 22
-    key_path: ~/.ssh/id_ed25519
-    remote_build: true  # Build images on server (for cross-architecture)
-    apps:
-      my-app: /opt/frankendeploy/apps/my-app
+    key_path: ~/.ssh/id_ed25519   # optional, see SSH authentication
+    remote_build: true            # build images on the server
 
   staging:
     host: staging.example.com
     user: deploy
-    port: 22
+    port: 2222
 ```
-
-## Server Configuration
-
-### Adding Servers
-
-```bash
-frankendeploy server add production deploy@prod.example.com
-```
-
-FrankenDeploy automatically tests the SSH connection after adding a server. If the default key doesn't work, it will:
-- In interactive mode: show available keys and let you choose
-- In CI/CD mode (`--yes`): try keys automatically
-
-With all options:
-```bash
-frankendeploy server add staging deploy@staging.example.com \
-  --port 2222 \
-  --key ~/.ssh/id_rsa \
-  --skip-test
-```
-
-Use `--skip-test` to skip the automatic SSH connection test.
 
 ### Server Fields
 
 | Field | Description | Default |
 |-------|-------------|---------|
-| `host` | Server hostname or IP | Required |
-| `user` | SSH username | Required |
+| `host` | Hostname or IP | Required |
+| `user` | SSH user | Required |
 | `port` | SSH port | 22 |
-| `key_path` | Path to SSH private key | Auto-detected |
-| `remote_build` | Build Docker images on server instead of locally | Auto-detected |
-| `apps` | Deployed applications | Auto-populated |
+| `key_path` | SSH private key. When absent, ssh-agent and the usual keys are tried | Auto |
+| `remote_build` | Build Docker images on the server instead of locally | Unset (asked on architecture mismatch) |
 
-### Configuring Server Options
-
-Use `frankendeploy server set` to configure server-specific options:
+## Adding Servers
 
 ```bash
-# Enable remote build for a server
-frankendeploy server set production remote_build true
-
-# Disable remote build
-frankendeploy server set production remote_build false
+frankendeploy server add prod deploy@203.0.113.42
 ```
 
-### Managing Servers
+FrankenDeploy tests the SSH connection right away. On the first connection it shows the host key fingerprint and asks for confirmation, like OpenSSH, then records it in `~/.ssh/known_hosts`. If the connection fails, it looks for keys in `~/.ssh/`:
+- **Interactive**: lists the keys found (passphrase-protected ones included, the passphrase is prompted) and lets you choose
+- **`--yes` (CI)**: tries unencrypted keys one after the other
 
-List all servers:
+The working key is saved as `key_path`.
+
 ```bash
-frankendeploy server list
+frankendeploy server add staging deploy@staging.example.com --port 2222 --key ~/.ssh/staging_key
+frankendeploy server add ci user@host --skip-test     # no connection test
 ```
 
-Check server status:
+## SSH Authentication
+
+At connection time, FrankenDeploy tries in order:
+
+1. **ssh-agent**, when `SSH_AUTH_SOCK` is set
+2. **A key file**: `key_path`, or `~/.ssh/id_ed25519`, then `~/.ssh/id_rsa`, then the other keys in `~/.ssh/`
+
+Passphrase-protected keys are supported: the passphrase is prompted when needed and never stored. In non-interactive mode (`--yes`, CI), an encrypted key cannot be prompted: use ssh-agent or `FRANKENDEPLOY_SSH_KEY` (see [CI/CD](/frankendeploy/guides/deployment/#cicd-integration)).
+
+If the host key of a server changes (reinstalled VPS), the connection is refused with a clear message. When the change is expected: `ssh-keygen -R <host>`.
+
+## Server Options
+
 ```bash
-frankendeploy server status production
+frankendeploy server set prod remote_build true
+frankendeploy server set prod remote_build false
 ```
 
-Remove a server:
+`remote_build` is the only key today. FrankenDeploy also sets it for you when you accept the remote build proposal on an architecture mismatch.
+
+## Managing Servers
+
 ```bash
-frankendeploy server remove staging
+frankendeploy server list             # every server, with its options
+frankendeploy server status prod      # Docker, Caddy, network, CPU, memory, disk, per-app usage
+frankendeploy server remove staging   # forget the server (nothing changes on the machine)
 ```
 
-## SSH Key Auto-detection
+## Several Projects, Several Servers
 
-When adding a server, FrankenDeploy tests the SSH connection. If the connection fails, it discovers available keys in `~/.ssh/` and tries them in order of preference:
-
-1. `~/.ssh/id_ed25519` (preferred)
-2. `~/.ssh/id_rsa`
-3. Other `id_*` or `*.pem` files
-
-The first working key is automatically saved to the configuration.
-
-**Note:** Passphrase-protected keys are skipped during auto-detection.
-
-## Multiple Projects
-
-The global config is shared across all your projects. When you deploy an app, it's automatically registered under the server's `apps` section.
-
-This allows you to:
-- Deploy multiple apps to the same server
-- List all apps on a server: `frankendeploy app list production`
-- Manage apps independently
+Servers are shared by all your projects: deploy two applications to `prod` from two project directories, they get their own directory, database, network and Caddy configuration on the server. `frankendeploy app list prod` shows what runs there.
 
 ## Manual Editing
 
-You can manually edit the config file:
-
-```bash
-# Open in your editor
-$EDITOR ~/.config/frankendeploy/config.yaml
-```
-
-Example for adding a server manually:
+The file is plain YAML. To add a server without testing the connection:
 
 ```yaml
 servers:
-  production:
+  prod:
     host: my-vps.com
     user: deploy
     port: 22
@@ -142,23 +115,16 @@ servers:
 
 ## Troubleshooting
 
-### Config Not Found
-
-If FrankenDeploy can't find the config:
-```bash
-mkdir -p ~/.config/frankendeploy
-touch ~/.config/frankendeploy/config.yaml
-```
-
 ### SSH Connection Issues
 
-Test SSH connection manually:
+`frankendeploy doctor prod` reports the SSH connection first. To test by hand:
+
 ```bash
-ssh -i ~/.ssh/id_ed25519 deploy@your-server.com
+ssh -i ~/.ssh/id_ed25519 -p 22 deploy@your-server.com
 ```
 
-Check key permissions:
-```bash
-chmod 600 ~/.ssh/id_ed25519
-chmod 700 ~/.ssh
-```
+Key permissions matter: `chmod 600 ~/.ssh/id_ed25519` and `chmod 700 ~/.ssh`.
+
+### Behind a Gateway or a Bastion
+
+Declare the gateway as the host and its port as `port`. `server setup` reads the port the SSH daemon actually uses on the machine and opens it in the firewall too, so a gateway on 3022 in front of an sshd on 22 never locks you out.

--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -5,310 +5,304 @@ description: Project configuration reference
 
 ## Overview
 
-The `frankendeploy.yaml` file in your project root configures how FrankenDeploy builds and deploys your application.
+`frankendeploy.yaml`, at the root of your project, describes how FrankenDeploy builds and deploys the application. `frankendeploy init` writes it from what it detects; every field below can be edited by hand.
+
+The file is validated each time it is loaded. Unknown fields are rejected with an explicit error, so a typo never fails silently.
 
 ## Complete Reference
 
+Every field, with its default. Only `name` and `php.version` are required.
+
 ```yaml
 # Application name (required)
-# Used for Docker images, container names, directories
-# Must be lowercase, alphanumeric with hyphens
+# Used for the Docker image, the container names, the directories on the server
+# Lowercase letters, digits and hyphens only
 name: my-app
 
-# PHP Configuration
+# FrankenPHP image tag to build from (optional, default: "1", the latest 1.x)
+# Pin a version when you need reproducible builds
+frankenphp_version: "1"
+
+# FrankenPHP runtime options (optional)
+frankenphp:
+  # Worker mode: boots the Symfony kernel once and keeps it in memory
+  # between requests. Requires symfony/runtime >= 7.4 or the
+  # runtime/frankenphp-symfony package. Auto-enabled by init when detected.
+  worker: false
+
+# PHP configuration
 php:
-  # PHP version: 8.2, 8.3, or 8.4 (FrankenPHP requires PHP >= 8.2)
+  # PHP version: 8.2, 8.3 or 8.4 (FrankenPHP requires PHP >= 8.2)
   version: "8.3"
 
-  # PHP extensions to install
+  # PHP extensions to install in the image (dev and prod)
   extensions:
-    - pdo_pgsql
     - intl
     - opcache
-    - redis
-    - amqp
+    - zip
+    - pdo_pgsql
 
   # Custom php.ini values
   ini_values:
     - "memory_limit=256M"
     - "upload_max_filesize=50M"
-    - "post_max_size=50M"
 
-# FrankenPHP Runtime Options (optional)
-frankenphp:
-  # Worker mode: boots the Symfony kernel once and keeps it in memory
-  # between requests (significant latency improvement).
-  # Requires symfony/runtime >= 7.4 (native worker runner) or the
-  # runtime/frankenphp-symfony composer package.
-  # Auto-enabled by 'frankendeploy init' when either is detected.
-  worker: true
-
-# Database Configuration (optional)
+# Database (optional)
 database:
-  # Driver: pgsql, mysql, or sqlite
+  # Driver: pgsql, mysql, mariadb or sqlite
   driver: pgsql
 
-  # Database version for Docker image
+  # Version of the database Docker image
   version: "16"
 
-  # Path: SQLite database file path (only for sqlite driver)
-  # path: var/data.db
-
-  # Managed: if true (default for pgsql/mysql), FrankenDeploy creates a DB container
-  # If false, expects external DATABASE_URL in .env.local
-  # Note: SQLite does NOT support managed mode (file-based database)
+  # Managed: FrankenDeploy creates and maintains the database container
+  # in production and injects DATABASE_URL (default: true for pgsql,
+  # mysql and mariadb; not available for sqlite)
   managed: true
 
-# Symfony Messenger Workers (optional)
+  # SQLite only: path of the database file, relative to the project root
+  # path: var/data.db
+
+  # Local development only: override the host, port and name used in the
+  # generated DATABASE_URL of compose.yaml (rarely needed)
+  # host: database
+  # port: 5432
+  # name: app
+
+# Symfony Messenger (optional)
 messenger:
-  # Enable dedicated worker container
-  enabled: true
+  # Deploy a dedicated worker container running messenger:consume
+  enabled: false
 
-  # Number of worker processes
-  workers: 2
-
-  # Transports to consume
+  # Transports to consume (filled by init from config/packages/messenger.yaml)
   transports:
     - async
 
-# Dockerfile Customization (optional)
+# Symfony Mailer (optional): adds Mailpit to the local dev environment
+mailer:
+  enabled: false
+
+# Dockerfile customization (optional)
 dockerfile:
-  # Additional system packages
+  # Additional APT packages
   extra_packages:
     - imagemagick
-    - ffmpeg
 
-  # Additional Dockerfile commands
+  # Raw Dockerfile instructions, appended to the base stage
   extra_commands:
-    - "RUN pecl install imagick && docker-php-ext-enable imagick"
+    - "RUN install-php-extensions imagick"
 
-# Asset Build Configuration (optional)
+# Asset build (optional)
 assets:
-  # Build tool: npm, yarn, pnpm, or assetmapper
+  # Build tool: npm, yarn, pnpm or assetmapper
   build_tool: npm
 
-  # Command to build assets
+  # Command to build assets (npm, yarn, pnpm)
   build_command: "npm run build"
 
-  # Output directory (relative to project root)
+  # Output directory, relative to the project root
   output_dir: "public/build"
 
-# Deployment Configuration
+  # Node.js version of the build stage (default: 22)
+  node_version: "22"
+
+  # AssetMapper + symfonycasts/tailwind-bundle: run tailwind:build before
+  # asset-map:compile (auto-detected by init)
+  tailwind: false
+
+# Deployment
 deploy:
-  # Domain for HTTPS (required for production)
+  # Public domain served by Caddy with automatic HTTPS. Optional: without
+  # it the app runs on the server but is not publicly reachable.
   domain: my-app.com
 
   # Health check endpoint (default: /, or /api when API Platform is detected)
   healthcheck_path: /health
 
-  # Health check tuning (optional, 0 or omitted = defaults)
-  healthcheck_timeout: 90    # overall window in seconds (default: 90)
-  healthcheck_retries: 30    # max attempts (default: 30)
-  healthcheck_interval: 3    # seconds between attempts (default: 3)
+  # Health check window (0 or omitted = default)
+  healthcheck_timeout: 90    # overall window in seconds
+  healthcheck_retries: 30    # max attempts
+  healthcheck_interval: 3    # seconds between attempts
 
-  # Number of releases to keep (default: 5)
+  # Releases, Docker images and database backups to keep (default: 5)
   keep_releases: 5
 
-  # Files shared between releases
+  # Files and directories shared between releases
   shared_files:
     - .env.local
-
-  # Directories shared between releases
   shared_dirs:
     - var/log
     - var/sessions
-    - public/uploads
 
-  # Deployment hooks
+  # Optional resource limits of the app container
+  memory_limit: 512m
+  cpu_limit: "1.5"
+
+  # Deployment hooks, run inside the container
   hooks:
-    # Commands run before switching traffic
+    # In the NEW container, before traffic switches to it
     pre_deploy:
-      - php bin/console doctrine:migrations:migrate --no-interaction
+      - php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
+    # In the live container, after the switch
+    post_deploy: []
 
-    # Commands run after successful deployment
-    post_deploy:
-      - php bin/console cache:warmup
-
-# Environment Variables
+# Environment variables written into the generated Compose files
 env:
-  # Development environment
+  # compose.yaml (local development)
   dev:
     APP_DEBUG: "1"
-    MAILER_DSN: "smtp://mailhog:1025"
-
-  # Production environment
+    MAILER_DSN: "smtp://mailpit:1025"
+  # compose.prod.yaml only. NOT used by `frankendeploy deploy`:
+  # production variables are set on the server with `frankendeploy env set`
   prod:
     APP_DEBUG: "0"
-    TRUSTED_PROXIES: "127.0.0.1,REMOTE_ADDR"
 ```
 
 ## Field Details
 
 ### `name` (required)
 
-```yaml
-name: my-app
-```
+Lowercase letters, digits and hyphens. Used as the Docker image name, the container names (`<name>`, `<name>-worker`, `<name>-db`), the directory `/opt/frankendeploy/apps/<name>` and the Docker network `frankendeploy-<name>` on the server. Must be unique per server.
 
-- Must be unique per server
-- Lowercase letters, numbers, and hyphens only
-- Used as Docker image name and container name
+### `frankenphp_version`
 
-### `php.version`
-
-Supported versions:
-- `8.2`
-- `8.3`
-- `8.4`
-
-FrankenPHP requires PHP >= 8.2. If your `composer.json` allows older versions (e.g. `>=8.1`), `init` floors the detected version at 8.2 and warns you.
-
-### `php.extensions`
-
-Common extensions:
-- `pdo_pgsql` - PostgreSQL
-- `pdo_mysql` - MySQL
-- `intl` - Internationalization
-- `opcache` - Performance
-- `redis` - Redis cache
-- `amqp` - RabbitMQ
-- `gd` - Image processing
-- `imagick` - ImageMagick
-- `xdebug` - Debugging (dev only)
+Tag of the `dunglas/frankenphp` image the Dockerfile builds from (`FROM dunglas/frankenphp:<frankenphp_version>-php<php.version>`). Default `1`, which follows the latest 1.x release. Pin it (for instance `1.4`) when you need every build to use the same FrankenPHP.
 
 ### `frankenphp.worker`
 
-FrankenPHP worker mode boots the Symfony kernel **once** and keeps it in memory between requests, removing the per-request bootstrap cost.
+FrankenPHP worker mode boots the Symfony kernel **once** and keeps it in memory between requests, removing the per-request bootstrap cost. On a 2 vCPU VPS the same load test went from 23 to 53 requests per second, p95 from 5.5 s to 0.83 s.
 
 ```yaml
 frankenphp:
   worker: true
 ```
 
-Requirements and constraints:
+- A worker runtime must be installed: `symfony/runtime` >= 7.4 ships it natively; older apps can use the `runtime/frankenphp-symfony` package. `build` and `deploy` fail with a clear message if neither is present.
+- **The application must be stateless**: static properties survive between requests. Symfony services are reset automatically, hand-written static caches are not.
+- Memory leaks surface as automatic worker restarts.
+- `init` enables it automatically (with a warning) when a worker runtime is detected. Opt out with `worker: false`.
+- Production only: the dev environment keeps classic mode for easier debugging.
 
-- A FrankenPHP worker runtime must be installed: `symfony/runtime` >= 7.4 ships the worker runner natively (nothing to add on a recent Symfony), older apps can use the `runtime/frankenphp-symfony` package. `frankendeploy build` fails with a clear message if neither is present.
-- The generated Caddyfile only forces `APP_RUNTIME` for `runtime/frankenphp-symfony`; with the native runtime, Symfony selects the worker runner itself.
-- **The application must be stateless**: any static property or service state survives between requests. Symfony services are reset automatically, but hand-written static caches are not.
-- Memory leaks surface as automatic worker restarts (FrankenPHP restarts workers hitting their memory limit).
-- `frankendeploy init` enables it automatically (with a warning) when a worker runtime is detected. Opt out with `worker: false`.
-- Worker mode applies to **production only** — the dev environment keeps classic mode for easier debugging.
+When enabled, `build` generates a `Caddyfile` at the project root that is baked into the production image.
 
-When enabled, `frankendeploy build` generates a `Caddyfile` at the project root that is baked into the production image.
+### `php.version`
+
+`8.2`, `8.3` or `8.4`. FrankenPHP requires PHP >= 8.2: if `composer.json` allows older versions, `init` floors the detected version at 8.2 and warns you.
+
+### `php.extensions`
+
+Installed with `install-php-extensions` in the base image, so they are present in **both** dev and prod. `init` always adds `intl`, `opcache` and `zip`, the PDO driver of your database, `amqp` or `redis` when a Messenger transport uses them, and `pcntl` with Messenger (graceful worker shutdown).
+
+Common extensions: `pdo_pgsql`, `pdo_mysql`, `pdo_sqlite`, `intl`, `opcache`, `redis`, `amqp`, `gd`, `imagick`, `xdebug`. Xdebug is installed but disabled by default (`XDEBUG_MODE=off`); see [Local Development](/frankendeploy/guides/local-development/#debugging-with-xdebug) to enable it.
 
 ### `database.driver`
 
-| Driver | Docker Image |
-|--------|-------------|
-| `pgsql` | postgres:VERSION-alpine |
-| `mysql` | mysql:VERSION |
-| `mariadb` | mariadb:VERSION |
-| `sqlite` | No container needed |
+| Driver | Docker image | Managed mode |
+|--------|-------------|--------------|
+| `pgsql` | `postgres:<version>-alpine` | Yes |
+| `mysql` | `mysql:<version>` | Yes |
+| `mariadb` | `mariadb:<version>` | Yes |
+| `sqlite` | No container | No (file-based) |
 
-MariaDB is auto-detected from `DATABASE_URL` (a `mariadb://` scheme or a `serverVersion` ending in `-MariaDB`). The generated `DATABASE_URL` uses the `mysql://` scheme with the `-MariaDB` serverVersion suffix, as Doctrine expects.
-
-The scanner reads `DATABASE_URL` from `.env` **and** `.env.local` (the latter wins, matching Symfony's runtime behavior), and warns when the two files disagree on the driver.
-
-### `database.path`
-
-**SQLite only.** The file path for the SQLite database (relative to project root).
-
-```yaml
-database:
-  driver: sqlite
-  path: var/data.db
-```
-
-When using SQLite, FrankenDeploy automatically adds the database directory (e.g., `var`) to `shared_dirs` to ensure data persistence across deployments.
+The scanner reads `DATABASE_URL` from `.env` **and** `.env.local` (the latter wins, matching Symfony) and warns when the two disagree. MariaDB is detected from a `mariadb://` scheme or a `serverVersion` ending in `-MariaDB`; the generated URL uses the `mysql://` scheme with the `-MariaDB` suffix, as Doctrine expects.
 
 ### `database.managed`
 
-Controls how the database is provisioned in production:
-
 | Value | Behavior |
 |-------|----------|
-| `true` (default for pgsql/mysql) | FrankenDeploy creates a Docker container for the DB |
-| `false` | Use external database, set `DATABASE_URL` in `.env.local` |
+| `true` (default for pgsql, mysql, mariadb) | FrankenDeploy creates the `<name>-db` container on the first deploy, generates random credentials, injects `DATABASE_URL` into the app, keeps the data in a Docker volume, and dumps the database before every migration |
+| `false` | You provide `DATABASE_URL` with `frankendeploy env set` (external database) |
 
-:::caution[SQLite Limitation]
-SQLite does **not** support `managed: true`. SQLite is a file-based database and cannot run as a container. If you set `managed: true` with SQLite, validation will fail with an error.
-
-For SQLite persistence in production, ensure the database directory is in `shared_dirs`.
+:::caution[SQLite]
+SQLite cannot run as a container: `managed: true` with `driver: sqlite` fails validation. For persistence in production, the directory of the database file is added to `shared_dirs` automatically.
 :::
+
+### `database.path`
+
+SQLite only. Path of the database file relative to the project root, detected from `DATABASE_URL` (`sqlite:///%kernel.project_dir%/var/data.db` gives `var/data.db`).
 
 ### `messenger`
 
-Configures Symfony Messenger worker containers:
-
 ```yaml
 messenger:
-  enabled: true     # Deploy a dedicated worker container
-  workers: 2        # Number of worker processes
-  transports:       # Transports to consume
+  enabled: true
+  transports:
     - async
-    - high_priority
+    - scheduler_default
 ```
 
-When enabled, FrankenDeploy deploys a separate container (`<app>-worker`) running `messenger:consume`.
+When enabled, each deploy (and rollback) starts one `<name>-worker` container running `php bin/console messenger:consume <transports> --time-limit=3600 --memory-limit=256M`. The worker is recreated with the new image at every deploy, so it always runs the same code as the app.
 
-`frankendeploy init` fills `transports` from the transports actually configured in `config/packages/messenger.yaml` (resolving `%env()%` DSNs through `.env`/`.env.local`). The failure transport and `sync://` transports are excluded. With `symfony/scheduler` installed, `scheduler_default` is added so scheduled tasks actually run in production. An `amqp://` or `redis://` transport DSN also adds the matching PHP extension, and `pcntl` is always added with Messenger for graceful worker shutdown — every inference is announced at `init`.
+`init` fills `transports` from `config/packages/messenger.yaml` (resolving `%env()%` DSNs through `.env` / `.env.local`), excluding the failure transport and `sync://` transports. With `symfony/scheduler` installed, `scheduler_default` is added so scheduled tasks actually run in production. Every inference is announced at `init`.
+
+### `mailer.enabled`
+
+Set by `init` when `config/packages/mailer.yaml` exists. Adds a [Mailpit](https://mailpit.axllent.org/) service to the local dev environment (SMTP on `mailpit:1025`, web UI on http://localhost:8025). No effect in production.
 
 ### `dockerfile`
 
-Customize the generated Dockerfile:
-
 ```yaml
 dockerfile:
-  extra_packages:     # APT packages to install
+  extra_packages:     # APT packages installed in the base stage
     - imagemagick
-    - ffmpeg
-  extra_commands:     # Raw Dockerfile instructions
-    - "RUN pecl install redis && docker-php-ext-enable redis"
+  extra_commands:     # Raw Dockerfile instructions appended to the base stage
+    - "RUN install-php-extensions imagick"
 ```
 
-### `assets.tailwind`
+`extra_commands` are validated: only `RUN`, `ENV`, `ARG`, `COPY`, `WORKDIR` and a few other instructions are accepted, and shell injection patterns are rejected.
 
-With `symfonycasts/tailwind-bundle` (AssetMapper), `tailwind:build --minify` must run **before** `asset-map:compile` — otherwise the site deploys without CSS. The scanner detects the bundle and sets `tailwind: true` automatically (announced at `init`).
+### `assets`
 
-```yaml
-assets:
-  build_tool: assetmapper
-  tailwind: true
-```
+| `build_tool` | Detected from | What the image build runs |
+|------|-----------|-----|
+| `npm` | `package-lock.json` | Node stage: `npm ci`, then `build_command` |
+| `yarn` | `yarn.lock` | Node stage: `npm ci`, then `build_command` (see note) |
+| `pnpm` | `pnpm-lock.yaml` | Node stage: `npm ci`, then `build_command` (see note) |
+| `assetmapper` | `importmap.php` | `php bin/console asset-map:compile` in the PHP image, no Node stage |
 
-### `assets.build_tool`
+With `npm`, `yarn` and `pnpm`, the assets are built in a separate Node stage (`node_version`, default 22) and the `output_dir` directory is copied into the final image. **Note**: the Node stage currently installs dependencies with `npm ci` whatever the detected tool, so a project that only has a `yarn.lock` or `pnpm-lock.yaml` needs a `package-lock.json` as well (`npm install --package-lock-only`) until the stage honors the other package managers. With AssetMapper and `symfonycasts/tailwind-bundle`, `tailwind: true` (auto-detected) runs `tailwind:build --minify` first, otherwise the site deploys without CSS.
 
-| Tool | Detection |
-|------|-----------|
-| `npm` | package-lock.json |
-| `yarn` | yarn.lock |
-| `pnpm` | pnpm-lock.yaml |
-| `assetmapper` | importmap.php |
+### `deploy.domain`
+
+The public domain Caddy serves with an automatic Let's Encrypt certificate. Optional: without it, the deploy succeeds and the app runs on the server, but nothing exposes it publicly. The domain's A record must point to the server; `frankendeploy doctor` checks it.
+
+### `deploy.healthcheck_*`
+
+`healthcheck_path` is used both by the deploy-time health check (before traffic switches) and by the Docker `HEALTHCHECK` baked into the image. Default `/`, or `/api` when `init` detects API Platform (a pure API answers 404 on `/`). The window is 90 seconds by default: a cold Symfony container needs time for opcache warmup and database wait. See [Health checks](/frankendeploy/guides/deployment/#health-checks).
+
+### `deploy.keep_releases`
+
+Number of releases kept on the server for rollback (default 5). The same count drives the Docker images kept and the pre-migration database backups.
+
+### `deploy.shared_files` / `deploy.shared_dirs`
+
+Paths persisted across releases, stored under `/opt/frankendeploy/apps/<name>/shared/` and mounted into the container. Defaults: `.env.local` (mounted read-only) and `var/log`, `var/sessions`. Add `public/uploads` or any directory that must survive a deploy. Setting either list replaces the default.
+
+### `deploy.memory_limit` / `deploy.cpu_limit`
+
+Optional caps on the app container (`docker run --memory` / `--cpus`), applied from the next deploy. They protect the VPS from a leaking or runaway application. Log rotation is always on for every container FrankenDeploy starts (`json-file`, 10 MB × 3 files).
 
 ### `deploy.hooks`
 
-Hooks run inside the container. Available commands:
-- Symfony console: `php bin/console ...`
-- Composer: `composer ...`
-- Any installed binary
+Commands run inside the container with `docker exec`: Symfony console, Composer, any installed binary.
 
-**Auto-fill:** When running `frankendeploy init`, hooks are automatically populated based on detected features:
-- If Doctrine is detected: `php bin/console doctrine:migrations:migrate --no-interaction` in `pre_deploy`
-- If Symfony: `php bin/console cache:warmup` in `post_deploy`
+- `pre_deploy` runs in the **new** container while the old one still serves traffic. A failure removes the new container and aborts the deploy (unless `--force`). With a managed database, a hook containing `doctrine:migrations:migrate` triggers an automatic backup first.
+- `post_deploy` runs in the live container after the switch. A failure only warns.
+
+`init` adds the migration hook when Doctrine is detected. No `cache:warmup` hook is needed: the cache is warmed at image build time.
 
 ### `env`
 
-Environment variables are passed to Docker. For secrets, use:
-- Server environment variables
-- Docker secrets
-- External secrets manager
+`env.dev` is written into the generated `compose.yaml`; `env.prod` into `compose.prod.yaml`, a template for people who deploy with Compose by hand.
+
+**`frankendeploy deploy` does not read `env.prod`.** In production, the container gets `SERVER_NAME`, `APP_ENV=prod`, `APP_DEBUG=0` and the managed `DATABASE_URL` from FrankenDeploy, and everything else from the `.env.local` on the server, managed with [`frankendeploy env`](/frankendeploy/guides/environment-variables/). Secrets never belong in `frankendeploy.yaml`, which is versioned.
 
 ## Validation
 
-Run to validate your configuration:
+The configuration is validated on every load (`build`, `deploy`, `dev`, …). To check it without doing anything else:
 
 ```bash
 frankendeploy build
 ```
 
-Errors are displayed with details on how to fix them.
+Errors name the field and explain how to fix it.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -5,9 +5,9 @@ description: What is FrankenDeploy and why use it
 
 ## What is FrankenDeploy?
 
-**FrankenDeploy** is a CLI tool that simplifies deploying Symfony applications on VPS servers using [FrankenPHP](https://frankenphp.dev).
+**FrankenDeploy** is a CLI that deploys Symfony applications to any VPS using [FrankenPHP](https://frankenphp.dev).
 
-It provides a seamless experience from local development to production deployment, handling Docker configuration, server setup, and zero-downtime deployments.
+It covers the whole path from local development to production: Docker configuration, server preparation, zero-downtime deployments, rollbacks. One YAML file, a handful of commands, no PaaS.
 
 ## Built on FrankenPHP
 
@@ -17,37 +17,37 @@ FrankenDeploy is a deployment layer on top of **FrankenPHP**, the modern PHP app
 - **Worker mode** - Keeps your app in memory for ultra-fast responses
 - **Single binary** - No separate PHP-FPM, nginx, or Apache needed
 
-FrankenDeploy wraps all this power into simple commands.
+FrankenDeploy wraps all this into simple commands.
 
-## Key Features
+## What it does for you
 
 ### Auto-detection
-FrankenDeploy analyzes your Symfony project and automatically detects:
+`frankendeploy init` analyzes your Symfony project and detects:
 - PHP version from `composer.json` (8.2 minimum, required by FrankenPHP)
-- Required PHP extensions
-- Database driver (PostgreSQL, MySQL, SQLite)
-- Asset build tools (Webpack Encore, Vite, AssetMapper)
+- Required PHP extensions (from `composer.json`, plus what your database and Messenger transports need)
+- Database driver (PostgreSQL, MySQL, MariaDB, SQLite) from `.env` / `.env.local`
+- Asset build tool (Webpack Encore, Vite, AssetMapper, Tailwind bundle)
+- Symfony Messenger transports, Mailer, Scheduler
 - API Platform (sets the health check path to `/api`)
+- FrankenPHP worker mode when your runtime supports it
 
-### Docker Generation
-Generates optimized Docker configuration:
-- Multi-stage Dockerfile with FrankenPHP
-- compose.yaml for local development
-- Production-ready configuration
+### Docker generation
+Generates an optimized multi-stage `Dockerfile` for FrankenPHP, a `compose.yaml` for local development, and the supporting files. Missing files are generated at deploy time; files you customized are never overwritten.
 
-Missing files are generated automatically at deploy time — customized files are never overwritten.
+### Server preparation
+`frankendeploy server setup` turns a bare Ubuntu/Debian VPS into a deployment target: Docker, UFW firewall, Fail2ban, and Caddy as a front reverse proxy with automatic Let's Encrypt certificates. `frankendeploy doctor` checks everything (local Docker, SSH, server, DNS) and tells you exactly what to fix before you deploy.
 
-### One-Command Deployment
+### One-command, zero-downtime deployment
 ```bash
-frankendeploy deploy production
+frankendeploy deploy prod
 ```
-Handles everything: building, transferring, starting containers, health checks, and cleanup.
+Builds the image (locally or on the server), transfers it, starts the new version next to the old one, runs your migrations, checks the application health, then switches traffic. If anything fails before the switch, the old version keeps serving. A managed database, its credentials and a backup before each migration are handled for you.
 
-### Rolling Deployments
-- Zero-downtime deployments
-- Automatic health checks
-- Instant rollback if something fails
-- Release history management
+### Operations
+- `rollback` to any kept release, with the same health check as a deploy
+- `env set` / `env push` for production secrets, applied without downtime with `--reload`
+- `logs`, `exec`, `shell` on the running container
+- Several applications on one VPS, each on its own isolated Docker network
 
 ## Quick Example
 
@@ -55,25 +55,24 @@ Handles everything: building, transferring, starting containers, health checks, 
 # In your Symfony project
 cd my-symfony-app
 
-# Initialize FrankenDeploy (with optional domain)
+# Analyze the project and create frankendeploy.yaml
 frankendeploy init --domain my-app.com
 
-# Generate Docker files (optional — deploy does it for you)
+# Optional: start the local development environment
 frankendeploy build
-
-# Start local development
 frankendeploy dev up
 
-# Configure a server (one-time setup)
-frankendeploy server add production deploy@my-vps.com
-frankendeploy server setup production --email admin@example.com
+# Declare and prepare a server (one-time)
+frankendeploy server add prod deploy@my-vps.com
+frankendeploy server setup prod --email admin@example.com
+frankendeploy doctor prod
 
-# Set environment variables for this app
+# Production secrets for this app
 # (DATABASE_URL is injected automatically with a managed database)
-frankendeploy env set production APP_SECRET="your-secret"
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
 
-# Deploy!
-frankendeploy deploy production --remote-build
+# Deploy
+frankendeploy deploy prod
 ```
 
 ## Next Steps

--- a/docs/src/content/docs/guides/configuration.md
+++ b/docs/src/content/docs/guides/configuration.md
@@ -1,13 +1,15 @@
 ---
 title: Project Configuration
-description: Configure frankendeploy.yaml for your project
+description: How frankendeploy init builds your frankendeploy.yaml, and how to adjust it
 ---
 
-## Configuration File
+## The Configuration File
 
-FrankenDeploy uses `frankendeploy.yaml` in your project root. This file is created by `frankendeploy init` and can be customized.
+FrankenDeploy reads one file, `frankendeploy.yaml`, at the root of your project. `frankendeploy init` creates it from what it detects; you can then edit it by hand. It is versioned with your code and contains no secret.
 
-## Full Example
+The full list of fields is in the [frankendeploy.yaml reference](/frankendeploy/config/project/). This page explains where the values come from.
+
+## A Typical File
 
 ```yaml
 name: my-app
@@ -15,194 +17,77 @@ name: my-app
 php:
   version: "8.3"
   extensions:
-    - pdo_pgsql
     - intl
     - opcache
-    - redis
-  ini_values:
-    - "memory_limit=256M"
-    - "upload_max_filesize=50M"
+    - zip
+    - pdo_pgsql
 
 database:
   driver: pgsql
   version: "16"
+  managed: true
 
 assets:
-  build_tool: npm
-  build_command: "npm run build"
-  output_dir: "public/build"
+  build_tool: assetmapper
 
 deploy:
   domain: my-app.com
-  healthcheck_path: /health
+  healthcheck_path: /api
   keep_releases: 5
-  shared_files:
-    - .env.local
-  shared_dirs:
-    - var/log
-    - var/sessions
   hooks:
     pre_deploy:
-      - php bin/console doctrine:migrations:migrate --no-interaction
-    post_deploy:
-      - php bin/console cache:warmup
-
-env:
-  dev:
-    APP_DEBUG: "1"
-  prod:
-    APP_DEBUG: "0"
-```
-
-## Configuration Options
-
-### `name`
-
-Your application name. Used for Docker images, container names, and directory structure.
-
-```yaml
-name: my-symfony-app
-```
-
-Must be lowercase, alphanumeric with hyphens only.
-
-### `php`
-
-PHP configuration for your application.
-
-```yaml
-php:
-  version: "8.3"      # PHP version (8.2 minimum — required by FrankenPHP)
-  extensions:         # PHP extensions to install
-    - pdo_pgsql
-    - intl
-  ini_values:         # Custom php.ini settings
-    - "memory_limit=256M"
-```
-
-### `database`
-
-Database configuration for Docker Compose.
-
-```yaml
-database:
-  driver: pgsql       # pgsql, mysql, or sqlite
-  version: "16"       # Database version
-```
-
-#### SQLite Configuration
-
-SQLite is a file-based database and is handled differently from PostgreSQL and MySQL:
-
-```yaml
-database:
-  driver: sqlite
-  version: "3"
-  path: var/data.db   # Automatically detected from DATABASE_URL
-```
-
-Key differences for SQLite:
-- **No `managed` option**: SQLite cannot run as a container, so `managed: true` is not allowed
-- **Automatic shared_dirs**: The SQLite database directory is automatically added to `shared_dirs` for persistence
-- **Path detection**: The file path is extracted from your `DATABASE_URL` in `.env`
-
-Example `.env` for SQLite:
-```bash
-DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"
-```
-
-### `assets`
-
-Frontend asset build configuration.
-
-```yaml
-assets:
-  build_tool: npm        # npm, yarn, pnpm, or assetmapper
-  build_command: "npm run build"
-  output_dir: "public/build"
-  node_version: "22"     # Node.js version for the build stage (default: 22)
-```
-
-For Symfony AssetMapper, set:
-```yaml
-assets:
-  build_tool: assetmapper
-```
-
-### `deploy`
-
-Deployment configuration.
-
-```yaml
-deploy:
-  domain: example.com           # Domain for HTTPS (Caddy config)
-  healthcheck_path: /health     # Health check endpoint
-  keep_releases: 5              # Number of releases to keep
-  shared_files:                 # Files shared between releases
-    - .env.local
-  shared_dirs:                  # Directories shared between releases
-    - var/log
-    - var/sessions
-  hooks:
-    pre_deploy:                 # Commands before switching traffic
-      - php bin/console doctrine:migrations:migrate --no-interaction
-    post_deploy:                # Commands after deployment
-      - php bin/console cache:warmup
-  memory_limit: 512m            # Optional: cap the app container memory
-  cpu_limit: "1.5"              # Optional: cap the app container CPUs
-```
-
-**Log rotation** is always on: every container FrankenDeploy starts (app, worker, database, Caddy) uses the `json-file` driver capped at 10 MB × 3 files, so container logs can never fill the server disk. Optional `memory_limit` / `cpu_limit` protect the VPS from a leaking or runaway app container — with 0 downtime deploys, the limits apply from the next deploy.
-
-### `env`
-
-Environment variables for different environments.
-
-```yaml
-env:
-  dev:
-    APP_DEBUG: "1"
-    MAILER_DSN: "smtp://mailhog:1025"
-  prod:
-    APP_DEBUG: "0"
-    TRUSTED_PROXIES: "127.0.0.1,REMOTE_ADDR"
+      - php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
 ```
 
 ## Auto-detection
 
-When you run `frankendeploy init`, it automatically detects:
+`frankendeploy init` scans the project and announces every inference:
 
-| Feature | Detection Method |
-|---------|------------------|
-| PHP version | `composer.json` require.php constraint (floored at 8.2) |
-| PHP extensions | `composer.json` ext-* requirements |
-| Database | `doctrine.yaml`, `.env` DATABASE_URL |
-| Assets | `package.json`, `vite.config.js`, `importmap.php` |
-| API Platform | `composer.json` (`api-platform/*`) — sets `healthcheck_path: /api` |
+| Feature | Detected from | Result |
+|---------|---------------|--------|
+| PHP version | `composer.json` `require.php` | `php.version`, floored at 8.2 (FrankenPHP requirement) |
+| PHP extensions | `composer.json` `ext-*` and known packages, database driver, Messenger DSNs | `php.extensions` (always includes `intl`, `opcache`, `zip`) |
+| Database | `DATABASE_URL` in `.env` and `.env.local` (`.env.local` wins) | `database.driver`, `database.version`, `database.path` for SQLite |
+| Assets | `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `importmap.php`, Vite/Webpack config | `assets.build_tool`, `assets.tailwind` |
+| Messenger | `config/packages/messenger.yaml` | `messenger.enabled`, `messenger.transports` (plus `scheduler_default` with `symfony/scheduler`) |
+| Mailer | `config/packages/mailer.yaml` | `mailer.enabled` (Mailpit in dev) |
+| API Platform | `api-platform/*` in `composer.json` | `deploy.healthcheck_path: /api` |
+| Doctrine | `config/packages/doctrine.yaml` | migration hook in `deploy.hooks.pre_deploy` |
+| Worker mode | `symfony/runtime` >= 7.4 or `runtime/frankenphp-symfony` | `frankenphp.worker: true` |
 
-### Init Options
+When `.env` and `.env.local` disagree on the database driver, `init` warns and follows `.env.local`, as Symfony would at runtime.
 
-You can pass additional options to `frankendeploy init`:
+## Init Options
 
 ```bash
-# Set your production domain during initialization
+# Set the production domain right away
 frankendeploy init --domain my-app.com
 
-# Overwrite existing configuration
-frankendeploy init --force
-
-# Custom project name
+# Use a custom application name (default: the directory name)
 frankendeploy init --name my-custom-name
+
+# Overwrite an existing frankendeploy.yaml
+frankendeploy init --force
 ```
 
-If no domain is provided, you can add it later in `frankendeploy.yaml` under `deploy.domain`.
+Without `--domain`, add it later under `deploy.domain`: the app deploys fine without one, it just is not publicly reachable.
+
+## Adjusting the File
+
+The most common edits after `init`:
+
+- **Shared directories**: add `public/uploads` (or any directory that must survive a deploy) to `deploy.shared_dirs`. Setting the list replaces the default `var/log`, `var/sessions`.
+- **Resource limits**: `deploy.memory_limit: 512m` and `deploy.cpu_limit: "1.5"` cap the app container.
+- **Health check**: point `deploy.healthcheck_path` to a route that proves the app works (a database query, for instance), and widen the window with `healthcheck_timeout` if a cold start takes long.
+- **Extra system packages or PHP extensions**: `dockerfile.extra_packages` and `php.extensions`.
+- **Pin FrankenPHP**: `frankenphp_version: "1.4"` for reproducible builds.
+
+Production **environment variables and secrets are not in this file**: they live on the server, managed with [`frankendeploy env`](/frankendeploy/guides/environment-variables/).
 
 ## Validation
 
-FrankenDeploy validates your configuration. Run:
+The file is validated every time it is loaded, and unknown fields are rejected (a typo never fails silently). To validate without doing anything else:
 
 ```bash
 frankendeploy build
 ```
-
-If there are issues, you'll see validation errors with details on how to fix them.

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -6,33 +6,37 @@ description: Deploy your Symfony application to production
 ## Basic Deployment
 
 ```bash
-frankendeploy deploy production
+frankendeploy deploy prod
 ```
 
-This command performs a complete blue-green deployment:
-1. Generates missing Docker artifacts (`Dockerfile`, `docker-entrypoint.sh`, `.dockerignore`) — no need to run `build` first, and customized files are never overwritten
-2. Builds the Docker image (locally, or on the server with remote build)
-3. Transfers it to the server
-4. Sets up the managed database container if configured (`DATABASE_URL` is injected automatically)
-5. Starts the **new** container alongside the old one and runs pre-deploy hooks
-6. Runs health checks on the new container
-7. Swaps traffic to the new container (zero downtime), then stops the old one
-8. Updates Caddy configuration and cleans up old releases
+One command, a complete blue-green deployment:
 
-If any step fails before the swap, the old container keeps serving traffic untouched.
+1. Pre-flight check of the environment variables the app needs on the server (`APP_SECRET`, `DATABASE_URL` for an external database)
+2. Generates missing Docker artifacts (`Dockerfile`, `docker-entrypoint.sh`, `.dockerignore`, `Caddyfile` in worker mode). No need to run `build` first; customized files are never overwritten
+3. Builds the Docker image, locally or on the server with remote build, and transfers it
+4. Ensures the application's isolated Docker network exists
+5. Starts the managed database container if configured, and injects `DATABASE_URL`
+6. Starts the **new** container next to the old one, backs up the database, runs the `pre_deploy` hooks (migrations)
+7. Runs the health check on the new container
+8. Switches traffic to the new container (zero downtime), then stops the old one
+9. Restarts the Messenger worker on the new image, runs the `post_deploy` hooks
+10. Writes the Caddy configuration for the domain and reloads the proxy
+11. Cleans up old releases, images and backups beyond `keep_releases`
+
+If any step fails before the switch, the old container keeps serving traffic untouched. Before a first deploy, run [`frankendeploy doctor prod`](/frankendeploy/guides/doctor/).
 
 ## Deployment Options
 
 ### Custom Tag
 ```bash
-frankendeploy deploy production --tag v1.2.3
+frankendeploy deploy prod --tag v1.2.3
 ```
 
-By default, tags are timestamps like `20240115-143052`.
+By default, tags are timestamps like `20260902-143052`. The tag names the release and the Docker image.
 
 ### Cross-Architecture Detection
 
-FrankenDeploy automatically detects architecture mismatches between your local machine and the server. When deploying from Apple Silicon (ARM) to an x86_64 VPS, you'll see:
+FrankenDeploy compares the architecture of your machine and of the server. Deploying from Apple Silicon (arm64) to an x86_64 VPS, you see:
 
 ```
 ⚠️  Architecture mismatch detected:
@@ -42,76 +46,68 @@ FrankenDeploy automatically detects architecture mismatches between your local m
    Local builds will not run on this server.
 ```
 
-In **interactive mode**, FrankenDeploy prompts you to enable remote build and saves your preference for future deployments.
+In **interactive mode**, FrankenDeploy offers to enable remote build and saves the preference on the server entry (`remote_build: true` in the [global config](/frankendeploy/config/global/)).
 
-In **CI/CD mode** (`--yes`), you must explicitly use `--remote-build` or pre-configure the server:
+In **CI/CD mode** (`--yes`), either pass `--remote-build` or configure the server once:
 
 ```bash
-# Configure server for remote builds
-frankendeploy server set production remote_build true
-
-# Or use the flag
-frankendeploy deploy production --remote-build --yes
+frankendeploy server set prod remote_build true
 ```
 
-### Remote Build (Recommended for Apple Silicon)
-Build the Docker image directly on the server instead of locally:
+### Remote Build (recommended for Apple Silicon)
+Build the Docker image on the server instead of locally:
 ```bash
-frankendeploy deploy production --remote-build
+frankendeploy deploy prod --remote-build
 ```
-
-This is **recommended** when:
-- Your local machine has a different architecture (Apple Silicon → x86 VPS)
-- Local builds are slow due to emulation
-- You want faster transfers (source code vs Docker image)
 
 How it works:
-1. Transfers source code over the existing SSH connection (pure-Go SFTP — no rsync/scp required, works on Windows; excludes node_modules/vendor)
-2. Builds Docker image on the VPS
-3. Deploys normally
+1. The source code is transferred over the existing SSH connection (pure-Go SFTP: no rsync or scp needed, works on Windows; `.git`, `node_modules`, `vendor`, `var` and `.env.local` are excluded)
+2. The image is built on the VPS, with Docker's layer cache, so the second build is much faster than the first
+3. The deploy continues normally
+
+Recommended when your machine has a different architecture than the server, when local builds are slow, or when your upload bandwidth is small (source code is much smaller than an image).
 
 ### Force Local Build
-If remote build is configured but you want to build locally anyway:
+If remote build is configured on the server but you want a local build this time:
 ```bash
-frankendeploy deploy production --no-remote-build
+frankendeploy deploy prod --no-remote-build
 ```
 
 ### Skip Build
-If you've already built the image:
+If the image with this tag already exists locally:
 ```bash
-frankendeploy deploy production --no-build
+frankendeploy deploy prod --no-build --tag v1.2.3
 ```
 
 ### Skip Individual Checks
 ```bash
 # Skip the pre-flight environment variables check
-frankendeploy deploy production --skip-env-check
+frankendeploy deploy prod --skip-env-check
 
 # Skip the health check entirely (traffic switches unverified)
-frankendeploy deploy production --skip-healthcheck
+frankendeploy deploy prod --skip-healthcheck
 ```
 
 ### Force Deploy
-`--force` skips the env pre-flight and continues even when pre-deploy hooks (e.g. migrations) or the health check fail — use with care:
+`--force` skips the env pre-flight and continues even when the database backup, the `pre_deploy` hooks (migrations) or the health check fail. Use with care:
 ```bash
-frankendeploy deploy production --force
+frankendeploy deploy prod --force
 ```
 
 ## Health Checks
 
-FrankenDeploy verifies your application is healthy before switching traffic.
+FrankenDeploy verifies that the new container answers before switching traffic to it.
 
-Configure in `frankendeploy.yaml`:
 ```yaml
 deploy:
   healthcheck_path: /health
 ```
 
-The default path is `/`. For **API Platform** projects, `init` detects the framework and sets the path to `/api` automatically — a pure API returns 404 on `/`, which would fail every health check. The same path is also used **by the Docker `HEALTHCHECK` baked into the generated image**, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
+The default path is `/`. For **API Platform** projects, `init` sets it to `/api` automatically: a pure API returns 404 on `/`, which would fail every health check. The same path is used by the Docker `HEALTHCHECK` baked into the image, so `docker ps` health status reflects the application actually answering, not just the web server process being up.
 
-The reverse proxy deliberately runs **no active health check** on the live container: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow application into a 503 for every visitor. The health check that protects production is the one run before the traffic switch. Per-request timeouts apply instead (5 s to connect, 60 s for the response headers): a container that accepts connections but never answers costs the affected visitor a 504, not an endless wait.
+The reverse proxy deliberately runs **no active health check** on the live container: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow application into a 503 for every visitor. Per-request timeouts apply instead (5 s to connect, 60 s for the response headers): a container that accepts connections but never answers costs the affected visitor a 504, not an endless wait.
 
-The check window is generous by default (90 seconds — a cold Symfony container needs time for opcache warmup and database wait) and tunable:
+The check window is generous by default (90 seconds: a cold Symfony container needs time for opcache warmup and database wait) and tunable:
 
 ```yaml
 deploy:
@@ -120,43 +116,41 @@ deploy:
   healthcheck_interval: 3    # seconds between attempts
 ```
 
-When the health check fails, FrankenDeploy prints the **last 50 log lines of the failing container** before removing it, so you immediately see the real cause (missing env variable, failed migration, PHP fatal…).
+When the health check fails, FrankenDeploy prints the **last 50 log lines of the failing container** before removing it, so you immediately see the real cause (missing variable, failed migration, PHP fatal…).
 
-Create a health endpoint in your Symfony app:
+A good health endpoint proves the app works, not only that PHP runs:
 
 ```php
 // src/Controller/HealthController.php
 #[Route('/health')]
-public function health(): Response
+public function health(Connection $connection): Response
 {
+    $connection->executeQuery('SELECT 1');
+
     return new Response('OK');
 }
 ```
 
-If the health check fails, the new container is removed and the old one keeps serving traffic — a failed deployment never takes your site down.
-
 ## Deployment Hooks
-
-Run commands before and after deployment:
 
 ```yaml
 deploy:
   hooks:
     pre_deploy:
-      - php bin/console doctrine:migrations:migrate --no-interaction
-      - php bin/console messenger:stop-workers
+      - php bin/console doctrine:migrations:migrate --no-interaction --allow-no-migration
     post_deploy:
-      - php bin/console cache:warmup
+      - php bin/console cache:pool:clear cache.app
 ```
 
-**Pre-deploy hooks** run in the new container before traffic is switched.
-**Post-deploy hooks** run after successful deployment.
+**`pre_deploy`** hooks run in the new container, before traffic is switched, while the old version still serves requests. A failure removes the new container and aborts the deploy (unless `--force`).
+
+**`post_deploy`** hooks run in the live container after the switch. A failure only warns.
+
+No `cache:warmup` hook is needed: the Symfony cache is warmed when the image is built.
 
 ## Database Migration Warning
 
-FrankenDeploy automatically detects when your project has Doctrine entities but no migration files. This can happen when you forget to generate migrations after creating entities.
-
-When this situation is detected (entities in `src/Entity/` but no files in `migrations/`), FrankenDeploy displays a warning:
+FrankenDeploy detects when the project has Doctrine entities but no migration files, a classic when you forget `make:migration` after creating entities:
 
 ```
 ⚠️  Warning: No database migrations found but entities exist!
@@ -175,23 +169,21 @@ When this situation is detected (entities in `src/Entity/` but no files in `migr
    Then redeploy your application.
 ```
 
-This warning only appears once per application. Once you add migrations and redeploy, the warning is automatically cleared.
-
-**Note:** This check only runs when you have a migration hook configured in your `pre_deploy` hooks.
+The warning appears once per application and clears itself once migrations exist. It only runs when a migration hook is configured in `pre_deploy`.
 
 ## Automatic Database Backup Before Migrations
 
-With a **managed database** (`database.managed: true`), FrankenDeploy dumps the database automatically before any `pre_deploy` hook containing `doctrine:migrations:migrate`:
+With a **managed database** (`database.managed: true`), FrankenDeploy dumps the database before any `pre_deploy` hook containing `doctrine:migrations:migrate`:
 
-- The dump is gzipped and stored on the server in `/opt/frankendeploy/apps/<app>/shared/backups/` (permissions `600`)
+- The gzipped dump is stored on the server in `/opt/frankendeploy/apps/<app>/shared/backups/` (permissions `600`)
 - Retention follows `deploy.keep_releases` (default: 5 backups)
-- A failed backup **aborts the deploy** — use `--force` to deploy without this safety net (not recommended)
+- A failed backup **aborts the deploy**. `--force` deploys without this safety net (not recommended)
 
-Why this matters: migrations run **before** the traffic switch, while the old code still serves requests. If the health check fails after a successful migration, the containers are rolled back but **the database schema is not** — the previous version then runs on the new schema. When that happens, FrankenDeploy tells you explicitly and points to the backup:
+Why this matters: migrations run **before** the traffic switch, while the old code still serves requests. If the health check fails after a successful migration, the containers are rolled back but **the database schema is not**: the previous version then runs on the new schema. When that happens, FrankenDeploy says so and points to the backup:
 
 ```
 ⚠️  The database was already migrated during this deploy. Rolling back the code may not be enough...
-⚠️  Database backup taken before the migration: /opt/frankendeploy/apps/demo/shared/backups/pgsql-20260721-120000.sql.gz
+⚠️  Database backup taken before the migration: /opt/frankendeploy/apps/my-app/shared/backups/pgsql-20260902-120000.sql.gz
 ```
 
 Restore example (PostgreSQL):
@@ -200,50 +192,57 @@ Restore example (PostgreSQL):
 gunzip -c backups/pgsql-<tag>.sql.gz | docker exec -i <app>-db psql -U <user> <db>
 ```
 
-**Best practice:** write backward-compatible migrations (expand/contract pattern — add columns before using them, drop them one release later). A code rollback then stays safe even after a migration.
+**Best practice:** write backward-compatible migrations (expand/contract: add columns before using them, drop them one release later). A code rollback then stays safe even after a migration.
 
-For an **external database** (not managed by FrankenDeploy), no automatic backup is possible — back it up yourself before deploying migrations.
+For an **external database**, no automatic backup is possible: back it up yourself before deploying migrations.
+
+## Messenger Workers
+
+With `messenger.enabled: true`, each deploy starts one `<app>-worker` container from the same image, running:
+
+```
+php bin/console messenger:consume <transports> --time-limit=3600 --memory-limit=256M
+```
+
+The worker is stopped and recreated after the traffic switch, so it always runs the same code as the app, and `rollback` does the same. `--time-limit` and `--memory-limit` make it restart cleanly (Docker's `restart: unless-stopped` brings it back), which is the recommended way to run long-lived PHP workers. A failure to start the worker warns but does not fail the deploy.
+
+```bash
+frankendeploy logs prod --service worker      # worker logs
+frankendeploy logs prod --service all -f      # app and worker
+```
 
 ## Release Management
-
-FrankenDeploy keeps multiple releases for instant rollback:
 
 ```yaml
 deploy:
   keep_releases: 5
 ```
 
-Releases are stored in `/opt/frankendeploy/apps/your-app/releases/`.
+Releases are stored in `/opt/frankendeploy/apps/<app>/releases/<tag>/`, with `current` pointing to the live one. `keep_releases` also drives **disk usage**: after each deploy, FrankenDeploy removes the Docker images whose tag left the retention window (never an image in use by a container), and the database backups beyond the same count. With remote builds, dangling intermediate layers are pruned after each build. Rollback targets and disk retention therefore always match.
 
-`keep_releases` also drives **disk usage**: after each deploy, FrankenDeploy removes the Docker images whose tag left the retention window (an image never in use by a container is the only kind removed), plus the pre-migration database backups beyond the same count. With remote builds, dangling intermediate layers are pruned after each build. Rollback targets and disk retention therefore always match.
-
-View releases:
 ```bash
-frankendeploy app status production
+frankendeploy app status prod
 ```
 
 ## Environment Variables
 
-Set production environment variables in `frankendeploy.yaml`:
+Production variables live **on the server**, per application, in `/opt/frankendeploy/apps/<app>/shared/.env.local`, and are managed with `frankendeploy env`:
 
-```yaml
-env:
-  prod:
-    APP_ENV: prod
-    APP_DEBUG: "0"
-    DATABASE_URL: "${DATABASE_URL}"
+```bash
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+frankendeploy env set prod MAILER_DSN="smtp://..." --reload
 ```
 
-For secrets, set them directly on the server or use a secrets manager.
+FrankenDeploy itself sets `SERVER_NAME`, `APP_ENV=prod`, `APP_DEBUG=0` and, with a managed database, `DATABASE_URL`. The `env.prod` section of `frankendeploy.yaml` only feeds the generated `compose.prod.yaml` and is **not** read by `deploy`. See [Environment Variables](/frankendeploy/guides/environment-variables/).
 
 ## Shared Files and Directories
 
-Files and directories that persist between releases:
+Paths that persist between releases, mounted into every container from `/opt/frankendeploy/apps/<app>/shared/`:
 
 ```yaml
 deploy:
   shared_files:
-    - .env.local
+    - .env.local          # mounted read-only
   shared_dirs:
     - var/log
     - var/sessions
@@ -252,65 +251,56 @@ deploy:
 
 ## Zero-Downtime Deployment
 
-FrankenDeploy ensures zero downtime:
+1. The new container starts next to the old one, under a temporary name
+2. Migrations run and the health check verifies the new container
+3. Traffic switches through a rename-based swap: the old container is renamed away while still running, the new one takes the app name, and Docker's embedded DNS follows the name, so Caddy never sees a missing upstream
+4. The old container is stopped
 
-1. New container starts alongside old one
-2. Health checks verify new container
-3. Traffic switches to the new container via a rename-based swap (Docker's embedded DNS follows the container name, so no request is dropped)
-4. Old container is stopped
-
-If anything fails — including the swap itself — traffic stays on the old container.
+If anything fails, including the swap itself, traffic stays on the old container.
 
 ## Network Isolation
 
-Each application runs on its own Docker network, `frankendeploy-<app-name>`, with its worker and its managed database. Caddy is attached to every app network so it can reach `<app-name>:8080` by name; nothing else is. Two applications deployed on the same VPS cannot reach each other's containers, so a compromised app cannot talk to another app's database.
+Each application runs on its own Docker network, `frankendeploy-<app>`, with its worker and its managed database. Caddy is attached to every app network so it can reach `<app>:8080` by name; nothing else is. Two applications deployed on the same VPS cannot reach each other's containers, so a compromised app cannot talk to another app's database.
 
-The network is created by the first deploy. An application deployed before per-app networks existed is migrated transparently on its next deploy: the database container joins the app network, the new app container starts on it, and once the old container is stopped the database leaves the shared network. Every step checks the current state before acting, so a deploy interrupted in the middle completes on the next run. `frankendeploy doctor` reports the isolation status of the app.
+The network is created by the first deploy. An application deployed before per-app networks existed (FrankenDeploy < 0.15) is migrated transparently on its next deploy: the database container joins the app network, the new app container starts on it, and once the old container is stopped the database leaves the shared network. Every step checks the current state before acting, so a deploy interrupted in the middle completes on the next run. `frankendeploy doctor` reports the isolation status of the app.
 
 ## Managed Database
 
-With `database.managed: true` (the default for PostgreSQL/MySQL), each deployment ensures the database container is running and injects the generated `DATABASE_URL` into your application automatically. Credentials are created once and persist across deployments — you never have to set `DATABASE_URL` yourself.
+With `database.managed: true` (the default for PostgreSQL, MySQL and MariaDB), the first deploy creates the `<app>-db` container with random credentials and a persistent volume, and every deploy makes sure it runs and injects `DATABASE_URL` into the app. Credentials are saved on the server (`shared/.db_credentials`, permissions `600`) and reused: you never set `DATABASE_URL` yourself, and the database survives deploys, rollbacks and reboots.
 
 ## Monitoring Deployments
 
-### View Logs During Deploy
-Use verbose mode:
 ```bash
-frankendeploy deploy production --verbose
-```
-
-### Check Deployment Status
-```bash
-frankendeploy app status production
-```
-
-### View Application Logs
-```bash
-frankendeploy logs production
-frankendeploy logs production -f  # Follow mode
+frankendeploy deploy prod --verbose       # every command run on the server
+frankendeploy app status prod             # container status, releases
+frankendeploy logs prod -f                # follow the app logs
+frankendeploy logs prod --since 10m       # last 10 minutes
+frankendeploy logs prod --tail 500        # last 500 lines
 ```
 
 ## CI/CD Integration
-
-FrankenDeploy provides environment variables and flags for seamless CI/CD integration.
 
 ### Environment Variables
 
 | Variable | Description |
 |----------|-------------|
-| `FRANKENDEPLOY_SERVER` | Server name to use (alternative to argument) |
-| `FRANKENDEPLOY_SSH_KEY` | SSH private key content (base64 or raw) |
-| `FRANKENDEPLOY_KNOWN_HOSTS` | Known hosts file content |
+| `FRANKENDEPLOY_SERVER` | Server name to use (alternative to the argument) |
+| `FRANKENDEPLOY_SSH_KEY` | Content of the SSH private key (raw PEM, not base64). Encrypted keys cannot be used here: use an unencrypted deploy key |
+| `FRANKENDEPLOY_KNOWN_HOSTS` | Content of a `known_hosts` file with the server's host key |
 | `FRANKENDEPLOY_SKIP_HOST_KEY_CHECK` | Skip host key verification (not recommended) |
+
+The server itself must be declared on the runner: run `frankendeploy server add prod user@host --skip-test` in the job, as in the examples below.
 
 ### Non-Interactive Mode
 
-Use `--yes` or `-y` to skip all confirmation prompts:
+`--yes` (`-y`) answers every prompt with its default and never waits for input:
 
 ```bash
-frankendeploy deploy production --yes
-frankendeploy app remove production my-app --force --yes
+frankendeploy deploy prod --yes
+frankendeploy app remove prod my-app --force --yes
 ```
+
+`frankendeploy doctor prod` exits with code 1 on a blocking problem, which makes it a good gate before `deploy`.
 
 ### GitHub Actions Example
 
@@ -328,16 +318,20 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install FrankenDeploy
-        run: |
-          curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh
+        run: curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh
 
       - name: Deploy
         env:
-          FRANKENDEPLOY_SERVER: production
+          FRANKENDEPLOY_SERVER: prod
           FRANKENDEPLOY_SSH_KEY: ${{ secrets.SSH_KEY }}
           FRANKENDEPLOY_KNOWN_HOSTS: ${{ secrets.KNOWN_HOSTS }}
-        run: frankendeploy deploy --yes
+        run: |
+          frankendeploy server add prod ${{ secrets.SSH_TARGET }} --skip-test
+          frankendeploy doctor prod
+          frankendeploy deploy --yes
 ```
+
+`SSH_TARGET` is `user@host`. The image is built on the runner (x86_64, like most VPS), so no remote build is needed.
 
 ### GitLab CI Example
 
@@ -345,11 +339,15 @@ jobs:
 deploy:
   stage: deploy
   image: ubuntu:22.04
-  script:
+  before_script:
+    - apt-get update && apt-get install -y curl ca-certificates
     - curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh
+  script:
+    - frankendeploy server add prod $SSH_TARGET --skip-test
+    - frankendeploy doctor prod
     - frankendeploy deploy --yes
   variables:
-    FRANKENDEPLOY_SERVER: production
+    FRANKENDEPLOY_SERVER: prod
     FRANKENDEPLOY_SSH_KEY: $SSH_PRIVATE_KEY
     FRANKENDEPLOY_KNOWN_HOSTS: $KNOWN_HOSTS
   only:

--- a/docs/src/content/docs/guides/doctor.md
+++ b/docs/src/content/docs/guides/doctor.md
@@ -1,0 +1,68 @@
+---
+title: Preflight Checks
+description: Diagnose your machine, your server and your DNS before deploying
+---
+
+## Why
+
+Most first deployments fail for boring reasons: Docker missing on the server, a `sudo` that asks for a password, a domain whose A record still points to the old host. `frankendeploy doctor` finds them **before** the deploy, and every failed check names the command that fixes it.
+
+```bash
+frankendeploy doctor prod
+```
+
+## What it checks
+
+**Locally**
+- Docker CLI installed and daemon reachable (needed for local builds and the dev environment)
+
+**On the server, over SSH**
+- Passwordless `sudo` (unless you connect as root)
+- Docker installed and usable without `sudo`
+- The `frankendeploy` network created by `server setup`
+- The Caddy reverse proxy container running
+- Free disk space (a build or an image transfer needs a few GB)
+
+**For the application, when run inside a project**
+- The app network `frankendeploy-<app>` exists, Caddy is attached to it, and no container of the app is left on the shared network (see [Network isolation](/frankendeploy/guides/deployment/#network-isolation))
+
+**DNS**
+- The domain (`deploy.domain`, or `--domain`) resolves to the public IP of the server. The IP is asked to the server itself, so a VPS behind a gateway is handled. This is the number one cause of Let's Encrypt failures.
+
+## Reading the report
+
+```
+✅ Local Docker — daemon 29.4.0
+✅ SSH connection — deploy@203.0.113.42:22
+✅ Remote sudo — connected as root
+❌ Remote Docker — docker: command not found
+      Run 'frankendeploy server setup <name> --email you@example.com' to install Docker and Caddy.
+❌ Docker network — network "frankendeploy" missing
+      Run 'frankendeploy server setup <name> --email you@example.com', or create it manually:
+        docker network create frankendeploy
+❌ Caddy proxy — caddy container not running
+      Run 'frankendeploy server setup <name> --email you@example.com' to (re)start the reverse proxy.
+✅ Disk space — 41.5 GB free (9% used)
+❌ DNS my-app.com — resolves to 198.51.100.7, server is 203.0.113.42
+      Point the A record of my-app.com to 203.0.113.42, then wait for the DNS to propagate.
+
+Error: doctor found blocking problems
+```
+
+- ❌ is blocking: `doctor` exits with code 1, which makes it usable as a CI gate.
+- ⚠️ is a warning: the deploy can proceed, but something deserves a look.
+- With everything green, the report ends with `Everything looks good — ready to deploy!`.
+
+## When to run it
+
+- After `server setup`, to confirm the server is ready
+- After changing a DNS record, before the first deploy of a domain
+- Whenever a deploy fails: the error messages of `deploy` point to `doctor`
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--domain` | Domain to check instead of `deploy.domain` from `frankendeploy.yaml` |
+
+`doctor` never changes anything on the server.

--- a/docs/src/content/docs/guides/environment-variables.md
+++ b/docs/src/content/docs/guides/environment-variables.md
@@ -1,30 +1,40 @@
 ---
 title: Environment Variables
-description: Managing environment variables in production
+description: Managing production secrets and configuration
 ---
 
-## Overview
+## Where Variables Live
 
-FrankenDeploy stores environment variables **per application** in a `.env.local` file on the server. Each application has its own isolated environment variables that persist across deployments.
+Production variables are stored **on the server, per application**, in `/opt/frankendeploy/apps/<app>/shared/.env.local`. The file is mounted read-only into the app and worker containers, survives deploys and rollbacks, and is never part of your repository.
 
-**Important:** Environment variables are tied to the current project (defined in `frankendeploy.yaml`), not to the server globally.
+Commands are run from the project directory: the application is the one in `frankendeploy.yaml`, the server is the argument.
+
+## What FrankenDeploy Sets for You
+
+| Variable | Value |
+|----------|-------|
+| `APP_ENV` | `prod` |
+| `APP_DEBUG` | `0` |
+| `SERVER_NAME` | `:8080` (the port Caddy proxies to) |
+| `DATABASE_URL` | Generated and injected with a managed database (`database.managed: true`). With an external database, set it yourself |
+
+The `env.prod` section of `frankendeploy.yaml` is **not** applied in production: it only feeds the generated `compose.prod.yaml`. Everything the app needs at runtime goes through the commands below.
 
 ## Setting Variables
 
 ```bash
-# Set a single variable
-frankendeploy env set prod APP_SECRET="your-secret-key"
-frankendeploy env set prod DATABASE_URL="postgresql://user:pass@host/db"
+# Set a variable
+frankendeploy env set prod MAILER_DSN="smtp://user:pass@smtp.example.com:587"
 
-# Apply changes immediately (rolling restart)
+# Apply it right away with a rolling restart (see below)
 frankendeploy env set prod MAILER_DSN="smtp://..." --reload
 ```
 
-Without `--reload`, changes take effect on the next deployment.
+Without `--reload`, the change applies at the next deployment.
 
 ### Secrets: use `--from-stdin`
 
-Passing a secret as `KEY=value` leaves it in your shell history. With `--from-stdin`, the value never touches the history:
+Passing a secret as `KEY=value` leaves it in your shell history. With `--from-stdin`, the value never touches it:
 
 ```bash
 # Interactive: hidden prompt
@@ -34,21 +44,18 @@ frankendeploy env set prod APP_SECRET --from-stdin
 openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
 ```
 
-## Listing Variables
+`deploy` refuses to start when `APP_SECRET` is missing (or `DATABASE_URL` with an external database), and offers to generate `APP_SECRET` for you in interactive mode.
+
+## Listing and Reading
 
 ```bash
-frankendeploy env list prod
-```
-
-Sensitive values (passwords, secrets, tokens) are automatically masked in the output.
-
-## Getting a Single Variable
-
-```bash
+frankendeploy env list prod            # all variables, sensitive values masked
 frankendeploy env get prod DATABASE_URL
 ```
 
-## Removing Variables
+Values of keys containing `SECRET`, `PASSWORD`, `PASS`, `KEY`, `TOKEN`, `DSN` or `DATABASE_URL` are masked in `env list` and in `--verbose` output; `env get` shows the full value.
+
+## Removing
 
 ```bash
 frankendeploy env remove prod OLD_VARIABLE
@@ -56,72 +63,64 @@ frankendeploy env remove prod OLD_VARIABLE
 
 ## Bulk Operations
 
-### Push a .env file
+### Push a `.env` file
 
-Push a local `.env` file to the server. Variables are merged with existing ones:
+Variables of a local file are merged into the server's `.env.local` (existing keys are overwritten, others kept):
 
 ```bash
-# Create a local .env.prod file
-echo "APP_SECRET=my-secret" > .env.prod
-echo "DATABASE_URL=postgresql://..." >> .env.prod
-
-# Push to server
 frankendeploy env push prod .env.prod
-
-# Push and apply immediately
 frankendeploy env push prod .env.prod --reload
 ```
 
-### Pull from server
+Only files named `.env*` are accepted.
 
-Download current environment variables to a local backup file:
+### Pull from the server
 
 ```bash
 frankendeploy env pull prod
-# Creates .env.prod.backup
+# writes .env.prod.backup (permissions 600) in the current directory
 ```
+
+The file is named after the server (`.env.<server>.backup`). Do not commit it.
 
 ## Zero-Downtime Updates
 
-The `--reload` flag performs a rolling restart:
+`--reload` restarts the application without dropping a request, with the same mechanism as a deploy:
 
-1. Starts a new container with updated environment
-2. Waits for health check to pass
-3. Switches traffic to the new container
-4. Removes the old container
+1. A new container starts with the updated `.env.local`, on the same image
+2. FrankenDeploy waits for its health check
+3. Traffic switches to it (rename-based swap)
+4. The old container is stopped
 
-This minimizes downtime to near-zero.
+If the new container never becomes healthy, it is removed and the old one keeps serving.
 
 ## Required Variables
 
-For Symfony applications, you typically need:
-
-| Variable | Description |
-|----------|-------------|
-| `APP_SECRET` | Symfony secret key (required) |
-| `APP_ENV` | Environment (auto-set to `prod`) |
-| `DATABASE_URL` | Database connection string — **injected automatically** with a managed database (`database.managed: true`); only set it for an external database |
-| `MAILER_DSN` | Email transport (optional) |
+| Variable | Notes |
+|----------|-------|
+| `APP_SECRET` | Required by Symfony. Checked before every deploy |
+| `DATABASE_URL` | Injected automatically with a managed database. Required, and checked, with an external one |
+| `MAILER_DSN`, `MESSENGER_TRANSPORT_DSN`, … | Whatever your `config/packages/*.yaml` reference through `%env()%` |
 
 ## Security Notes
 
-- Variables are stored in `/opt/frankendeploy/apps/<app>/shared/.env.local`
-- Every write (`env set`, `env push`, `env remove`, deploy-generated secrets) enforces `chmod 600` on the file — secrets are never left world-readable
-- The file is mounted read-only into containers
-- Sensitive values are masked in `env list` output and in verbose command logs (same detection list for both)
-- Never commit `.env.prod.backup` files to git
-- Use strong, unique secrets for production
+- Every write (`env set`, `env push`, `env remove`, credentials generated by a deploy) enforces `chmod 600` on the server file
+- The file is mounted read-only into the containers
+- Secrets are never written to `frankendeploy.yaml` or transmitted through Git
+- Sensitive values are masked in `env list` and in verbose logs (same detection list for both)
+- The file is stored in clear on the server disk, protected by its permissions: anyone with root or SSH access to the server can read it. Encrypting it there would not help, since the key would sit next to it. Use your provider's disk encryption for backups and snapshots
+- The Symfony secrets vault works as usual: commit the vault, set only `SYMFONY_DECRYPTION_SECRET` with `env set --from-stdin`
 
 ## Workflow Example
 
 ```bash
-# 1. Configure your production environment
-frankendeploy env set prod APP_SECRET=$(openssl rand -hex 32)
-frankendeploy env set prod DATABASE_URL="postgresql://user:pass@db.example.com/myapp"
+# 1. Production secrets, once
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+frankendeploy env set prod MAILER_DSN --from-stdin
 
-# 2. Deploy your application
-frankendeploy deploy prod --remote-build
+# 2. Deploy
+frankendeploy deploy prod
 
-# 3. Later, update a variable with zero downtime
+# 3. Later, change a value without downtime
 frankendeploy env set prod FEATURE_FLAG=enabled --reload
 ```

--- a/docs/src/content/docs/guides/local-development.md
+++ b/docs/src/content/docs/guides/local-development.md
@@ -5,128 +5,104 @@ description: Use FrankenDeploy for local Symfony development
 
 ## Development Environment
 
-FrankenDeploy provides a Docker-based development environment that mirrors your production setup.
-
-## Starting the Environment
+`frankendeploy build` generates a `compose.yaml` that runs your application on FrankenPHP with the services it needs. The image is the same multi-stage `Dockerfile` as production, built with its `frankenphp_dev` target.
 
 ```bash
+frankendeploy build      # once, generates compose.yaml
 frankendeploy dev up
 ```
 
 This starts:
-- Your Symfony application on **http://localhost:8000**
-- Database (PostgreSQL or MySQL if configured)
-- MailHog (if Symfony Mailer is detected) on **http://localhost:8025**
-- RabbitMQ (if Symfony Messenger is detected) on **http://localhost:15672**
+- Your Symfony application on **http://localhost:8000** (and https://localhost with a local certificate)
+- The database (PostgreSQL, MySQL or MariaDB) with `DATABASE_URL` already set
+- [Mailpit](https://mailpit.axllent.org/) when `mailer.enabled` (SMTP on `mailpit:1025`, web UI on **http://localhost:8025**)
+- RabbitMQ 4 when a Messenger transport uses `amqp://` (management UI on **http://localhost:15672**)
 
 ## Development Commands
 
-### Start with Build
-If you've made changes to the Dockerfile:
 ```bash
-frankendeploy dev up --build
+frankendeploy dev up --build      # rebuild the image first (Dockerfile or extensions changed)
+frankendeploy dev logs            # follow the logs (default)
+frankendeploy dev logs --tail 50  # last 50 lines
+frankendeploy dev down            # stop the environment
+frankendeploy dev restart         # restart it
 ```
 
-### View Logs
-```bash
-frankendeploy dev logs
-frankendeploy dev logs -f  # Follow mode
-```
-
-### Stop Environment
-```bash
-frankendeploy dev down
-```
-
-### Restart
-```bash
-frankendeploy dev restart
-```
+`dev up` runs in the background by default (`--detach`).
 
 ## Volume Mounts
 
-Your source code is mounted into the container, so changes are reflected immediately.
-
-The following directories are excluded from mounts (for performance):
-- `vendor/` - Installed fresh in container
-- `node_modules/` - Installed fresh in container
-- `var/` - Cache and logs
+Your project directory is mounted at `/app` in the container, so code changes are visible immediately. `vendor/` is a named Docker volume: dependencies are installed inside the container and never clash with a local `vendor/` from another PHP version. Everything else, including `var/` and `node_modules/`, is shared with your machine.
 
 ## Running Symfony Commands
 
-Use Docker Compose to run commands in the container:
+The application service is named `app`:
 
 ```bash
-# Symfony console
 docker compose exec app php bin/console cache:clear
-
-# Composer
 docker compose exec app composer require some/package
-
-# Run tests
 docker compose exec app php bin/phpunit
 ```
 
 ## Database Access
 
-### PostgreSQL
+The dev database uses `app` / `app` as user and password and `app` as database name. Its port is bound to `127.0.0.1` only, so nothing on your network can reach it.
+
 ```bash
-# Connect via psql
+# PostgreSQL
 docker compose exec database psql -U app -d app
+# from your machine: postgresql://app:app@127.0.0.1:5432/app
 
-# Connection details for your app
-DATABASE_URL=postgresql://app:app@database:5432/app
-```
-
-### MySQL
-```bash
-# Connect via mysql
+# MySQL / MariaDB
 docker compose exec database mysql -u app -papp app
-
-# Connection details
-DATABASE_URL=mysql://app:app@database:3306/app
+# from your machine: mysql://app:app@127.0.0.1:3306/app
 ```
+
+Inside the container, `DATABASE_URL` points to the `database` service. Override the host, port or name with `database.host`, `database.port`, `database.name` in `frankendeploy.yaml` if you need to.
 
 ## Debugging with Xdebug
 
-To enable Xdebug, add to your `frankendeploy.yaml`:
+PHP extensions listed in `frankendeploy.yaml` are installed in the image (dev and prod). The dev stage ships `XDEBUG_MODE=off`, so listing `xdebug` is harmless until you enable it:
 
 ```yaml
 php:
   extensions:
     - xdebug
-  ini_values:
-    - "xdebug.mode=debug"
-    - "xdebug.client_host=host.docker.internal"
+env:
+  dev:
+    XDEBUG_MODE: debug
+    XDEBUG_CONFIG: "client_host=host.docker.internal"
 ```
 
 Then rebuild:
+
 ```bash
 frankendeploy build
 frankendeploy dev up --build
 ```
 
+Keep in mind that the extension is also present in the production image, unloaded but installed. Remove it from `extensions` before a release if you prefer a lean image.
+
 ## Email Testing
 
-If Symfony Mailer is detected, MailHog is automatically included.
+With `mailer.enabled: true` (set by `init` when `config/packages/mailer.yaml` exists), Mailpit catches every email sent by the app. Point the mailer at it, either in `.env.local` or in the `env.dev` section of `frankendeploy.yaml`:
 
-- SMTP: `mailhog:1025`
-- Web UI: http://localhost:8025
-
-Add to your `.env.local`:
-```
-MAILER_DSN=smtp://mailhog:1025
+```yaml
+env:
+  dev:
+    MAILER_DSN: "smtp://mailpit:1025"
 ```
 
-## Hot Reload for Assets
+Open http://localhost:8025 to read the messages.
 
-If you're using Webpack Encore or Vite, run the dev server separately:
+## Assets
+
+With Webpack Encore or Vite, run the dev server on your machine, next to the container:
 
 ```bash
-# In another terminal
 npm run dev
 # or
 yarn dev
 ```
 
-For AssetMapper, changes are reflected automatically.
+With AssetMapper, changes are served directly by Symfony in dev mode.

--- a/docs/src/content/docs/guides/rollback.md
+++ b/docs/src/content/docs/guides/rollback.md
@@ -1,130 +1,122 @@
 ---
 title: Rollback & Recovery
-description: How to rollback to a previous release
+description: How to roll back to a previous release
 ---
 
 ## Quick Rollback
 
-Roll back to the previous release:
-
 ```bash
-frankendeploy rollback production
+frankendeploy rollback prod
 ```
 
 This switches traffic back to the previous release with the **same guarantees as a deployment**:
-- The rollback container gets the same shared directories, environment and managed `DATABASE_URL` as a regular deploy
-- A health check runs **before** the swap — if the old release is unhealthy, the rollback aborts and the current version keeps running
+- The rollback container gets the same shared directories, `.env.local` and managed `DATABASE_URL` as a regular deploy, and runs on the same isolated network
+- A health check runs **before** the swap: if the old release is unhealthy, the rollback aborts and the current version keeps running
 - The swap itself is zero-downtime (same rename-based mechanism as deploy)
-- Messenger workers are rolled back to the same release
+- The Messenger worker is rolled back to the same release
 
-## Rollback to Specific Release
+A rollback only works while the release's Docker image is still on the server, which is what `keep_releases` guarantees.
 
-List available releases:
+## Rollback to a Specific Release
+
+List the releases kept on the server:
+
 ```bash
-frankendeploy app status production
+frankendeploy app status prod
 ```
 
-Output:
 ```
 Application: my-app
-Server:      production
+Server:      prod
 
-Status:      running
-Release:     20240115-143052
+Status:      Up 2 hours (healthy)
+Release:     20260902-143052
+Started:     2026-09-02T14:31:10Z
 
 Recent releases:
-  * 20240115-143052
-    20240115-120000
-    20240114-180000
-    20240114-150000
-    20240113-100000
+  * 20260902-143052
+    20260902-120000
+    20260901-180000
+    20260901-150000
+    20260831-100000
 ```
 
-Rollback to a specific release:
+Then:
+
 ```bash
-frankendeploy rollback production 20240114-180000
+frankendeploy rollback prod 20260901-180000
 ```
 
-## Automatic Rollback
+## What a Rollback Does Not Undo
 
-During a deployment, FrankenDeploy protects the running version if:
+**The database schema.** Migrations run during a deploy stay applied. With a managed database, a dump is taken before every migration (`/opt/frankendeploy/apps/<app>/shared/backups/`), and the deploy output tells you where it is when a rollback may not be enough:
 
-1. **Health check fails** - The new container doesn't respond correctly
-2. **Container won't start** - Docker fails to start the container
-3. **Pre-deploy hooks fail** - Migration or other commands fail
+```bash
+gunzip -c backups/pgsql-<tag>.sql.gz | docker exec -i <app>-db psql -U <user> <db>
+```
 
-In all these cases the new container is removed and the **old container keeps serving traffic untouched** — there is nothing to restore because traffic never left the working version:
+Write backward-compatible migrations (expand/contract) and a code rollback stays safe. See [Automatic Database Backup](/frankendeploy/guides/deployment/#automatic-database-backup-before-migrations).
+
+**Environment variables.** `.env.local` is shared between releases: a variable changed with `env set` stays changed.
+
+## Automatic Protection During a Deploy
+
+During a deployment, the running version is protected when:
+
+1. The database backup fails
+2. A `pre_deploy` hook (migration) fails
+3. The health check fails
+4. The container swap fails
+
+In every case the new container is removed and the **old container keeps serving traffic untouched**: nothing to restore, because traffic never left the working version.
 
 ```
 ⚠️  Health check failed, rolling back...
 ```
 
+The last 50 log lines of the failed container are printed so you see the cause immediately.
+
 ## Managing Releases
 
-### Keep More Releases
 ```yaml
 deploy:
   keep_releases: 10
 ```
 
-### Cleanup Old Releases
-Old releases are automatically cleaned after each deployment. Only the configured number of releases are kept (see `deploy.keep_releases` in `frankendeploy.yaml`).
+Releases, Docker images and database backups beyond this count are removed after each deploy. There is nothing to clean manually.
 
-To manually clean releases, connect to your server via SSH:
+## Troubleshooting a Failed Deployment
+
 ```bash
-ssh user@your-server
-rm -rf /opt/frankendeploy/apps/my-app/releases/OLD_RELEASE
+frankendeploy logs prod --tail 200              # app logs
+frankendeploy logs prod --service worker        # worker logs
+frankendeploy app status prod                   # container and release state
+frankendeploy shell prod                        # a shell in the running container
+frankendeploy exec prod curl -s http://localhost:8080/health   # the health endpoint, from inside
+frankendeploy doctor prod                       # server, network and DNS
 ```
 
-## Troubleshooting Failed Deployments
-
-### Check Logs
-```bash
-frankendeploy logs production --tail 200
-```
-
-### Check Container Status
-```bash
-frankendeploy app status production
-```
-
-### Connect to Container
-```bash
-frankendeploy shell production
-```
-
-### Check Health Endpoint
-```bash
-frankendeploy exec production curl -v http://localhost/health
-```
+The app listens on port **8080** inside the container; Caddy handles 80 and 443 in front of it.
 
 ## Recovery Strategies
 
-### If Container Won't Start
+### The New Version Fails Its Health Check
+Nothing to do on the server: the old version is still live. Read the log lines printed by the deploy, fix, deploy again.
 
-1. Check logs: `frankendeploy logs production`
-2. Rollback: `frankendeploy rollback production`
-3. Fix the issue locally
-4. Deploy again
+### The Deploy Succeeded but the App Misbehaves
+```bash
+frankendeploy logs prod -f
+frankendeploy rollback prod
+```
+Then fix locally and deploy again.
 
-### If Database Migration Fails
-
-1. FrankenDeploy auto-rolls back
-2. Check migration locally: `php bin/console doctrine:migrations:status`
-3. Fix migration
-4. Deploy again
-
-### If App Starts But Errors
-
-1. Check logs for errors
-2. Rollback if needed: `frankendeploy rollback production`
-3. Debug locally with same configuration
-4. Deploy fix
+### A Migration Failed Halfway
+PostgreSQL runs DDL in a transaction: a failed migration leaves the schema untouched. MySQL and MariaDB do not: check `doctrine:migrations:status` from `frankendeploy shell prod`, and use the pre-migration backup if the schema is partial.
 
 ## Best Practices
 
-1. **Always have a health endpoint** - Quick detection of issues
-2. **Keep multiple releases** - At least 5 for safe rollbacks
-3. **Test locally first** - Use `frankendeploy dev up`
-4. **Use staging** - Deploy to staging before production
-5. **Monitor after deploy** - Watch logs for a few minutes
+1. **Have a real health endpoint**: one that touches the database, so a broken deploy is caught before the switch
+2. **Keep several releases**: 5 is a good default
+3. **Write backward-compatible migrations**: the rollback then stays safe
+4. **Deploy to a staging server first** (`frankendeploy deploy staging`): same commands, another server entry
+5. **Watch the logs** for a few minutes after a deploy

--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -6,15 +6,17 @@ description: Configure your VPS for FrankenDeploy deployments
 ## Requirements
 
 Your VPS should have:
-- Ubuntu 22.04+ or Debian 11+ (recommended)
-- SSH access with key-based authentication
-- At least 1GB RAM
-- Port 80 and 443 open (FrankenDeploy configures UFW automatically)
+- Ubuntu or Debian (`server setup` refuses any other distribution with an explicit message; Ubuntu 22.04+ and Debian 12+ are what it is tested on)
+- SSH access with key-based authentication, as root or as a user with passwordless `sudo`
+- At least 1 GB of RAM (2 GB if you build images on the server)
+- Ports 80 and 443 reachable from the Internet (FrankenDeploy opens them in UFW)
+
+Throughout this page the server is called `prod`.
 
 ## Adding a Server
 
 ```bash
-frankendeploy server add production deploy@your-server.com
+frankendeploy server add prod deploy@your-server.com
 ```
 
 After adding a server, FrankenDeploy **automatically tests the SSH connection**. If the connection fails, it will:
@@ -35,7 +37,7 @@ The working key is saved to your configuration.
 
 Standard VPS (auto-detect key):
 ```bash
-frankendeploy server add prod deploy@51.210.xx.xx
+frankendeploy server add prod deploy@203.0.113.42
 ```
 
 Custom SSH port:
@@ -85,18 +87,21 @@ In CI/CD, set `FRANKENDEPLOY_KNOWN_HOSTS` with the content of your known_hosts f
 ## Setting Up the Server
 
 ```bash
-frankendeploy server setup production --email admin@example.com
+frankendeploy server setup prod --email admin@example.com
 ```
 
 The `--email` flag is **required** for Let's Encrypt certificate registration.
 
 This command:
-1. Installs Docker if not present
-2. Configures UFW firewall (HTTP/HTTPS + SSH — both your configured SSH port and the port the SSH daemon actually uses are allowed before the firewall is enabled, so a custom port or gateway setup can never lock you out)
-3. Installs and configures Fail2ban (SSH brute-force protection)
-4. Creates the FrankenDeploy directory structure
-5. Sets up the `frankendeploy` Docker network (Caddy's home network)
-6. Deploys Caddy as a Docker container (reverse proxy)
+1. Checks the distribution and `sudo` before changing anything
+2. Installs Docker if not present
+3. Configures UFW firewall (HTTP/HTTPS + SSH — both your configured SSH port and the port the SSH daemon actually uses are allowed before the firewall is enabled, so a custom port or gateway setup can never lock you out)
+4. Installs and configures Fail2ban (SSH brute-force protection: 5 attempts, 1 hour ban)
+5. Creates the FrankenDeploy directory structure
+6. Sets up the `frankendeploy` Docker network (Caddy's home network)
+7. Starts Caddy as a Docker container (reverse proxy with automatic HTTPS)
+
+Running it again on an already prepared server is safe: every step checks the current state.
 
 ### What Gets Created
 
@@ -151,10 +156,18 @@ Docker's default address pools cover about 30 bridge networks per host, which is
 
 ## Verifying Setup
 
-Check the server status:
+Run the preflight checks, which also verify the DNS of your domain:
 
 ```bash
-frankendeploy server status production
+frankendeploy doctor prod
+```
+
+Every failed check names the command that fixes it. See [Preflight Checks](/frankendeploy/guides/doctor/).
+
+For resource usage, check the server status:
+
+```bash
+frankendeploy server status prod
 ```
 
 This shows:
@@ -252,18 +265,36 @@ When you deploy an app, FrankenDeploy:
 
 This ensures **zero downtime** for existing apps during deployments.
 
-## Security Features
+## Security Model
 
-FrankenDeploy automatically configures:
+What FrankenDeploy does on the server, and what it deliberately leaves to you.
 
-1. **UFW Firewall** - Only SSH (your actual SSH ports, not just 22), 80 and 443 open
-2. **Fail2ban** - SSH brute-force protection (automatic)
+### What `server setup` does
 
-### Additional Recommendations
+- **UFW firewall**: only SSH (your actual SSH ports, not just 22), 80 and 443 are open; everything else is denied
+- **Fail2ban** on SSH: 5 failed attempts, 1 hour ban
+- **Caddy** is the only container with published ports. Its admin API listens on `localhost` inside the container and is never exposed
 
-1. **Disable root login** - Use a deploy user
-2. **SSH keys only** - Disable password authentication
-3. **Automatic updates** - Enable unattended-upgrades
+### What every deploy does
+
+- The application runs as a **non-root user** on an unprivileged port (8080)
+- **No port is published** for the app, the worker or the database: the only way in is Caddy, on 80 and 443
+- **TLS** with automatic Let's Encrypt certificates, HSTS enabled
+- **One Docker network per application**: apps sharing a VPS cannot reach each other's containers
+- **Secrets** live in `.env.local` on the server, `chmod 600`, mounted read-only; `env set --from-stdin` keeps them out of your shell history
+- **Managed databases** get random credentials, a random one-time root password (MySQL/MariaDB), and a dump before every migration
+- **Log rotation** on every container, so logs cannot fill the disk
+
+### What it does not do
+
+FrankenDeploy prepares a server; it is not a hardening tool.
+
+- **No automatic security updates**: install `unattended-upgrades` or update the system yourself
+- **No `sshd` hardening**: password authentication and root login stay as your distribution ships them. Disable password authentication once your key works
+- **No encryption of secrets at rest**: `.env.local` is readable by root and by anyone with SSH access. Use your provider's disk encryption for backups and snapshots
+- **No intrusion detection, no container hardening beyond non-root**
+
+A `server harden` command covering updates, `sshd` and an audit in `doctor` is [being discussed](https://github.com/yoanbernabeu/frankendeploy/issues/95).
 
 ## Multiple Environments
 
@@ -271,13 +302,13 @@ You can add multiple servers for different environments:
 
 ```bash
 frankendeploy server add staging deploy@staging.example.com
-frankendeploy server add production deploy@prod.example.com
+frankendeploy server add prod deploy@203.0.113.42
 
 # Setup both
 frankendeploy server setup staging --email dev@example.com
-frankendeploy server setup production --email admin@example.com
+frankendeploy server setup prod --email admin@example.com
 
 # Deploy to each
 frankendeploy deploy staging
-frankendeploy deploy production
+frankendeploy deploy prod
 ```

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -6,8 +6,10 @@ description: Deploy your Symfony app in 5 minutes
 ## Prerequisites
 
 - A Symfony project
-- Docker installed locally
-- A VPS with SSH access (for production deployment)
+- Docker installed locally (only needed for local builds and the dev environment)
+- A VPS running Ubuntu or Debian, reachable over SSH with a key
+
+Throughout the docs the server is called `prod`. Name yours as you like.
 
 ## Step 1: Initialize Your Project
 
@@ -15,23 +17,10 @@ Navigate to your Symfony project and run:
 
 ```bash
 cd my-symfony-app
-frankendeploy init
-```
-
-You can also specify your production domain directly:
-
-```bash
 frankendeploy init --domain my-app.com
 ```
 
-FrankenDeploy will:
-- Detect your PHP version
-- Identify required extensions
-- Find your database configuration
-- Detect your asset build system
-- Detect API Platform and set the health check path to `/api` automatically
-
-This creates a `frankendeploy.yaml` configuration file.
+FrankenDeploy analyzes the project (PHP version and extensions, database, assets, Messenger, Mailer, API Platform, worker mode) and writes a `frankendeploy.yaml`. Every inference is printed, so you can check what was detected. The domain can also be added later under `deploy.domain`.
 
 ## Step 2: Generate Docker Files (optional)
 
@@ -41,110 +30,95 @@ frankendeploy build
 
 This generates:
 - `Dockerfile` - Multi-stage build with FrankenPHP
-- `docker-entrypoint.sh` - Startup script (waits for DB, runs migrations)
-- `compose.yaml` - Development environment
-- `compose.prod.yaml` - Production template
+- `docker-entrypoint.sh` - Startup script (waits for the database to accept connections)
+- `compose.yaml` - Local development environment
+- `compose.prod.yaml` - Production template, for people who deploy with Compose by hand
 - `.dockerignore` - Optimized ignore patterns
+- `Caddyfile` - Only with FrankenPHP worker mode enabled
 
-This step is optional before deploying: `frankendeploy deploy` generates any missing Docker artifacts automatically (and never overwrites files you have customized). Run `build` explicitly when you want to inspect or customize the generated files, or to use the local dev environment.
+This step is optional before deploying: `frankendeploy deploy` generates any missing file and never overwrites one you customized. Run `build` explicitly to inspect or customize the generated files, or to use the local dev environment.
 
-## Step 3: Start Local Development
+## Step 3: Start Local Development (optional)
 
 ```bash
 frankendeploy dev up
 ```
 
-Your app is now running at **http://localhost:8000**
+Your app is now running at **http://localhost:8000**, with its database, Mailpit and RabbitMQ when your project needs them.
 
-Other dev commands:
 ```bash
-frankendeploy dev logs   # View logs
-frankendeploy dev down   # Stop environment
-frankendeploy dev restart # Restart
+frankendeploy dev logs      # View logs
+frankendeploy dev down      # Stop the environment
+frankendeploy dev restart   # Restart it
 ```
 
-## Step 4: Configure a Server
+## Step 4: Declare and Prepare a Server
 
 Add your VPS to FrankenDeploy:
 
 ```bash
-frankendeploy server add production deploy@your-vps.com
+frankendeploy server add prod deploy@your-vps.com
 ```
 
-FrankenDeploy will automatically test the SSH connection and find the right key.
+FrankenDeploy tests the SSH connection right away and finds the right key. Options: `--port 2222` for a custom SSH port, `--key ~/.ssh/my_key` to force a key, `--skip-test` to skip the connection test.
 
-Options:
-- `--port 2222` - Custom SSH port (default: 22)
-- `--key ~/.ssh/id_rsa` - SSH private key path (auto-detected if not specified)
-- `--skip-test` - Skip SSH connection test
-
-Then set up the server (installs Docker, Caddy, etc.):
+Then prepare the server (Docker, firewall, Fail2ban, Caddy):
 
 ```bash
-frankendeploy server setup production --email admin@example.com
+frankendeploy server setup prod --email admin@example.com
 ```
 
-The `--email` is required for Let's Encrypt SSL certificates.
+The `--email` is required for Let's Encrypt certificates.
 
-## Step 5: Configure Environment Variables
-
-Set your production secrets for this application (run from your project directory):
+Finally, check that everything is in place, including the DNS record of your domain:
 
 ```bash
-frankendeploy env set production APP_SECRET="your-secret-key"
+frankendeploy doctor prod
 ```
 
-**No `DATABASE_URL` needed with a managed database**: if your `frankendeploy.yaml` has `database.managed: true` (the default for PostgreSQL/MySQL), FrankenDeploy creates the database container and injects `DATABASE_URL` automatically. Only set it yourself when using an external database:
+Every failed check comes with the command that fixes it. See [Preflight checks](/frankendeploy/guides/doctor/).
+
+## Step 5: Configure Production Secrets
+
+Secrets live on the server, per application, in a `.env.local` file. Set them from your project directory:
 
 ```bash
-frankendeploy env set production DATABASE_URL="postgresql://user:pass@host/db"
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
 ```
 
-Or push a local `.env.prod` file:
+**No `DATABASE_URL` needed with a managed database**: when `frankendeploy.yaml` has `database.managed: true` (the default for PostgreSQL, MySQL and MariaDB), FrankenDeploy creates the database container and injects `DATABASE_URL` automatically. Only set it yourself for an external database:
 
 ```bash
-frankendeploy env push production .env.prod
+frankendeploy env set prod DATABASE_URL --from-stdin
 ```
+
+You can also push a whole file: `frankendeploy env push prod .env.prod`.
+
+If you forget `APP_SECRET`, the deploy stops before touching the server and offers to generate one for you.
 
 ## Step 6: Deploy
 
 ```bash
-frankendeploy deploy production --remote-build
+frankendeploy deploy prod
 ```
 
-The `--remote-build` flag builds the Docker image directly on the server (recommended for Apple Silicon Macs). FrankenDeploy also detects architecture mismatches automatically and offers to enable remote build for you.
+From an Apple Silicon Mac to an x86 VPS, FrankenDeploy detects the architecture mismatch and offers to build on the server (`--remote-build`); the choice is remembered.
 
-That's it! Your Symfony app is now live with:
+That's it. Your Symfony app is live with:
 - FrankenPHP as the application server
 - Automatic HTTPS via Caddy
-- Zero-downtime blue-green deployments with health checks and rollback
+- Zero-downtime blue-green deployments with health checks
+- A managed database with automatic backups before migrations
 
 ## Common Operations
 
-### View Production Logs
 ```bash
-frankendeploy logs production
-```
-
-### Execute Commands
-```bash
-frankendeploy exec production php bin/console cache:clear
-```
-
-### Open Shell
-```bash
-frankendeploy shell production
-```
-
-### Rollback
-```bash
-frankendeploy rollback production
-```
-
-### Update Environment Variables (Zero Downtime)
-Update an environment variable for your application and apply it immediately:
-```bash
-frankendeploy env set production NEW_VAR=value --reload
+frankendeploy logs prod -f                          # Follow production logs
+frankendeploy exec prod php bin/console cache:clear # Run a command in the container
+frankendeploy shell prod                            # Open a shell in the container
+frankendeploy rollback prod                         # Go back to the previous release
+frankendeploy env set prod NEW_VAR=value --reload   # Change a variable without downtime
+frankendeploy app status prod                       # Releases and container status
 ```
 
 ## Next Steps

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -25,9 +25,10 @@ export const navigation: NavSection[] = [
       { label: 'Project Configuration', href: '/frankendeploy/guides/configuration/', order: 1 },
       { label: 'Local Development', href: '/frankendeploy/guides/local-development/', order: 2 },
       { label: 'Server Setup', href: '/frankendeploy/guides/server-setup/', order: 3 },
-      { label: 'Environment Variables', href: '/frankendeploy/guides/environment-variables/', order: 4 },
-      { label: 'Deployment', href: '/frankendeploy/guides/deployment/', order: 5 },
-      { label: 'Rollback', href: '/frankendeploy/guides/rollback/', order: 6 },
+      { label: 'Preflight Checks', href: '/frankendeploy/guides/doctor/', order: 4 },
+      { label: 'Environment Variables', href: '/frankendeploy/guides/environment-variables/', order: 5 },
+      { label: 'Deployment', href: '/frankendeploy/guides/deployment/', order: 6 },
+      { label: 'Rollback', href: '/frankendeploy/guides/rollback/', order: 7 },
     ],
   },
   {
@@ -43,15 +44,16 @@ export const navigation: NavSection[] = [
       { label: 'frankendeploy', href: '/frankendeploy/commands/frankendeploy/', order: 1 },
       { label: 'init', href: '/frankendeploy/commands/frankendeploy_init/', order: 2 },
       { label: 'build', href: '/frankendeploy/commands/frankendeploy_build/', order: 3 },
-      { label: 'deploy', href: '/frankendeploy/commands/frankendeploy_deploy/', order: 4 },
-      { label: 'rollback', href: '/frankendeploy/commands/frankendeploy_rollback/', order: 5 },
-      { label: 'logs', href: '/frankendeploy/commands/frankendeploy_logs/', order: 6 },
-      { label: 'shell', href: '/frankendeploy/commands/frankendeploy_shell/', order: 7 },
-      { label: 'exec', href: '/frankendeploy/commands/frankendeploy_exec/', order: 8 },
+      { label: 'doctor', href: '/frankendeploy/commands/frankendeploy_doctor/', order: 4 },
+      { label: 'deploy', href: '/frankendeploy/commands/frankendeploy_deploy/', order: 5 },
+      { label: 'rollback', href: '/frankendeploy/commands/frankendeploy_rollback/', order: 6 },
+      { label: 'logs', href: '/frankendeploy/commands/frankendeploy_logs/', order: 7 },
+      { label: 'shell', href: '/frankendeploy/commands/frankendeploy_shell/', order: 8 },
+      { label: 'exec', href: '/frankendeploy/commands/frankendeploy_exec/', order: 9 },
       {
         label: 'dev',
         href: '/frankendeploy/commands/frankendeploy_dev/',
-        order: 9,
+        order: 10,
         children: [
           { label: 'up', href: '/frankendeploy/commands/frankendeploy_dev_up/' },
           { label: 'down', href: '/frankendeploy/commands/frankendeploy_dev_down/' },
@@ -62,19 +64,20 @@ export const navigation: NavSection[] = [
       {
         label: 'server',
         href: '/frankendeploy/commands/frankendeploy_server/',
-        order: 10,
+        order: 11,
         children: [
           { label: 'add', href: '/frankendeploy/commands/frankendeploy_server_add/' },
           { label: 'setup', href: '/frankendeploy/commands/frankendeploy_server_setup/' },
           { label: 'list', href: '/frankendeploy/commands/frankendeploy_server_list/' },
           { label: 'status', href: '/frankendeploy/commands/frankendeploy_server_status/' },
           { label: 'remove', href: '/frankendeploy/commands/frankendeploy_server_remove/' },
+          { label: 'set', href: '/frankendeploy/commands/frankendeploy_server_set/' },
         ],
       },
       {
         label: 'app',
         href: '/frankendeploy/commands/frankendeploy_app/',
-        order: 11,
+        order: 12,
         children: [
           { label: 'list', href: '/frankendeploy/commands/frankendeploy_app_list/' },
           { label: 'status', href: '/frankendeploy/commands/frankendeploy_app_status/' },
@@ -84,7 +87,7 @@ export const navigation: NavSection[] = [
       {
         label: 'env',
         href: '/frankendeploy/commands/frankendeploy_env/',
-        order: 12,
+        order: 13,
         children: [
           { label: 'set', href: '/frankendeploy/commands/frankendeploy_env_set/' },
           { label: 'get', href: '/frankendeploy/commands/frankendeploy_env_get/' },


### PR DESCRIPTION
Full review of the hand-written documentation (guides, configuration references, getting started, README) against what the CLI actually does. Generated command pages are untouched.

## Wrong claims fixed

| Where | Was | Now |
|---|---|---|
| `config/project.md` | `messenger.workers: 2` in the reference | Field does not exist; copying the example failed validation (`KnownFields`). Removed |
| `deployment.md`, `project.md`, `configuration.md` | `env.prod` sets production variables | `deploy` never reads it (only `compose.prod.yaml` does). Documented honestly, production goes through `env set` |
| `config/global.md` | `~/.config/frankendeploy/config.yaml` everywhere | Per-OS table (`~/Library/Application Support/...` on macOS) |
| `project.md` | `cache:warmup` auto-added in `post_deploy` | Removed in 0.13; migration hook has `--allow-no-migration` |
| `quickstart.md` | entrypoint "runs migrations" | It waits for the database; migrations are the `pre_deploy` hook |
| `local-development.md`, `project.md` | MailHog, `smtp://mailhog:1025` | Mailpit |
| `local-development.md` | `vendor`, `node_modules`, `var` excluded from mounts | Only `vendor` is a named volume |
| `deployment.md` CI | `FRANKENDEPLOY_SSH_KEY` "base64 or raw" | Raw PEM only, unencrypted |
| `global.md` | passphrase keys skipped, `apps` auto-populated, `remote_build` auto-detected | Prompted in interactive mode; `apps` is never written; `remote_build` is proposed on mismatch or set with `server set` |
| `rollback.md` | `curl http://localhost/health` | Port 8080 |
| `project.md` | `deploy.domain` required, `xdebug` dev only | Optional; extensions are in every image |

## Now documented

- **New guide: Preflight Checks (`doctor`)**, plus `doctor` and `server set` in the CLI sidebar
- `config/project.md` is a complete reference: `memory_limit`, `cpu_limit`, `assets.node_version`, `assets.tailwind`, `frankenphp_version`, `mailer.enabled`, `database.host/port/name`, hooks semantics, worker lifecycle
- `ssh_timeout`, `logs --service/--since`, `env push` rules, managed database credentials, what `deploy` injects (`SERVER_NAME`, `APP_ENV`, `APP_DEBUG`, `DATABASE_URL`)
- A **Security Model** section in Server Setup: what `setup` and `deploy` protect, what is deliberately left to the user (links #95)
- The Node stage limitation: `npm ci` whatever the detected tool (yarn/pnpm projects need a `package-lock.json` for now)

## Structure

- `config/project.md` = exhaustive reference, `guides/configuration.md` = short guide (init, auto-detection, options)
- Server named `prod` everywhere, "blue-green" everywhere, `203.0.113.42` as the example IP
- README: features, quick start (with `doctor` and `APP_SECRET`), full command table
- `npm run build` of the site passes

## Left for a later code PR

`build` help text ("handles composer install, migrations"), dead fields `deploy.healthcheck_host` and `servers.*.apps`, `env.prod` behaviour, yarn/pnpm in the Node stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
