### PR TITLE
feat(deploy): make Symfony trust Caddy with SYMFONY_TRUSTED_PROXIES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Symfony trusts Caddy out of the box**: the app container now receives `SYMFONY_TRUSTED_PROXIES` (read natively by Symfony >= 7.2) and `TRUSTED_PROXIES` set to the private subnets, so the real client IP and the HTTPS scheme reach the application: absolute URLs are generated in `https://`, session cookies get the `Secure` flag, and rate limiters see the visitor rather than the proxy. Safe because only Caddy can reach the app on its private per-app network. Nothing is injected when either variable is already defined in the server's `.env.local` - @yoanbernabeu
+
 ## [0.15.1] - 2026-09-02
 
 Follow-up to the per-app networks of 0.15.0: `doctor` on a freshly set up server is all green again.

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -484,7 +484,7 @@ func prepareRelease(ctx context.Context, client ssh.Executor, cfg *config.Projec
 // buildAppRunCommand builds the docker run command for the application
 // container. It is the single source of truth shared by deploy, rollback and
 // env reload: same volume mounts, env vars, non-root user and restart policy.
-func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseURL, containerName string) string {
+func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseURL, containerName string, extraEnv ...string) string {
 	sharedPath := filepath.Join(appPath, "shared")
 
 	volumeMounts := buildVolumeMounts(sharedPath, cfg.Deploy.EffectiveSharedDirs(), cfg.Deploy.EffectiveSharedFiles())
@@ -492,6 +492,9 @@ func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseU
 	envVars := fmt.Sprintf("-e SERVER_NAME=:%s -e APP_ENV=prod -e APP_DEBUG=0", constants.AppPort)
 	if databaseURL != "" {
 		envVars += fmt.Sprintf(" -e DATABASE_URL=%s", security.ShellEscape(databaseURL))
+	}
+	for _, kv := range extraEnv {
+		envVars += " -e " + kv
 	}
 
 	// Optional resource limits (validated at config load: safe to interpolate)
@@ -514,6 +517,28 @@ func buildAppRunCommand(cfg *config.ProjectConfig, imageName, appPath, databaseU
 		%s`, containerName, constants.AppNetworkName(cfg.Name), constants.ContainerUser, constants.DockerLogOptions, limits, envVars, volumeMounts, imageName)
 }
 
+// trustedProxiesEnv returns the KEY=value pairs that make Symfony trust
+// Caddy's X-Forwarded-* headers (real client IP, HTTPS scheme, Secure
+// cookies). SYMFONY_TRUSTED_PROXIES is read natively by Symfony >= 7.2;
+// TRUSTED_PROXIES covers apps that wired framework.trusted_proxies to it
+// themselves. A docker -e value overrides .env.local, so nothing is
+// injected when the user manages either variable there.
+func trustedProxiesEnv(ctx context.Context, client ssh.Executor, appName string) []string {
+	vars, err := deploy.ReadEnvVars(ctx, client, appName)
+	if err == nil {
+		if _, ok := vars["SYMFONY_TRUSTED_PROXIES"]; ok {
+			return nil
+		}
+		if _, ok := vars["TRUSTED_PROXIES"]; ok {
+			return nil
+		}
+	}
+	return []string{
+		"SYMFONY_TRUSTED_PROXIES=" + constants.TrustedProxies,
+		"TRUSTED_PROXIES=" + constants.TrustedProxies,
+	}
+}
+
 // readSavedDatabaseURL reads the DATABASE_URL persisted by a managed-database
 // deploy (shared/.db_credentials). Returns "" when no managed database is
 // configured or the file cannot be read.
@@ -532,7 +557,7 @@ func startNewContainer(ctx context.Context, client ssh.Executor, cfg *config.Pro
 	// Remove any leftover temp container from a previous failed deploy
 	forceRemoveContainer(ctx, client, containerName)
 
-	dockerRunCmd := buildAppRunCommand(cfg, imageName, appPath, databaseURL, containerName)
+	dockerRunCmd := buildAppRunCommand(cfg, imageName, appPath, databaseURL, containerName, trustedProxiesEnv(ctx, client, cfg.Name)...)
 
 	PrintVerboseCommand(dockerRunCmd)
 	result, err := client.Exec(ctx, dockerRunCmd)

--- a/internal/cmd/deploy_test.go
+++ b/internal/cmd/deploy_test.go
@@ -406,3 +406,42 @@ func TestRunHealthCheckOnContainer_UsesConfiguredRetries(t *testing.T) {
 		t.Errorf("expected 2 attempts from config, got %d", curlAttempts)
 	}
 }
+
+func TestStartNewContainer_InjectsTrustedProxies(t *testing.T) {
+	mock := &ssh.MockExecutor{} // empty .env.local
+	cfg := &config.ProjectConfig{Name: "myapp"}
+
+	if err := startNewContainer(context.Background(), mock, cfg, "myapp:t1", "/opt/frankendeploy/apps/myapp", "t1", "", "myapp-new"); err != nil {
+		t.Fatalf("startNewContainer() unexpected error: %v", err)
+	}
+	for _, want := range []string{
+		"-e SYMFONY_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+		"-e TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16",
+	} {
+		if !hasCommand(mock.Commands, want) {
+			t.Errorf("Symfony must be told to trust Caddy, missing %q in: %v", want, mock.Commands)
+		}
+	}
+}
+
+func TestStartNewContainer_RespectsUserTrustedProxies(t *testing.T) {
+	for _, userVar := range []string{"TRUSTED_PROXIES", "SYMFONY_TRUSTED_PROXIES"} {
+		mock := &ssh.MockExecutor{
+			ExecFunc: func(_ context.Context, command string) (*ssh.ExecResult, error) {
+				if strings.Contains(command, ".env.local") {
+					return &ssh.ExecResult{Stdout: userVar + "=203.0.113.9\n", ExitCode: 0}, nil
+				}
+				return &ssh.ExecResult{ExitCode: 0}, nil
+			},
+		}
+		cfg := &config.ProjectConfig{Name: "myapp"}
+
+		if err := startNewContainer(context.Background(), mock, cfg, "myapp:t1", "/opt/frankendeploy/apps/myapp", "t1", "", "myapp-new"); err != nil {
+			t.Fatalf("startNewContainer() unexpected error: %v", err)
+		}
+		// A docker -e value would override the user's .env.local: inject nothing
+		if hasCommand(mock.Commands, "TRUSTED_PROXIES=") {
+			t.Errorf("%s set by the user in .env.local: nothing must be injected, got %v", userVar, mock.Commands)
+		}
+	}
+}

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -26,6 +26,14 @@ const (
 	NetworkName = "frankendeploy"
 )
 
+// TrustedProxies is the value injected as SYMFONY_TRUSTED_PROXIES and
+// TRUSTED_PROXIES into the app container when the user set neither: the
+// app only receives traffic from Caddy, over its private per-app network,
+// and Symfony must trust Caddy's X-Forwarded-* headers to see the real
+// client IP and the HTTPS scheme. Explicit CIDRs rather than the
+// PRIVATE_SUBNETS keyword: they work on every Symfony version.
+const TrustedProxies = "127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16"
+
 // Health check defaults
 const (
 	// The generated Dockerfile declares HEALTHCHECK --start-period=60s: a cold


### PR DESCRIPTION
## Problem

The app container receives requests from Caddy over its private per-app network, but nothing told Symfony to trust Caddy's `X-Forwarded-*` headers. Observed on a real deployment (La Drache, behind HTTPS):

```
$ curl -sI https://drache.yoandev.co/api | grep -i link
link: <http://drache.yoandev.co/api/docs.jsonld>; rel="..."
```

Symfony believed it was serving plain HTTP: absolute URLs in `http://`, session cookies without the `Secure` flag, client IP equal to Caddy's.

## Fix

`buildAppRunCommand` (shared by `deploy`, `rollback` and `env --reload`) now injects:

- `SYMFONY_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16`: read natively by Symfony >= 7.2 (`framework.trusted_proxies` defaults to `%env(default::SYMFONY_TRUSTED_PROXIES)%`), no configuration needed in the app
- `TRUSTED_PROXIES` with the same value, for apps that wired `framework.trusted_proxies: '%env(TRUSTED_PROXIES)%'` themselves

Safe: since #97 only Caddy can reach `app:8080`, so trusting the private subnets trusts Caddy and nothing else. Same default as `dunglas/symfony-docker`. Explicit CIDRs rather than the `PRIVATE_SUBNETS` keyword, which needs Symfony 7.1.

A docker `-e` value overrides `.env.local` (Dotenv never overrides real environment variables), so **nothing is injected when the user defines either variable in `.env.local`**.

## Live validation (La Drache, Symfony 8.1, no proxy configuration in the app)

```
$ curl -sI https://drache.yoandev.co/api | grep -i link
link: <https://drache.yoandev.co/api/docs.jsonld>; rel="..."

$ frankendeploy exec prod env | grep TRUSTED
SYMFONY_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
```

Deploy in 1m03, no downtime.

## Tests

808 pass (2 new: injection with an empty `.env.local`, no injection when the user set `TRUSTED_PROXIES` or `SYMFONY_TRUSTED_PROXIES`). `make lint` clean.

Docs (a "Behind the proxy" section) follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
