### PR TITLE
docs: explain how Symfony trusts Caddy behind the proxy

### DIFF
--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -295,7 +295,7 @@ Commands run inside the container with `docker exec`: Symfony console, Composer,
 
 `env.dev` is written into the generated `compose.yaml`; `env.prod` into `compose.prod.yaml`, a template for people who deploy with Compose by hand.
 
-**`frankendeploy deploy` does not read `env.prod`.** In production, the container gets `SERVER_NAME`, `APP_ENV=prod`, `APP_DEBUG=0` and the managed `DATABASE_URL` from FrankenDeploy, and everything else from the `.env.local` on the server, managed with [`frankendeploy env`](/frankendeploy/guides/environment-variables/). Secrets never belong in `frankendeploy.yaml`, which is versioned.
+**`frankendeploy deploy` does not read `env.prod`.** In production, the container gets `SERVER_NAME`, `APP_ENV=prod`, `APP_DEBUG=0`, the managed `DATABASE_URL` and the trusted proxies (`SYMFONY_TRUSTED_PROXIES`, `TRUSTED_PROXIES`) from FrankenDeploy, and everything else from the `.env.local` on the server, managed with [`frankendeploy env`](/frankendeploy/guides/environment-variables/). Secrets never belong in `frankendeploy.yaml`, which is versioned.
 
 ## Validation
 

--- a/docs/src/content/docs/guides/deployment.md
+++ b/docs/src/content/docs/guides/deployment.md
@@ -264,6 +264,36 @@ Each application runs on its own Docker network, `frankendeploy-<app>`, with its
 
 The network is created by the first deploy. An application deployed before per-app networks existed (FrankenDeploy < 0.15) is migrated transparently on its next deploy: the database container joins the app network, the new app container starts on it, and once the old container is stopped the database leaves the shared network. Every step checks the current state before acting, so a deploy interrupted in the middle completes on the next run. `frankendeploy doctor` reports the isolation status of the app.
 
+## Behind the Proxy
+
+Requests reach your application through Caddy: Internet → Caddy (80/443, TLS) → app container (`:8080`, plain HTTP on the private app network). Caddy forwards the real client IP and the original scheme in `X-Forwarded-For` and `X-Forwarded-Proto`, but Symfony only honours those headers from proxies it trusts. Otherwise it believes it serves plain HTTP to Caddy's IP: absolute URLs come out in `http://`, session cookies lack the `Secure` flag, rate limiters and logs see the proxy instead of the visitor.
+
+FrankenDeploy handles it: every app container receives
+
+```
+SYMFONY_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+```
+
+- **Symfony >= 7.2** reads `SYMFONY_TRUSTED_PROXIES` natively: nothing to configure in the application.
+- **Older Symfony** applications need the classic wiring in `config/packages/framework.yaml`:
+  ```yaml
+  framework:
+      trusted_proxies: '%env(TRUSTED_PROXIES)%'
+      trusted_headers: ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix']
+  ```
+
+Trusting the private subnets is safe here: since each app runs on its own Docker network, Caddy is the only thing that can reach the container, so the only proxy Symfony trusts is the one FrankenDeploy put in front of it.
+
+To use other values, define `SYMFONY_TRUSTED_PROXIES` or `TRUSTED_PROXIES` yourself with `frankendeploy env set`: when either is present in the server's `.env.local`, FrankenDeploy injects nothing (a `docker run -e` value would otherwise override yours). `SYMFONY_TRUSTED_HOSTS` is not needed: Caddy only routes the configured domain to the container.
+
+To check what Symfony sees, look at an absolute URL it generates. With API Platform:
+
+```bash
+curl -sI https://my-app.com/api | grep -i link
+# link: <https://my-app.com/api/docs.jsonld>; rel="..."   ← https, the scheme is trusted
+```
+
 ## Managed Database
 
 With `database.managed: true` (the default for PostgreSQL, MySQL and MariaDB), the first deploy creates the `<app>-db` container with random credentials and a persistent volume, and every deploy makes sure it runs and injects `DATABASE_URL` into the app. Credentials are saved on the server (`shared/.db_credentials`, permissions `600`) and reused: you never set `DATABASE_URL` yourself, and the database survives deploys, rollbacks and reboots.

--- a/docs/src/content/docs/guides/environment-variables.md
+++ b/docs/src/content/docs/guides/environment-variables.md
@@ -17,6 +17,7 @@ Commands are run from the project directory: the application is the one in `fran
 | `APP_DEBUG` | `0` |
 | `SERVER_NAME` | `:8080` (the port Caddy proxies to) |
 | `DATABASE_URL` | Generated and injected with a managed database (`database.managed: true`). With an external database, set it yourself |
+| `SYMFONY_TRUSTED_PROXIES`, `TRUSTED_PROXIES` | Private subnets, so Symfony trusts Caddy's `X-Forwarded-*` headers (real client IP, HTTPS). Not injected when you define either one yourself. See [Behind the Proxy](/frankendeploy/guides/deployment/#behind-the-proxy) |
 
 The `env.prod` section of `frankendeploy.yaml` is **not** applied in production: it only feeds the generated `compose.prod.yaml`. Everything the app needs at runtime goes through the commands below.
 

--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -279,7 +279,7 @@ What FrankenDeploy does on the server, and what it deliberately leaves to you.
 
 - The application runs as a **non-root user** on an unprivileged port (8080)
 - **No port is published** for the app, the worker or the database: the only way in is Caddy, on 80 and 443
-- **TLS** with automatic Let's Encrypt certificates, HSTS enabled
+- **TLS** with automatic Let's Encrypt certificates, HSTS enabled; Symfony trusts only Caddy as a proxy (`SYMFONY_TRUSTED_PROXIES` set to the private subnets), so it sees the real client IP and the HTTPS scheme
 - **One Docker network per application**: apps sharing a VPS cannot reach each other's containers
 - **Secrets** live in `.env.local` on the server, `chmod 600`, mounted read-only; `env set --from-stdin` keeps them out of your shell history
 - **Managed databases** get random credentials, a random one-time root password (MySQL/MariaDB), and a dump before every migration


### PR DESCRIPTION
Follow-up to #101.

- New **Behind the Proxy** section in the deployment guide: request path, injected `SYMFONY_TRUSTED_PROXIES` / `TRUSTED_PROXIES`, why the private subnets are safe on a per-app network, `framework.yaml` wiring for Symfony < 7.2, how to override, how to check what Symfony sees
- The variables are listed with the others FrankenDeploy sets (environment variables guide, `frankendeploy.yaml` reference) and in the Security Model

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK