### PR TITLE
docs: the beginner path (before you start, first deployment, troubleshooting, FAQ, glossary)

### DIFF
--- a/docs/src/content/docs/before-you-start.md
+++ b/docs/src/content/docs/before-you-start.md
@@ -1,0 +1,105 @@
+---
+title: Before You Start
+description: What you need before your first deployment, explained from scratch
+---
+
+This page is for you if you have never put an application online on a server. It takes about twenty minutes and ends with everything FrankenDeploy needs. If you already have a VPS, an SSH key and a domain, jump to [Your First Deployment](/frankendeploy/first-deployment/).
+
+## What you will need
+
+| | What | Why |
+|---|---|---|
+| 1 | A Symfony application that runs on your machine | It is what we deploy |
+| 2 | A **VPS** (a rented Linux server) running Ubuntu or Debian | It is where the app will live |
+| 3 | An **SSH key** on your machine, registered on the VPS | It is how FrankenDeploy talks to the server |
+| 4 | A **domain name** pointing to the VPS | It is your `https://` address |
+| 5 | FrankenDeploy installed on your machine | See [Installation](/frankendeploy/installation/) |
+
+Docker on your machine is **optional**: FrankenDeploy can build on the server. You only need it for the local development environment or local builds.
+
+## 1. A VPS
+
+A VPS is a small virtual machine rented by the month, with a public IP address, on which you have full control. Any provider works. What to pick when ordering:
+
+- **Operating system**: Ubuntu 24.04 or Debian 12. FrankenDeploy refuses anything else, on purpose.
+- **Size**: 2 vCPU and 2 GB of RAM are comfortable for a Symfony app with its database; 1 GB works for a small site. You can resize later.
+- **Authentication**: choose **SSH key** if the provider offers it, and paste the public key you create in the next step. If the provider only gives you a root password, that works too for the first connection.
+
+Write down the **public IP address** the provider gives you, for example `203.0.113.42`. The docs use that address everywhere.
+
+## 2. An SSH key
+
+SSH is the encrypted connection between your machine and the server. A key pair replaces the password: the private key stays on your machine, the public key goes on the server.
+
+If you already have `~/.ssh/id_ed25519`, skip to the test. Otherwise, on macOS or Linux (on Windows, use the same commands in PowerShell or WSL):
+
+```bash
+ssh-keygen -t ed25519 -C "you@example.com"
+```
+
+Accept the default location. A passphrase is a good idea; FrankenDeploy asks for it when needed and never stores it.
+
+Register the public key on the server. If the provider let you paste it at creation, it is already there. Otherwise, with the root password the provider gave you:
+
+```bash
+ssh-copy-id root@203.0.113.42
+```
+
+Then test:
+
+```bash
+ssh root@203.0.113.42
+```
+
+The first time, SSH shows the server's fingerprint and asks you to confirm: answer `yes`. You should land on a prompt on the server. Type `exit` to come back.
+
+<div class="callout callout-tip">
+
+**root or a dedicated user?**
+
+Connecting as `root` is the simplest and works fine with FrankenDeploy. Providers sometimes create a user such as `ubuntu` or `debian` with passwordless `sudo` instead: that works too. What does not work is a user that has to type a password for `sudo`.
+
+</div>
+
+## 3. A domain name
+
+Your visitors will not type an IP address. Buy a domain (or use a subdomain of one you own), then create a **DNS record of type A** pointing to the server's IP:
+
+| Type | Name | Value |
+|------|------|-------|
+| A | `my-app.com` (or `app.my-domain.com`) | `203.0.113.42` |
+
+Where: in the DNS zone of the registrar where you bought the domain. The record can take from a few minutes to a few hours to propagate. You can check from your machine:
+
+```bash
+dig +short my-app.com
+# 203.0.113.42   ← done
+```
+
+FrankenDeploy checks it too (`frankendeploy doctor`) and refuses to deploy while the domain does not point to the server: without that, the HTTPS certificate cannot be issued.
+
+You can deploy without a domain, the app will just not be reachable from the Internet yet. Add the domain later in `frankendeploy.yaml`.
+
+## 4. The Symfony application
+
+Any Symfony application works, from a fresh `symfony new` to a large project. FrankenDeploy reads `composer.json`, `.env`, `config/packages/` to configure itself. Three things worth checking before the first deploy:
+
+- The application starts with `APP_ENV=prod` on your machine (`APP_ENV=prod php bin/console cache:clear` shows configuration errors early).
+- If you use Doctrine, your migrations are generated and committed (`php bin/console make:migration`). FrankenDeploy runs them at each deploy and warns when entities exist without migrations.
+- Your `.env` only contains defaults, never production secrets: those go on the server with `frankendeploy env set`.
+
+## 5. FrankenDeploy
+
+Follow [Installation](/frankendeploy/installation/), then check:
+
+```bash
+frankendeploy --version
+```
+
+## Ready
+
+You have an IP, a working `ssh root@203.0.113.42`, a domain pointing to it, and the CLI installed. [Your First Deployment](/frankendeploy/first-deployment/) takes it from here.
+
+## Vocabulary you will meet
+
+**VPS**, **SSH**, **DNS**, **reverse proxy**, **container**, **image**, **health check**, **migration**, **blue-green**: each one is defined in a few words in the [Glossary](/frankendeploy/glossary/).

--- a/docs/src/content/docs/config/project.md
+++ b/docs/src/content/docs/config/project.md
@@ -213,9 +213,13 @@ The scanner reads `DATABASE_URL` from `.env` **and** `.env.local` (the latter wi
 | `true` (default for pgsql, mysql, mariadb) | FrankenDeploy creates the `<name>-db` container on the first deploy, generates random credentials, injects `DATABASE_URL` into the app, keeps the data in a Docker volume, and dumps the database before every migration |
 | `false` | You provide `DATABASE_URL` with `frankendeploy env set` (external database) |
 
-:::caution[SQLite]
+<div class="callout callout-warning">
+
+**SQLite**
+
 SQLite cannot run as a container: `managed: true` with `driver: sqlite` fails validation. For persistence in production, the directory of the database file is added to `shared_dirs` automatically.
-:::
+
+</div>
 
 ### `database.path`
 

--- a/docs/src/content/docs/first-deployment.md
+++ b/docs/src/content/docs/first-deployment.md
@@ -1,0 +1,249 @@
+---
+title: Your First Deployment
+description: A Symfony app on the Internet in one hour, step by step, with the real output of every command
+---
+
+We deploy an API Platform application with a PostgreSQL database (the demo app of the API Platform Con 2026 talk) from an empty Ubuntu VPS to `https://my-app.com`. Every terminal block below is the real output of the command, captured on that server; only the application name, the domain and the host are replaced by `my-app`, `my-app.com` and `203.0.113.42`.
+
+Before starting, you need what [Before You Start](/frankendeploy/before-you-start/) describes: a VPS you can `ssh` into, a domain pointing to it, and FrankenDeploy installed. Count one hour the first time, including reading.
+
+## Step 1: Describe the project (2 minutes)
+
+In the project directory:
+
+```bash
+frankendeploy init --domain my-app.com
+```
+
+```
+ℹ️  Analyzing project...
+✅ Created frankendeploy.yaml
+
+📋 Project Configuration:
+   Name:        my-app
+   PHP:         8.4
+   Extensions:  ctype, iconv, intl, opcache, zip, pdo_pgsql
+   Database:    pgsql 16
+   Assets:      assetmapper
+   Domain:      my-app.com
+   Healthcheck: /api (API Platform detected)
+
+Next steps:
+  1. Review frankendeploy.yaml and adjust if needed
+  2. Run 'frankendeploy build' to generate Docker files
+  3. Run 'frankendeploy dev up' to start local development
+```
+
+FrankenDeploy read `composer.json` (PHP 8.4, the extensions), `.env` (PostgreSQL 16), `importmap.php` (AssetMapper) and noticed API Platform, so the health check will hit `/api` rather than `/`. Everything landed in one file, `frankendeploy.yaml`, that you commit with the project. Open it: it is short and every line is explained in the [reference](/frankendeploy/config/project/).
+
+<div class="callout callout-note">
+
+**What just happened**
+
+Nothing on any server yet. `init` only wrote a file. When it makes a choice for you (adding an extension, enabling worker mode), it says so on this screen.
+
+</div>
+
+## Step 2: Declare the server (1 minute)
+
+```bash
+frankendeploy server add prod root@203.0.113.42
+```
+
+```
+✅ Added server 'prod' (root@203.0.113.42)
+ℹ️  Testing SSH connection...
+✅ SSH connection successful
+```
+
+`prod` is the name you will use in every other command. The connection details are saved on your machine, outside the project (nothing about your server goes into Git). On the first connection FrankenDeploy shows the server's fingerprint and asks you to confirm it, like `ssh` does.
+
+## Step 3: Prepare the server (3 minutes)
+
+```bash
+frankendeploy server setup prod --email you@example.com
+```
+
+```
+✅ Connected to 203.0.113.42
+ℹ️  Setting up server for FrankenDeploy...
+ℹ️  [1/5] Installing prerequisites...
+ℹ️  [2/5] Installing Fail2ban...
+ℹ️  [3/5] Installing Docker...
+ℹ️  [4/5] Configuring FrankenDeploy...
+ℹ️  [5/5] Configuring firewall and starting Caddy...
+✅ Caddy container is running
+✅ Server 'prod' is ready for deployments!
+
+Configuration:
+  Email:    you@example.com (for Let's Encrypt)
+  Caddy:    Docker container with Admin API
+  Docker:   Installed with 'frankendeploy' network
+  Firewall: Ports 22, 80, 443 open
+  Fail2ban: SSH protection enabled (5 retries, 1h ban)
+
+Next step:
+  Run 'frankendeploy deploy prod' from your Symfony project
+```
+
+The email is what Let's Encrypt uses to warn you about a certificate problem. In three minutes the server got Docker, a firewall that only lets SSH, HTTP and HTTPS through, Fail2ban against SSH brute force, and Caddy, the reverse proxy that will obtain and renew the HTTPS certificate. You can run this command again later, it changes nothing on a prepared server.
+
+## Step 4: Check everything (30 seconds)
+
+```bash
+frankendeploy doctor prod
+```
+
+```
+✅ Local Docker — daemon 29.4.0
+✅ SSH connection — root@203.0.113.42:22
+✅ Remote sudo — connected as root
+✅ Remote Docker — 29.7.2
+✅ Docker network — frankendeploy
+✅ Caddy proxy — Up 51 seconds
+✅ Disk space — 43.4 GB free (4% used)
+✅ App network — frankendeploy-my-app (created by the first deploy)
+❌ DNS my-app.com — domain does not resolve
+      Create an A record for my-app.com pointing to 203.0.113.42 at your DNS provider.
+      DNS changes can take up to a few hours to propagate.
+
+Error: doctor found blocking problems
+```
+
+This is the real output of the day: the DNS record had just been created and had not propagated yet. `doctor` is the command to run whenever you wonder where you stand: every red line names what to do. A few minutes later:
+
+```
+✅ DNS my-app.com — → 203.0.113.42
+
+✅ Everything looks good — ready to deploy!
+```
+
+## Step 5: The first deploy, refused (10 seconds)
+
+```bash
+frankendeploy deploy prod
+```
+
+```
+ℹ️  Deploying my-app to prod...
+✅ Connected to 203.0.113.42
+ℹ️  Running pre-flight checks...
+❌ Missing required environment variables:
+
+   APP_SECRET (Symfony security secret)
+
+Run the following commands to configure them:
+
+   frankendeploy env set prod APP_SECRET=$(openssl rand -hex 32)
+
+Then run 'frankendeploy deploy prod' again.
+
+Or use --force to skip this check (not recommended for production)
+```
+
+FrankenDeploy refused before touching anything: Symfony needs `APP_SECRET`, and it is not on the server. Production secrets never live in the project; they live on the server, in a file only the application can read. Run the command it gives you (or the variant below, which keeps the secret out of your shell history):
+
+```bash
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+```
+
+No `DATABASE_URL` to set: `frankendeploy.yaml` says the database is managed, so FrankenDeploy will create it and pass its address to the app.
+
+## Step 6: The first deploy (1 to 3 minutes)
+
+```bash
+frankendeploy deploy prod
+```
+
+```
+ℹ️  Deploying my-app to prod...
+✅ Connected to 203.0.113.42
+ℹ️  Using remote build (server configured for cross-architecture)
+ℹ️  Running pre-flight checks...
+✅ Pre-flight checks passed
+ℹ️  Transferring source code to server...
+ℹ️    121 files transferred
+✅ Source code transferred
+ℹ️  Building Docker image on server...
+✅ Image built: my-app:20260901-140326
+ℹ️  Preparing application network...
+✅ Created network frankendeploy-my-app
+ℹ️  Setting up managed database...
+✅ Database ready: pgsql
+ℹ️  Preparing release...
+ℹ️  Starting new version (blue-green)...
+ℹ️  Backing up database before migration...
+✅ Database backup: /opt/frankendeploy/apps/my-app/shared/backups/pgsql-20260901-140326.sql.gz
+ℹ️  Running pre-deploy hooks...
+ℹ️  Running health check...
+✅ Health check passed
+ℹ️  Swapping containers...
+ℹ️  Updating reverse proxy...
+✅ Caddy configured for my-app.com
+ℹ️  Cleaning up old releases...
+✅ Deployment complete in 1m4s!
+
+Application deployed: my-app
+  Tag: 20260901-140326
+  URL: https://my-app.com
+```
+
+Open the URL: the app answers over HTTPS, certificate included. The very first deploy on a server takes longer (here, the first one took 5 minutes: Docker had to download the base images); the next ones take about a minute.
+
+<div class="callout callout-note">
+
+**What just happened, line by line**
+
+- **Using remote build**: this deploy came from an Apple Silicon Mac to an x86 server. FrankenDeploy noticed on the first attempt, offered to build on the server instead, and remembered the answer. From a Linux or Intel machine, the image is built locally and transferred.
+- **Source code transferred, image built**: your project became a Docker image, a self-contained package with PHP, your code, your dependencies and your compiled assets.
+- **Created network, database ready**: the app gets its own private network on the server, and a PostgreSQL container with generated credentials. Nothing to configure.
+- **Starting new version, backing up, pre-deploy hooks**: the new container starts next to whatever was running before, the database is dumped, then the migrations run.
+- **Health check passed**: FrankenDeploy asked the new container for `/api` and got a 200. Only now does it continue.
+- **Swapping containers**: traffic moves to the new container. On a redeploy, the old one is stopped only after that, so nobody sees an error.
+- **Caddy configured**: the reverse proxy now knows `my-app.com` and requests the certificate.
+
+</div>
+
+## Step 7: Ship a change (1 minute)
+
+Edit anything, commit or not, and run the same command:
+
+```bash
+frankendeploy deploy prod
+```
+
+Same output, one difference at the end: no `Created network` line, the network exists. During the minute it takes, the previous version keeps answering; the switch happens after the health check. That is the whole point: deploying becomes a habit rather than an event.
+
+## Step 8: Undo it (30 seconds)
+
+Something wrong with that change? Go back:
+
+```bash
+frankendeploy rollback prod
+```
+
+```
+ℹ️  Connecting to 203.0.113.42...
+ℹ️  Rolling back from 20260902-131358 to 20260902-115928...
+ℹ️  Running health check...
+✅ Health check passed
+ℹ️  Swapping containers...
+✅ Rolled back to release 20260902-115928
+```
+
+The previous release is still on the server (five are kept by default), it gets the same health check as a deploy, and the switch is the same zero-downtime swap. `frankendeploy app status prod` lists the releases you can go back to.
+
+## Where you are now
+
+- The app is at `https://my-app.com`, with a certificate that renews itself.
+- The server has a firewall, Fail2ban, and only exposes ports 22, 80 and 443.
+- The database lives in a Docker volume on the server, and is dumped before every migration.
+- Secrets are in `/opt/frankendeploy/apps/my-app/shared/.env.local`, readable only by the app.
+- `frankendeploy logs prod -f` shows what the app says; `frankendeploy shell prod` opens a shell inside it.
+
+## What to read next
+
+- [Environment Variables](/frankendeploy/guides/environment-variables/): `MAILER_DSN`, API keys, and applying a change without downtime
+- [Deployment](/frankendeploy/guides/deployment/): health checks, hooks, backups, what happens when something fails
+- [Troubleshooting](/frankendeploy/guides/troubleshooting/): every error message, its cause and its fix
+- [Security Model](/frankendeploy/guides/server-setup/#security-model): what is handled for you, and what stays your job (system updates, off-site backups)

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -1,82 +1,50 @@
 ---
 title: Introduction
-description: What is FrankenDeploy and why use it
+description: What FrankenDeploy is, who it is for, and where to start
 ---
 
-## What is FrankenDeploy?
+## In one sentence
 
-**FrankenDeploy** is a CLI that deploys Symfony applications to any VPS using [FrankenPHP](https://frankenphp.dev).
+**FrankenDeploy** puts a Symfony application online on a server you own, with one command, and keeps it online while you ship new versions.
 
-It covers the whole path from local development to production: Docker configuration, server preparation, zero-downtime deployments, rollbacks. One YAML file, a handful of commands, no PaaS.
+```bash
+frankendeploy deploy prod
+```
+
+Behind that command: a Docker image built for your app, a server prepared with a firewall and HTTPS, a health check before every traffic switch, a database backed up before every migration, and a rollback when something goes wrong. You keep a plain VPS, a plain Symfony project, and no vendor to depend on.
+
+## Where to start
+
+<div class="grid grid-cols-1 md:grid-cols-2 gap-4 not-prose my-6">
+  <a href="/frankendeploy/before-you-start/" class="block rounded-xl border border-white/10 bg-white/5 p-5 hover:bg-white/10 transition-colors">
+    <div class="text-lg font-semibold text-white mb-1">I have never deployed anything</div>
+    <div class="text-[#C3B2D3] text-sm">You have a Symfony app that works on your machine and you want it on the Internet. Start with <strong>Before You Start</strong>, then follow <strong>Your First Deployment</strong> step by step. About an hour, no prior server knowledge.</div>
+  </a>
+  <a href="/frankendeploy/quickstart/" class="block rounded-xl border border-white/10 bg-white/5 p-5 hover:bg-white/10 transition-colors">
+    <div class="text-lg font-semibold text-white mb-1">I know Docker and SSH</div>
+    <div class="text-[#C3B2D3] text-sm">You want the commands, then the details. The <strong>Quick Start</strong> is ten lines; <strong>Under the Hood</strong> and the <strong>frankendeploy.yaml reference</strong> tell you exactly what runs on the server.</div>
+  </a>
+</div>
+
+## What it does
+
+- **Reads your project** and writes one configuration file, `frankendeploy.yaml`: PHP version and extensions, database, assets, Messenger, worker mode, all detected from your code.
+- **Prepares a bare Ubuntu or Debian server**: Docker, UFW firewall, Fail2ban, and Caddy as a reverse proxy with automatic Let's Encrypt certificates. `frankendeploy doctor` checks the machine, the server and your DNS, and names the command that fixes each problem.
+- **Deploys without downtime**: the new version starts next to the old one, runs its migrations, passes a health check, and only then receives the traffic. If anything fails first, the old version keeps serving and nothing changed for your visitors.
+- **Runs the database for you**: PostgreSQL, MySQL or MariaDB in a container, credentials generated and injected, a dump before every migration.
+- **Operates the app**: `logs`, `exec`, `shell`, `env set` for secrets applied without downtime, `rollback` to any kept release with the same health check as a deploy.
+- **Hosts several apps on one server**, each on its own isolated Docker network.
+
+## What it is not
+
+- **Not a PaaS**: there is no dashboard, no account, no monthly fee. The server is yours, and so is its maintenance (system updates, backups off the machine). The [Security Model](/frankendeploy/guides/server-setup/#security-model) says exactly what FrankenDeploy handles and what it leaves to you.
+- **Not a cluster**: one VPS, one copy of your app. Enough for most projects; not built for horizontal scaling.
+- **Not magic**: it runs standard Docker, Caddy and shell commands on an ordinary Linux server. Everything it does can be read in [the deployment guide](/frankendeploy/guides/deployment/) and in the [source code](https://github.com/yoanbernabeu/frankendeploy).
 
 ## Built on FrankenPHP
 
-FrankenDeploy is a deployment layer on top of **FrankenPHP**, the modern PHP application server created by Kévin Dunglas. FrankenPHP combines:
+FrankenDeploy is a deployment layer on top of [FrankenPHP](https://frankenphp.dev), the PHP application server created by Kévin Dunglas: Caddy and PHP in a single binary, HTTP/2 and HTTP/3, and a worker mode that keeps your Symfony kernel in memory between requests. FrankenDeploy generates the Docker image, FrankenPHP runs it.
 
-- **Caddy web server** - Automatic HTTPS, HTTP/2, HTTP/3
-- **Worker mode** - Keeps your app in memory for ultra-fast responses
-- **Single binary** - No separate PHP-FPM, nginx, or Apache needed
+## Status
 
-FrankenDeploy wraps all this into simple commands.
-
-## What it does for you
-
-### Auto-detection
-`frankendeploy init` analyzes your Symfony project and detects:
-- PHP version from `composer.json` (8.2 minimum, required by FrankenPHP)
-- Required PHP extensions (from `composer.json`, plus what your database and Messenger transports need)
-- Database driver (PostgreSQL, MySQL, MariaDB, SQLite) from `.env` / `.env.local`
-- Asset build tool (Webpack Encore, Vite, AssetMapper, Tailwind bundle)
-- Symfony Messenger transports, Mailer, Scheduler
-- API Platform (sets the health check path to `/api`)
-- FrankenPHP worker mode when your runtime supports it
-
-### Docker generation
-Generates an optimized multi-stage `Dockerfile` for FrankenPHP, a `compose.yaml` for local development, and the supporting files. Missing files are generated at deploy time; files you customized are never overwritten.
-
-### Server preparation
-`frankendeploy server setup` turns a bare Ubuntu/Debian VPS into a deployment target: Docker, UFW firewall, Fail2ban, and Caddy as a front reverse proxy with automatic Let's Encrypt certificates. `frankendeploy doctor` checks everything (local Docker, SSH, server, DNS) and tells you exactly what to fix before you deploy.
-
-### One-command, zero-downtime deployment
-```bash
-frankendeploy deploy prod
-```
-Builds the image (locally or on the server), transfers it, starts the new version next to the old one, runs your migrations, checks the application health, then switches traffic. If anything fails before the switch, the old version keeps serving. A managed database, its credentials and a backup before each migration are handled for you.
-
-### Operations
-- `rollback` to any kept release, with the same health check as a deploy
-- `env set` / `env push` for production secrets, applied without downtime with `--reload`
-- `logs`, `exec`, `shell` on the running container
-- Several applications on one VPS, each on its own isolated Docker network
-
-## Quick Example
-
-```bash
-# In your Symfony project
-cd my-symfony-app
-
-# Analyze the project and create frankendeploy.yaml
-frankendeploy init --domain my-app.com
-
-# Optional: start the local development environment
-frankendeploy build
-frankendeploy dev up
-
-# Declare and prepare a server (one-time)
-frankendeploy server add prod deploy@my-vps.com
-frankendeploy server setup prod --email admin@example.com
-frankendeploy doctor prod
-
-# Production secrets for this app
-# (DATABASE_URL is injected automatically with a managed database)
-openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
-
-# Deploy
-frankendeploy deploy prod
-```
-
-## Next Steps
-
-- [Installation](/frankendeploy/installation/) - Install FrankenDeploy on your system
-- [Quick Start](/frankendeploy/quickstart/) - Get up and running in 5 minutes
-- [Project Configuration](/frankendeploy/guides/configuration/) - Customize your deployment
+FrankenDeploy is open source (MIT) and young: the command set is stable, but breaking changes can still happen between minor versions. Each one is listed in the [changelog](https://github.com/yoanbernabeu/frankendeploy/blob/main/CHANGELOG.md).

--- a/docs/src/content/docs/glossary.md
+++ b/docs/src/content/docs/glossary.md
@@ -1,0 +1,44 @@
+---
+title: Glossary
+description: The words used across the documentation, in a few lines each
+---
+
+**Application server** · The program that runs your PHP code and answers HTTP requests. With FrankenDeploy it is FrankenPHP, which bundles Caddy and PHP in one binary.
+
+**Blue-green deployment** · Starting the new version next to the old one, checking it, then switching the traffic. The old version stays up until the switch, so a failure never takes the site down.
+
+**Caddy** · A web server and reverse proxy that obtains HTTPS certificates by itself. FrankenDeploy runs one on the server, in front of every app.
+
+**Container** · An isolated process started from an image, with its own filesystem and network. Your app, its database and its worker each run in one.
+
+**Deploy** · Building the new version, sending it to the server, and switching the traffic to it.
+
+**DNS, A record** · The Domain Name System turns `my-app.com` into an IP address. An A record is the line saying "`my-app.com` is at `203.0.113.42`".
+
+**Docker** · The tool that builds images and runs containers. FrankenDeploy installs it on the server; on your machine it is optional.
+
+**Health check** · A request FrankenDeploy sends to the new container (`/` or `/api` by default) before switching traffic to it. A 200 means the app works; anything else stops the deploy.
+
+**Image** · A self-contained package: PHP, your code, its dependencies, compiled assets. Built once per deploy, run as a container.
+
+**Managed database** · A database container that FrankenDeploy creates, starts, backs up and connects to your app, without any configuration on your side.
+
+**Migration** · A versioned change to the database schema (Doctrine Migrations). FrankenDeploy runs pending migrations in the new container before switching traffic, after dumping the database.
+
+**Release** · One deployed version of the app on the server, identified by its tag (a timestamp by default). Several are kept so you can roll back.
+
+**Reverse proxy** · A server that receives the visitors' requests and passes them to your app. Caddy does it here: it handles the domain, HTTPS and HTTP/2, and the app only sees plain HTTP on a private port.
+
+**Rollback** · Switching the traffic back to a previous release, with the same health check as a deploy.
+
+**Shared files and directories** · What survives from one release to the next: `.env.local`, logs, sessions, uploads. Everything else is replaced at each deploy.
+
+**SSH** · The encrypted connection between your machine and the server. FrankenDeploy uses it for everything; a key pair replaces the password.
+
+**Swap** · The instant where the traffic moves from the old container to the new one. FrankenDeploy does it by renaming the containers, which takes no time and drops no request.
+
+**VPS** · Virtual Private Server: a rented Linux machine with a public IP, on which you are root. Any provider works.
+
+**Worker** · A process that consumes Symfony Messenger queues (asynchronous jobs, scheduled tasks). FrankenDeploy runs one as a separate container when `messenger.enabled` is true.
+
+**Worker mode (FrankenPHP)** · Keeping the Symfony kernel in memory between requests instead of booting it every time. Much faster; requires the application to be stateless.

--- a/docs/src/content/docs/guides/faq.md
+++ b/docs/src/content/docs/guides/faq.md
@@ -1,0 +1,76 @@
+---
+title: FAQ
+description: Short answers to the questions people ask after the talk
+---
+
+## Do I need Docker on my machine?
+
+Only for two things: building the image locally, and the local development environment (`frankendeploy dev up`). With `--remote-build` (or `remote_build: true` on the server), the image is built on the VPS and your machine needs nothing but the CLI. From an Apple Silicon Mac to an x86 server, remote build is the recommended path anyway.
+
+## Which servers work?
+
+Any VPS running **Ubuntu or Debian**, reachable over SSH as root or as a user with passwordless `sudo`. 1 GB of RAM runs a small site; 2 GB is comfortable, more if you build on the server. The provider does not matter.
+
+## How much does it cost?
+
+FrankenDeploy is free and open source (MIT). A VPS able to run a Symfony app with its database costs a few euros a month. The domain is the other cost.
+
+## Can I keep my existing database?
+
+Yes. Set `database.managed: false` in `frankendeploy.yaml` and give the app its `DATABASE_URL` with `frankendeploy env set prod DATABASE_URL --from-stdin`. FrankenDeploy then leaves the database alone: no container, no automatic backup (do your own before migrating).
+
+## Where are my files on the server?
+
+Under `/opt/frankendeploy/apps/<app>/`: `releases/<tag>/` for each deployed version, `current` pointing to the live one, `shared/` for what persists between versions (`.env.local`, `var/log`, `var/sessions`, your uploads directory if you added it to `shared_dirs`, `backups/` for the database dumps). The database data itself is in a Docker volume, `<app>-db-data`.
+
+## Where do user uploads go?
+
+Add the directory to `deploy.shared_dirs` (for instance `public/uploads`): it is stored under `shared/` on the server and mounted into every release, so a deploy never loses it. Everything else in the container is replaced at each deploy.
+
+## What about cron jobs?
+
+Use [Symfony Scheduler](https://symfony.com/doc/current/scheduler.html): your recurring tasks become messages, consumed by the Messenger worker that FrankenDeploy runs for you (`messenger.enabled: true`, `scheduler_default` added to the transports by `init`). No crontab to maintain on the server, and the worker restarts with every deploy.
+
+## Can I run several apps on one VPS?
+
+Yes, that is a normal setup. Each app has its own directory, database, domain, Caddy configuration and Docker network; they cannot see each other. Deploy each one from its project directory to the same server. `frankendeploy app list prod` shows what runs there.
+
+## Can I deploy to several servers (staging, production)?
+
+Yes: `frankendeploy server add staging ...`, then `frankendeploy deploy staging`. Servers are declared once on your machine and shared by all your projects.
+
+## Does a deploy cause downtime?
+
+No. The new version starts next to the old one, runs its migrations, passes a health check, and only then receives the traffic; the old one is stopped after. If anything fails before the switch, nothing changes for your visitors. The only thing a code rollback does not undo is a database migration, which is why the database is dumped before each one.
+
+## How do I set secrets?
+
+On the server, never in the project: `frankendeploy env set prod KEY --from-stdin`. They land in a file only the app can read. `--reload` applies a change without downtime.
+
+## Is HTTPS automatic?
+
+Yes. Caddy obtains a Let's Encrypt certificate for `deploy.domain` at the first deploy and renews it. The only requirement is a DNS A record pointing to the server; `frankendeploy doctor` checks it.
+
+## Does it work from Windows?
+
+The CLI runs on Windows (a binary is published for each release). Remote builds and SFTP transfers work without any Unix tool. The **server** must be Linux.
+
+## Can I see or change what is generated?
+
+Yes: `frankendeploy build` writes the `Dockerfile`, `docker-entrypoint.sh`, `compose.yaml`, `.dockerignore` (and a `Caddyfile` in worker mode) into your project. Edit them; FrankenDeploy never overwrites a file you changed.
+
+## Is it safe to run `server setup` twice?
+
+Yes. Every step checks the current state; a second run changes nothing on a prepared server, and repairs what is missing on a damaged one.
+
+## What does FrankenDeploy not do for me?
+
+System security updates, off-site backups of the database dumps, monitoring. The [Security Model](/frankendeploy/guides/server-setup/#security-model) lists it precisely.
+
+## Can I use it in CI?
+
+Yes. `--yes` removes every prompt, `FRANKENDEPLOY_SSH_KEY` and `FRANKENDEPLOY_KNOWN_HOSTS` carry the credentials, and `doctor` exits 1 on a blocking problem. Recipes for GitHub Actions and GitLab CI are in the [deployment guide](/frankendeploy/guides/deployment/#cicd-integration).
+
+## Something is wrong, where do I look?
+
+[Troubleshooting](/frankendeploy/guides/troubleshooting/) lists every message with its fix. `frankendeploy doctor prod` first, `frankendeploy logs prod -f` second.

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -1,0 +1,171 @@
+---
+title: Troubleshooting
+description: Every error message, what it means, and the command that fixes it
+---
+
+FrankenDeploy tries to say what is wrong and what to do about it. This page collects the messages you can meet, in the order you would meet them, with a little more context than fits in a terminal. Not finding yours? `frankendeploy doctor prod` is the first thing to run: it checks the machine, the server and the DNS and explains every failure.
+
+## Connecting to the server
+
+### `failed to connect to 203.0.113.42: ...`
+
+The SSH connection itself failed. In order of likelihood:
+
+- **Wrong user, host or port**: `frankendeploy server list` shows what is saved. Fix with `frankendeploy server remove prod` then `server add` again.
+- **The key is not on the server**: `ssh -v root@203.0.113.42` from your terminal tells you which keys were tried. Register yours with `ssh-copy-id root@203.0.113.42`.
+- **A firewall in front of the server** blocks port 22 (some providers ship one): open it in the provider's console.
+
+### `no usable SSH credentials for prod` / `no working SSH key found`
+
+FrankenDeploy found no key that the server accepts. It tries ssh-agent, then `key_path` from the config, then `~/.ssh/id_ed25519`, `~/.ssh/id_rsa` and the other keys in `~/.ssh/`. Point it at the right one:
+
+```bash
+frankendeploy server add prod root@203.0.113.42 --key ~/.ssh/my_key
+```
+
+### `key ~/.ssh/id_ed25519 is passphrase-protected and no terminal is available to prompt`
+
+You run with `--yes` or in CI, and the key is encrypted, so nobody can type the passphrase. Either load the key in ssh-agent (`ssh-add ~/.ssh/id_ed25519`) before running, or in CI use an unencrypted deploy key through `FRANKENDEPLOY_SSH_KEY`.
+
+### `The authenticity of host '203.0.113.42' can't be established.`
+
+Normal on the first connection: SSH shows the server's fingerprint and asks you to confirm. Answer `yes`; the key is recorded in `~/.ssh/known_hosts`. In CI, where nobody can answer, provide `FRANKENDEPLOY_KNOWN_HOSTS` with the content of a `known_hosts` file (get it with `ssh-keyscan 203.0.113.42`).
+
+### `host key for 203.0.113.42 has changed (fingerprint: SHA256:...)`
+
+The server presents a different key than the one recorded. If you reinstalled or recreated the VPS, that is expected: `ssh-keygen -R 203.0.113.42`, then run the command again and confirm the new fingerprint. If you did not, stop and investigate: someone may be intercepting the connection.
+
+## Preparing the server
+
+### `unsupported Linux distribution: ...`
+
+`server setup` only knows Ubuntu and Debian (it uses `apt` and their package names). Reinstall the VPS with Ubuntu 24.04 or Debian 12; every provider offers them.
+
+### `passwordless sudo is required for server setup.`
+
+You connect as a user who must type a password for `sudo`. Either connect as `root`, or give the user passwordless sudo on the server:
+
+```bash
+echo "deploy ALL=(ALL) NOPASSWD:ALL" | sudo tee /etc/sudoers.d/deploy
+```
+
+### `--email is required (used for Let's Encrypt certificates)`
+
+```bash
+frankendeploy server setup prod --email you@example.com
+```
+
+Let's Encrypt uses it to warn you about certificate problems. Any real address works.
+
+### I ran `server setup` and lost SSH access
+
+That should not happen: the firewall step allows your SSH port (the one you connect to, and the one `sshd` listens on) before enabling UFW. If it did, use your provider's console (a web-based terminal that bypasses SSH) and run `ufw allow 22/tcp`. Then please [open an issue](https://github.com/yoanbernabeu/frankendeploy/issues) with your setup: it is a bug.
+
+## Checking with doctor
+
+### `❌ Remote Docker — docker not found on the server`
+
+The server was not prepared: `frankendeploy server setup prod --email you@example.com`.
+
+### `❌ Docker network — network "frankendeploy" missing` / `❌ Caddy proxy — caddy container not running`
+
+Same cause, same fix. `server setup` is safe to run again on a prepared server; it recreates what is missing.
+
+### `❌ DNS my-app.com — domain does not resolve` / `resolves to 198.51.100.7, server is 203.0.113.42`
+
+The A record of the domain does not point to the server yet. Create or fix it at your DNS provider, then wait: propagation takes from minutes to hours. `dig +short my-app.com` shows what the world currently sees. Your own machine may cache an old answer longer than the rest of the Internet; `doctor` resolves from your machine, so a stale cache can make it say no while the record is right.
+
+### `❌ Local Docker — docker CLI not found`
+
+Docker is not installed on your machine. You need it for local builds and the dev environment. If you deploy with `--remote-build` (or `remote_build: true` on the server), the image is built on the server and local Docker is not used; `doctor` still reports the missing CLI.
+
+## Deploying
+
+### `Missing required environment variables: APP_SECRET (Symfony security secret)`
+
+Symfony refuses to start without `APP_SECRET`, so FrankenDeploy refuses to deploy without it. Run the command printed under the message:
+
+```bash
+openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+```
+
+`DATABASE_URL` is required too when `database.managed` is `false` (external database).
+
+### `Architecture mismatch: local arm64 → server x86_64`
+
+You build on an Apple Silicon Mac for an Intel/AMD server; the image would not run there. In interactive mode FrankenDeploy offers to build on the server and remembers the choice. In CI (`--yes`), say it explicitly once:
+
+```bash
+frankendeploy server set prod remote_build true
+```
+
+### `deployment failed health check: HTTP check failed (status: 500)` (or 404, 502)
+
+The new container started but did not answer 200 on the health path (`/` by default, `/api` for API Platform). FrankenDeploy prints the container's last 50 log lines right above this message: the cause is there (a missing variable, a failed database connection, a PHP fatal). The previous version is still serving; fix and deploy again.
+
+- **404**: the health path does not exist in your app. Set `deploy.healthcheck_path` to a route that does (an API-only app answers 404 on `/`).
+- **500**: read the logs. `frankendeploy logs prod` shows the live container; the failed one's logs were printed by the deploy.
+- **The app is just slow to start**: widen the window with `deploy.healthcheck_timeout` (90 seconds by default).
+
+### `deployment failed health check: container not running (status: exited)`
+
+The container died at startup. The printed logs say why; the usual suspects are a wrong `DATABASE_URL` for an external database, or a `pre_deploy` hook that needs a variable you have not set.
+
+### `pre-deploy hooks failed: ...`
+
+A `pre_deploy` command (typically the migrations) exited with an error, inside the new container, before any traffic switch. The output of the command is shown. The old version still serves. With a managed database, the dump taken just before is listed above, in case the migration went half-way (MySQL and MariaDB do not run DDL in a transaction).
+
+### `database backup failed (use --force to deploy without a backup)`
+
+The dump before the migration did not succeed, so the deploy stopped rather than migrate without a safety net. `frankendeploy logs prod --service app` will not help here: check the database container with `ssh` and `docker logs my-app-db`. Disk full is the classic cause (`doctor` reports free space).
+
+### `database volume my-app-db-data exists but .../.db_credentials is missing`
+
+The database data is there but the file holding its credentials is gone, so FrankenDeploy cannot start a container that matches the data. Either restore `shared/.db_credentials` from a backup of the server, or, if the data does not matter, remove both and let the next deploy start fresh (the message gives the exact commands).
+
+### `reverse proxy configuration failed — the application is running on the server but NOT publicly reachable`
+
+The deploy succeeded but Caddy could not load the configuration for your domain, on the app's first public exposure. The Caddy error is shown. Most often the domain is not in a form Caddy accepts; check `deploy.domain`. `docker logs caddy` on the server has the details.
+
+### `swap failed: ...`
+
+The rename that hands the traffic to the new container failed. FrankenDeploy restores the old container under its name, so the site keeps working, and removes the new one. This is rare (a Docker daemon problem); run the deploy again, and `doctor` if it persists.
+
+### The deploy succeeded, the site shows the previous version
+
+Your browser, or a CDN in front of the server, is caching. `curl -sI https://my-app.com` from a terminal shows what the server answers. FrankenDeploy switches traffic when the health check passes; `frankendeploy app status prod` shows which release is live.
+
+### The deploy succeeded, the site shows "Your connection is not private"
+
+The certificate has not been issued yet. Caddy requests it from Let's Encrypt when it sees the domain, which takes a few seconds; if it fails, the reason is in `docker logs caddy` on the server. Almost always: the domain does not point to this server (`doctor` checks it), or port 80 is not reachable from the Internet (a provider firewall).
+
+## Rolling back
+
+### `no previous release available`
+
+Only one release is on the server, there is nothing to go back to. Releases accumulate with deploys (five are kept by default).
+
+### `release '20260901-140326' not found. Available releases: ...`
+
+The release was removed by retention, or the tag is misspelled. The list shows what is available.
+
+### `rollback aborted, current version untouched: ...`
+
+The release you want to go back to failed its health check when started. Rather than switch to a broken version, FrankenDeploy kept the current one. The printed logs say why the old release fails today (a migration it does not know, a variable it needs).
+
+## Environment variables
+
+### I changed a variable and nothing happened
+
+Without `--reload`, a change applies at the next deploy. `frankendeploy env set prod KEY=value --reload` restarts the app right away, without downtime.
+
+### `env set` refuses my value
+
+Keys must be valid environment variable names (`[A-Z_][A-Z0-9_]*`). Values with spaces or special characters are fine when quoted, or passed with `--from-stdin`.
+
+## Still stuck
+
+- `frankendeploy deploy prod --verbose` prints every command run on the server, with secrets masked.
+- `frankendeploy shell prod` opens a shell inside the running container.
+- `ssh root@203.0.113.42` then `docker ps` and `docker logs <container>` show the raw state.
+- [Open an issue](https://github.com/yoanbernabeu/frankendeploy/issues) with the `--verbose` output: the messages are designed to be pasted.

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -1,128 +1,58 @@
 ---
 title: Quick Start
-description: Deploy your Symfony app in 5 minutes
+description: The ten commands, for people who know Docker and SSH
 ---
 
-## Prerequisites
-
-- A Symfony project
-- Docker installed locally (only needed for local builds and the dev environment)
-- A VPS running Ubuntu or Debian, reachable over SSH with a key
-
-Throughout the docs the server is called `prod`. Name yours as you like.
-
-## Step 1: Initialize Your Project
-
-Navigate to your Symfony project and run:
+You have a Symfony project, a VPS on Ubuntu or Debian you can `ssh` into as root (or with passwordless `sudo`), and a domain whose A record points to it. Here is everything.
 
 ```bash
-cd my-symfony-app
+# 1. In the project: detect PHP, extensions, database, assets, Messenger, worker mode
 frankendeploy init --domain my-app.com
-```
 
-FrankenDeploy analyzes the project (PHP version and extensions, database, assets, Messenger, Mailer, API Platform, worker mode) and writes a `frankendeploy.yaml`. Every inference is printed, so you can check what was detected. The domain can also be added later under `deploy.domain`.
+# 2. Declare and prepare the server: Docker, UFW, Fail2ban, Caddy with Let's Encrypt
+frankendeploy server add prod root@203.0.113.42
+frankendeploy server setup prod --email you@example.com
 
-## Step 2: Generate Docker Files (optional)
-
-```bash
-frankendeploy build
-```
-
-This generates:
-- `Dockerfile` - Multi-stage build with FrankenPHP
-- `docker-entrypoint.sh` - Startup script (waits for the database to accept connections)
-- `compose.yaml` - Local development environment
-- `compose.prod.yaml` - Production template, for people who deploy with Compose by hand
-- `.dockerignore` - Optimized ignore patterns
-- `Caddyfile` - Only with FrankenPHP worker mode enabled
-
-This step is optional before deploying: `frankendeploy deploy` generates any missing file and never overwrites one you customized. Run `build` explicitly to inspect or customize the generated files, or to use the local dev environment.
-
-## Step 3: Start Local Development (optional)
-
-```bash
-frankendeploy dev up
-```
-
-Your app is now running at **http://localhost:8000**, with its database, Mailpit and RabbitMQ when your project needs them.
-
-```bash
-frankendeploy dev logs      # View logs
-frankendeploy dev down      # Stop the environment
-frankendeploy dev restart   # Restart it
-```
-
-## Step 4: Declare and Prepare a Server
-
-Add your VPS to FrankenDeploy:
-
-```bash
-frankendeploy server add prod deploy@your-vps.com
-```
-
-FrankenDeploy tests the SSH connection right away and finds the right key. Options: `--port 2222` for a custom SSH port, `--key ~/.ssh/my_key` to force a key, `--skip-test` to skip the connection test.
-
-Then prepare the server (Docker, firewall, Fail2ban, Caddy):
-
-```bash
-frankendeploy server setup prod --email admin@example.com
-```
-
-The `--email` is required for Let's Encrypt certificates.
-
-Finally, check that everything is in place, including the DNS record of your domain:
-
-```bash
+# 3. Check local Docker, SSH, sudo, server, disk and DNS; every failure names its fix
 frankendeploy doctor prod
-```
 
-Every failed check comes with the command that fixes it. See [Preflight checks](/frankendeploy/guides/doctor/).
-
-## Step 5: Configure Production Secrets
-
-Secrets live on the server, per application, in a `.env.local` file. Set them from your project directory:
-
-```bash
+# 4. Production secrets live on the server (DATABASE_URL is generated with a managed database)
 openssl rand -hex 32 | frankendeploy env set prod APP_SECRET --from-stdin
+
+# 5. Blue-green deploy: build, transfer, migrate, health check, switch, Caddy
+frankendeploy deploy prod            # add --remote-build from Apple Silicon to an x86 VPS
+
+# 6. Day two
+frankendeploy logs prod -f
+frankendeploy env set prod MAILER_DSN --from-stdin --reload
+frankendeploy rollback prod
+frankendeploy app status prod
 ```
 
-**No `DATABASE_URL` needed with a managed database**: when `frankendeploy.yaml` has `database.managed: true` (the default for PostgreSQL, MySQL and MariaDB), FrankenDeploy creates the database container and injects `DATABASE_URL` automatically. Only set it yourself for an external database:
+## What you get
+
+| | |
+|---|---|
+| Image | Multi-stage Dockerfile on `dunglas/frankenphp`, non-root, cache warmed at build, `HEALTHCHECK` on your health path, FrankenPHP worker mode when the runtime supports it |
+| Server | `/opt/frankendeploy/apps/<app>/{releases,current,shared}`, one Docker network per app, Caddy attached to it, nothing but 80/443 published |
+| Deploy | New container under a temporary name, DB dump, `pre_deploy` hooks, health check, rename-based swap, worker restart, Caddy reload, retention of images, releases and backups |
+| Failure | Anything failing before the swap leaves the old container serving; `--force` overrides hook and health failures |
+| Secrets | `shared/.env.local`, `chmod 600`, mounted read-only; `SYMFONY_TRUSTED_PROXIES` injected so Symfony sees HTTPS and the client IP |
+
+## Where the details are
+
+- [Deployment](/frankendeploy/guides/deployment/): the deploy sequence, health checks, hooks, network isolation
+- [frankendeploy.yaml reference](/frankendeploy/config/project/): every field and its default
+- [Global config](/frankendeploy/config/global/): servers, SSH authentication, `remote_build`
+- [CI/CD](/frankendeploy/guides/deployment/#cicd-integration): `FRANKENDEPLOY_SSH_KEY`, `--yes`, `doctor` as a gate
+- [Security Model](/frankendeploy/guides/server-setup/#security-model): what is done, what is deliberately not
+- [Troubleshooting](/frankendeploy/guides/troubleshooting/): every error message, cause and fix
+
+## Local development (optional)
 
 ```bash
-frankendeploy env set prod DATABASE_URL --from-stdin
+frankendeploy build     # Dockerfile, compose.yaml, entrypoint, .dockerignore
+frankendeploy dev up    # http://localhost:8000, database, Mailpit, RabbitMQ when needed
 ```
 
-You can also push a whole file: `frankendeploy env push prod .env.prod`.
-
-If you forget `APP_SECRET`, the deploy stops before touching the server and offers to generate one for you.
-
-## Step 6: Deploy
-
-```bash
-frankendeploy deploy prod
-```
-
-From an Apple Silicon Mac to an x86 VPS, FrankenDeploy detects the architecture mismatch and offers to build on the server (`--remote-build`); the choice is remembered.
-
-That's it. Your Symfony app is live with:
-- FrankenPHP as the application server
-- Automatic HTTPS via Caddy
-- Zero-downtime blue-green deployments with health checks
-- A managed database with automatic backups before migrations
-
-## Common Operations
-
-```bash
-frankendeploy logs prod -f                          # Follow production logs
-frankendeploy exec prod php bin/console cache:clear # Run a command in the container
-frankendeploy shell prod                            # Open a shell in the container
-frankendeploy rollback prod                         # Go back to the previous release
-frankendeploy env set prod NEW_VAR=value --reload   # Change a variable without downtime
-frankendeploy app status prod                       # Releases and container status
-```
-
-## Next Steps
-
-- [Environment Variables](/frankendeploy/guides/environment-variables/) - Managing secrets and configuration
-- [Configuration Guide](/frankendeploy/guides/configuration/) - Customize your setup
-- [Deployment Guide](/frankendeploy/guides/deployment/) - Advanced deployment options
+Same image as production, `frankenphp_dev` target. See [Local Development](/frankendeploy/guides/local-development/).

--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -80,11 +80,14 @@ import frankenbearSmile from '../asset/frankenbear_smile.png';
 
             <!-- CTA Buttons -->
             <div class="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-10 animate-slide-up delay-300" style="opacity: 0;">
-              <a href="/frankendeploy/getting-started/" class="btn-lime text-lg px-8 py-4 group">
-                Get Started
+              <a href="/frankendeploy/before-you-start/" class="btn-lime text-lg px-8 py-4 group">
+                New to deployment? Start here
                 <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>
+              </a>
+              <a href="/frankendeploy/quickstart/" class="btn-ghost text-lg px-8 py-4">
+                I know Docker: Quick Start
               </a>
               <a href="https://github.com/yoanbernabeu/frankendeploy" target="_blank" class="btn-ghost text-lg px-8 py-4">
                 <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
@@ -375,8 +378,8 @@ import frankenbearSmile from '../asset/frankenbear_smile.png';
               Open source. Free. No vendor lock-in.
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
-              <a href="/frankendeploy/getting-started/" class="btn-lime text-lg px-10 py-5 group">
-                Get Started
+              <a href="/frankendeploy/first-deployment/" class="btn-lime text-lg px-10 py-5 group">
+                Your First Deployment
                 <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -15,8 +15,10 @@ export const navigation: NavSection[] = [
     title: 'Getting Started',
     items: [
       { label: 'Introduction', href: '/frankendeploy/getting-started/', order: 1 },
-      { label: 'Installation', href: '/frankendeploy/installation/', order: 2 },
-      { label: 'Quick Start', href: '/frankendeploy/quickstart/', order: 3 },
+      { label: 'Before You Start', href: '/frankendeploy/before-you-start/', order: 2 },
+      { label: 'Installation', href: '/frankendeploy/installation/', order: 3 },
+      { label: 'Your First Deployment', href: '/frankendeploy/first-deployment/', order: 4 },
+      { label: 'Quick Start', href: '/frankendeploy/quickstart/', order: 5 },
     ],
   },
   {
@@ -29,13 +31,16 @@ export const navigation: NavSection[] = [
       { label: 'Environment Variables', href: '/frankendeploy/guides/environment-variables/', order: 5 },
       { label: 'Deployment', href: '/frankendeploy/guides/deployment/', order: 6 },
       { label: 'Rollback', href: '/frankendeploy/guides/rollback/', order: 7 },
+      { label: 'Troubleshooting', href: '/frankendeploy/guides/troubleshooting/', order: 8 },
+      { label: 'FAQ', href: '/frankendeploy/guides/faq/', order: 9 },
     ],
   },
   {
-    title: 'Configuration',
+    title: 'Reference',
     items: [
       { label: 'frankendeploy.yaml', href: '/frankendeploy/config/project/', order: 1 },
       { label: 'Global Config', href: '/frankendeploy/config/global/', order: 2 },
+      { label: 'Glossary', href: '/frankendeploy/glossary/', order: 3 },
     ],
   },
   {


### PR DESCRIPTION
PR 1 of 3 of the documentation plan for the public launch: **the beginner path**.

## New pages

| Page | For | Content |
|---|---|---|
| **Before You Start** | someone who has never deployed | What a VPS is and how to order one, creating an SSH key and testing it, the DNS A record, checking the Symfony app, in about twenty minutes |
| **Your First Deployment** | same | A narrative tutorial in 8 steps with the **real output of every command** (init, server add, server setup, doctor with the DNS not propagated yet, the deploy refused for a missing `APP_SECRET`, the deploy, a redeploy, a rollback), each followed by "what just happened". Captured on the demo app; app name, domain and host replaced by `my-app`, `my-app.com`, `203.0.113.42` |
| **Troubleshooting** | everyone | Every error message a user can meet (taken from the code: SSH, host key, `server setup`, `doctor`, env pre-flight, architecture mismatch, health check, hooks, backup, Caddy, swap, rollback), its cause and the command that fixes it |
| **FAQ** | everyone | The 17 questions people ask after the talk (Docker needed?, existing database?, cron?, uploads?, several apps?, Windows?, CI?…) |
| **Glossary** | beginners | 20 words in two lines each, from VPS to worker mode |

## Changed pages

- **Introduction** rewritten: one sentence, two doors ("I have never deployed" / "I know Docker and SSH"), what it does, what it is not, status
- **Quick Start** becomes the ten-command cheat sheet for people who know Docker, with a "what you get" table and links to the details
- **Landing page**: two buttons (`New to deployment? Start here` → Before You Start, `I know Docker: Quick Start`), bottom CTA → Your First Deployment
- **Navigation**: Getting Started (Introduction, Before You Start, Installation, Your First Deployment, Quick Start), Guides + Troubleshooting + FAQ, "Configuration" section renamed **Reference** with the Glossary

## Fixed

The `:::note[...]` / `:::caution[...]` admonition syntax was rendered as literal text (the site has no remark directive plugin): it was already the case in the `frankendeploy.yaml` reference. Converted to the site's `callout` markup everywhere.

`npm run build` from a clean state: no warning, no error. No real domain or host in any example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
