### PR TITLE
docs(landing): back to two calls to action in the hero

### DIFF
--- a/docs/src/pages/index.astro
+++ b/docs/src/pages/index.astro
@@ -80,20 +80,14 @@ import frankenbearSmile from '../asset/frankenbear_smile.png';
 
             <!-- CTA Buttons -->
             <div class="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start mb-10 animate-slide-up delay-300" style="opacity: 0;">
-              <a href="/frankendeploy/before-you-start/" class="btn-lime text-lg px-8 py-4 group">
-                New to deployment? Start here
+              <a href="/frankendeploy/getting-started/" class="btn-lime text-lg px-8 py-4 group">
+                Get Started
                 <svg class="w-5 h-5 transition-transform group-hover:translate-x-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M13 7l5 5m0 0l-5 5m5-5H6" />
                 </svg>
               </a>
               <a href="/frankendeploy/quickstart/" class="btn-ghost text-lg px-8 py-4">
-                I know Docker: Quick Start
-              </a>
-              <a href="https://github.com/yoanbernabeu/frankendeploy" target="_blank" class="btn-ghost text-lg px-8 py-4">
-                <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
-                </svg>
-                GitHub
+                Quick Start
               </a>
             </div>
 


### PR DESCRIPTION
Three buttons in the hero (beginner path, quick start, GitHub) were too many. Back to two: **Get Started** (the introduction page routes beginners and experts with its two cards) and **Quick Start**. GitHub is already in the header. The bottom section keeps Your First Deployment + Quick Start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK