### PR TITLE
docs: the expert path (under the hood, security model, limits, upgrading)

### DIFF
--- a/docs/src/content/docs/first-deployment.md
+++ b/docs/src/content/docs/first-deployment.md
@@ -246,4 +246,4 @@ The previous release is still on the server (five are kept by default), it gets 
 - [Environment Variables](/frankendeploy/guides/environment-variables/): `MAILER_DSN`, API keys, and applying a change without downtime
 - [Deployment](/frankendeploy/guides/deployment/): health checks, hooks, backups, what happens when something fails
 - [Troubleshooting](/frankendeploy/guides/troubleshooting/): every error message, its cause and its fix
-- [Security Model](/frankendeploy/guides/server-setup/#security-model): what is handled for you, and what stays your job (system updates, off-site backups)
+- [Security Model](/frankendeploy/security/): what is handled for you, and what stays your job (system updates, off-site backups)

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -22,7 +22,7 @@ Behind that command: a Docker image built for your app, a server prepared with a
   </a>
   <a href="/frankendeploy/quickstart/" class="block rounded-xl border border-white/10 bg-white/5 p-5 hover:bg-white/10 transition-colors">
     <div class="text-lg font-semibold text-white mb-1">I know Docker and SSH</div>
-    <div class="text-[#C3B2D3] text-sm">You want the commands, then the details. The <strong>Quick Start</strong> is ten lines; <strong>Under the Hood</strong> and the <strong>frankendeploy.yaml reference</strong> tell you exactly what runs on the server.</div>
+    <div class="text-[#C3B2D3] text-sm">You want the commands, then the details. The <strong>Quick Start</strong> is ten lines; <a href="/frankendeploy/under-the-hood/" class="underline">Under the Hood</a> and the <a href="/frankendeploy/config/project/" class="underline">frankendeploy.yaml reference</a> tell you exactly what runs on the server.</div>
   </a>
 </div>
 
@@ -37,9 +37,9 @@ Behind that command: a Docker image built for your app, a server prepared with a
 
 ## What it is not
 
-- **Not a PaaS**: there is no dashboard, no account, no monthly fee. The server is yours, and so is its maintenance (system updates, backups off the machine). The [Security Model](/frankendeploy/guides/server-setup/#security-model) says exactly what FrankenDeploy handles and what it leaves to you.
+- **Not a PaaS**: there is no dashboard, no account, no monthly fee. The server is yours, and so is its maintenance (system updates, backups off the machine). The [Security Model](/frankendeploy/security/) says exactly what FrankenDeploy handles and what it leaves to you.
 - **Not a cluster**: one VPS, one copy of your app. Enough for most projects; not built for horizontal scaling.
-- **Not magic**: it runs standard Docker, Caddy and shell commands on an ordinary Linux server. Everything it does can be read in [the deployment guide](/frankendeploy/guides/deployment/) and in the [source code](https://github.com/yoanbernabeu/frankendeploy).
+- **Not magic**: it runs standard Docker, Caddy and shell commands on an ordinary Linux server. Everything it does can be read in [Under the Hood](/frankendeploy/under-the-hood/) and in the [source code](https://github.com/yoanbernabeu/frankendeploy).
 
 ## Built on FrankenPHP
 

--- a/docs/src/content/docs/guides/faq.md
+++ b/docs/src/content/docs/guides/faq.md
@@ -65,7 +65,7 @@ Yes. Every step checks the current state; a second run changes nothing on a prep
 
 ## What does FrankenDeploy not do for me?
 
-System security updates, off-site backups of the database dumps, monitoring. The [Security Model](/frankendeploy/guides/server-setup/#security-model) lists it precisely.
+System security updates, off-site backups of the database dumps, monitoring. The [Security Model](/frankendeploy/security/) lists it precisely.
 
 ## Can I use it in CI?
 

--- a/docs/src/content/docs/guides/server-setup.md
+++ b/docs/src/content/docs/guides/server-setup.md
@@ -265,36 +265,9 @@ When you deploy an app, FrankenDeploy:
 
 This ensures **zero downtime** for existing apps during deployments.
 
-## Security Model
+## Security
 
-What FrankenDeploy does on the server, and what it deliberately leaves to you.
-
-### What `server setup` does
-
-- **UFW firewall**: only SSH (your actual SSH ports, not just 22), 80 and 443 are open; everything else is denied
-- **Fail2ban** on SSH: 5 failed attempts, 1 hour ban
-- **Caddy** is the only container with published ports. Its admin API listens on `localhost` inside the container and is never exposed
-
-### What every deploy does
-
-- The application runs as a **non-root user** on an unprivileged port (8080)
-- **No port is published** for the app, the worker or the database: the only way in is Caddy, on 80 and 443
-- **TLS** with automatic Let's Encrypt certificates, HSTS enabled; Symfony trusts only Caddy as a proxy (`SYMFONY_TRUSTED_PROXIES` set to the private subnets), so it sees the real client IP and the HTTPS scheme
-- **One Docker network per application**: apps sharing a VPS cannot reach each other's containers
-- **Secrets** live in `.env.local` on the server, `chmod 600`, mounted read-only; `env set --from-stdin` keeps them out of your shell history
-- **Managed databases** get random credentials, a random one-time root password (MySQL/MariaDB), and a dump before every migration
-- **Log rotation** on every container, so logs cannot fill the disk
-
-### What it does not do
-
-FrankenDeploy prepares a server; it is not a hardening tool.
-
-- **No automatic security updates**: install `unattended-upgrades` or update the system yourself
-- **No `sshd` hardening**: password authentication and root login stay as your distribution ships them. Disable password authentication once your key works
-- **No encryption of secrets at rest**: `.env.local` is readable by root and by anyone with SSH access. Use your provider's disk encryption for backups and snapshots
-- **No intrusion detection, no container hardening beyond non-root**
-
-A `server harden` command covering updates, `sshd` and an audit in `doctor` is [being discussed](https://github.com/yoanbernabeu/frankendeploy/issues/95).
+`server setup` installs a firewall, Fail2ban and a reverse proxy that is the only thing listening on the Internet; every deploy runs the app as non-root, publishes no port, and isolates each app on its own network. What is protected, how, and what deliberately stays your job (system updates, `sshd` hardening, off-site backups) is laid out in the [Security Model](/frankendeploy/security/).
 
 ## Multiple Environments
 

--- a/docs/src/content/docs/guides/troubleshooting.md
+++ b/docs/src/content/docs/guides/troubleshooting.md
@@ -99,7 +99,7 @@ You build on an Apple Silicon Mac for an Intel/AMD server; the image would not r
 frankendeploy server set prod remote_build true
 ```
 
-### `deployment failed health check: HTTP check failed (status: 500)` (or 404, 502)
+### `deployment failed health check: health check failed on my-app-new: HTTP check failed (status: 500) (after 30 attempts)`
 
 The new container started but did not answer 200 on the health path (`/` by default, `/api` for API Platform). FrankenDeploy prints the container's last 50 log lines right above this message: the cause is there (a missing variable, a failed database connection, a PHP fatal). The previous version is still serving; fix and deploy again.
 
@@ -107,7 +107,7 @@ The new container started but did not answer 200 on the health path (`/` by defa
 - **500**: read the logs. `frankendeploy logs prod` shows the live container; the failed one's logs were printed by the deploy.
 - **The app is just slow to start**: widen the window with `deploy.healthcheck_timeout` (90 seconds by default).
 
-### `deployment failed health check: container not running (status: exited)`
+### `deployment failed health check: health check failed on my-app-new: container not running (status: exited) (after 1 attempts)`
 
 The container died at startup. The printed logs say why; the usual suspects are a wrong `DATABASE_URL` for an external database, or a `pre_deploy` hook that needs a variable you have not set.
 

--- a/docs/src/content/docs/limits.md
+++ b/docs/src/content/docs/limits.md
@@ -1,0 +1,36 @@
+---
+title: Limits & Non-Goals
+description: What FrankenDeploy is not designed for, so you can decide before you start
+---
+
+FrankenDeploy targets one common situation: a Symfony application, a VPS, a small team or a single person, and the wish to deploy without a platform in between. Outside that situation, here is what to expect.
+
+## By design
+
+| | FrankenDeploy | If you need more |
+|---|---|---|
+| **Servers per app** | One. No load balancing, no failover, no horizontal scaling | Kubernetes, a PaaS, or a container orchestrator with a real load balancer |
+| **Database** | One container on the same VPS, one volume, no replication, no automatic failover. Backups are dumps on the same disk | A managed database at your provider, and `database.managed: false` |
+| **Zero downtime** | For the application, through the container swap. Not for the database container itself (a PostgreSQL major upgrade stops it) | Plan database upgrades as maintenance |
+| **Framework** | Symfony (detection requires `symfony/framework-bundle`), PHP >= 8.2 as FrankenPHP requires | Other PHP frameworks may work with a hand-written `frankendeploy.yaml` and Dockerfile, untested |
+| **Server OS** | Ubuntu or Debian, `apt` based, x86_64 or arm64 | Anything else is refused by `server setup` on purpose |
+| **Client OS** | macOS, Linux, Windows (the CLI is a single binary) | |
+| **Ingress** | HTTP and HTTPS through Caddy. No raw TCP or UDP exposure of your containers (no public database port, no custom TCP service) | Publish it yourself with `docker run -p` outside FrankenDeploy |
+| **Domains** | One `deploy.domain` per app, served with HTTPS. No automatic `www` redirect, no wildcard | Add a `.caddy` file by hand in `/opt/frankendeploy/caddy/apps/` |
+| **Apps per server** | As many as the machine handles. Docker's default address pools cap bridge networks at about 30 | `default-address-pools` in `/etc/docker/daemon.json`, see the error message |
+| **Secrets** | A `.env.local` file per app on the server, `chmod 600` | Symfony's secrets vault works on top of it; no Vault or cloud secret manager integration |
+| **Scheduled tasks** | Through Symfony Scheduler and the Messenger worker | A crontab on the host is yours to manage |
+| **Assets** | npm (`npm ci`), AssetMapper. Yarn and pnpm are detected but the Node stage currently runs `npm ci` and needs a `package-lock.json` | `npm install --package-lock-only` for now |
+| **SQLite** | Supported as a file in a shared directory, not as a managed database | |
+| **Custom Dockerfile** | You can edit the generated one; it is never overwritten. FrankenDeploy assumes its contract (port 8080, `app` user, `docker-entrypoint`) | A validation of custom Dockerfiles is [in progress](https://github.com/yoanbernabeu/frankendeploy/issues/91) |
+| **Windows Server, Docker Swarm, Podman** | Not supported | |
+
+## Numbers
+
+- A deploy takes about a minute after the first one on a 2 vCPU VPS (image build with a warm cache, transfer, health check). The first one downloads the base images: several minutes.
+- A Symfony app in worker mode on a 2 vCPU VPS served 53 requests per second at p95 0.83 s in a load test (23 req/s without worker mode). Your numbers depend on your app.
+- 5 releases, 5 images and 5 database dumps are kept by default; each image is 500 MB to 1 GB. `keep_releases` drives all three.
+
+## Stability
+
+FrankenDeploy is in its 0.x versions. The commands and `frankendeploy.yaml` are stable in practice, but a minor version can change what happens on the server (0.15 moved apps to their own networks, 0.16 changed the environment of the container). Every change of that kind is documented in [Upgrading](/frankendeploy/upgrading/) and in the [changelog](https://github.com/yoanbernabeu/frankendeploy/blob/main/CHANGELOG.md), and is applied transparently at the next deploy.

--- a/docs/src/content/docs/quickstart.md
+++ b/docs/src/content/docs/quickstart.md
@@ -41,11 +41,12 @@ frankendeploy app status prod
 
 ## Where the details are
 
-- [Deployment](/frankendeploy/guides/deployment/): the deploy sequence, health checks, hooks, network isolation
+- [Under the Hood](/frankendeploy/under-the-hood/): the server layout, the exact `docker run`, the generated Caddyfile, the deploy sequence step by step
+- [Limits & Non-Goals](/frankendeploy/limits/): what it is not designed for
 - [frankendeploy.yaml reference](/frankendeploy/config/project/): every field and its default
 - [Global config](/frankendeploy/config/global/): servers, SSH authentication, `remote_build`
 - [CI/CD](/frankendeploy/guides/deployment/#cicd-integration): `FRANKENDEPLOY_SSH_KEY`, `--yes`, `doctor` as a gate
-- [Security Model](/frankendeploy/guides/server-setup/#security-model): what is done, what is deliberately not
+- [Security Model](/frankendeploy/security/): what is done, what is deliberately not
 - [Troubleshooting](/frankendeploy/guides/troubleshooting/): every error message, cause and fix
 
 ## Local development (optional)

--- a/docs/src/content/docs/security.md
+++ b/docs/src/content/docs/security.md
@@ -1,0 +1,73 @@
+---
+title: Security Model
+description: What FrankenDeploy protects, how, and what it deliberately leaves to you
+---
+
+FrankenDeploy prepares a server and runs your application on it with sane defaults. It is not a hardening tool, and this page is meant to be precise about the boundary: what is handled, with which mechanism, and what remains your responsibility.
+
+## Threat model
+
+The server is a single VPS you own, reachable from the Internet. The risks FrankenDeploy addresses, in order of likelihood:
+
+1. **Automated attacks on the server itself**: SSH brute force, scans of open ports
+2. **A compromised application**: a vulnerability in your code or a dependency giving an attacker a shell inside the container
+3. **Another application on the same server** reaching yours, or your database
+4. **Secrets leaking**: through Git, shell history, world-readable files, logs
+5. **Losing data**: a migration that goes wrong, a deploy that breaks the site
+
+It does not address a compromised server (root access obtained by other means), a compromised provider, or attacks on the application logic itself.
+
+## What `server setup` does
+
+| Measure | Mechanism | Verify on the server |
+|---|---|---|
+| Firewall | UFW, default deny incoming; allowed: your SSH port(s), 80, 443 | `sudo ufw status` |
+| SSH brute force | Fail2ban, `sshd` jail: 5 failed attempts in 10 minutes, 1 hour ban | `sudo fail2ban-client status sshd` |
+| No lock-out | Both the port you connect to and the port `sshd` listens on are allowed before UFW is enabled | the `Firewall:` line of the setup output |
+| Proxy admin API | Caddy's admin endpoint listens on `localhost:2019` inside its container; reloads go through `docker exec` | `docker port caddy` shows only 80 and 443 |
+
+## What every deploy does
+
+| Measure | Mechanism |
+|---|---|
+| No root in containers | The app and worker run as uid 1000 (`--user 1000:1000`); the image's production stage ends with `USER app` |
+| Nothing published | The app, worker and database containers publish no port; Caddy is the only way in, on 80 and 443 |
+| Network isolation | One Docker network per app; Caddy is attached to it; two apps on one server cannot reach each other's containers, database included |
+| TLS | Let's Encrypt certificate obtained and renewed by Caddy; `Strict-Transport-Security max-age=31536000`; `X-Content-Type-Options`, `X-Frame-Options DENY`, `Referrer-Policy`, `Server` header removed |
+| Proxy trust | `SYMFONY_TRUSTED_PROXIES` limited to private subnets, so only Caddy can set `X-Forwarded-*`; Symfony sees the real client IP and the HTTPS scheme |
+| Secrets at rest | `shared/.env.local` and `.db_credentials` are `chmod 600`, owned by the deploy user, mounted **read-only** in the containers |
+| Secrets in transit | Everything goes over SSH (host key verified like OpenSSH, `known_hosts`); `env set --from-stdin` keeps values out of the shell history; sensitive values are masked in `env list` and `--verbose` output |
+| Secrets in Git | Nothing secret goes into `frankendeploy.yaml`; `env.prod` is not used in production |
+| Database credentials | Generated (24 random hex characters), one user per app, random one-time root password for MySQL/MariaDB, never written to the image |
+| Data safety | Dump before every migration, health check before every traffic switch, previous release kept for rollback |
+| Disk exhaustion | Log rotation on every container (10 MB × 3), Caddy access logs 10 MB × 5, images and backups pruned with `keep_releases` |
+| Input validation | Hook commands, extra Dockerfile instructions, release tags, app and server names are validated against shell injection before reaching the server |
+
+## What it does not do
+
+Say it plainly so you can plan for it.
+
+| Not done | Why | What to do |
+|---|---|---|
+| **System security updates** | `server setup` runs once; a VPS deployed in January still runs January's `openssl` in September | `sudo apt install unattended-upgrades` on the server, or update it on a schedule |
+| **`sshd` hardening** | FrankenDeploy never edits `sshd_config`: cutting your own access on a server it does not own is a worse outcome than leaving the defaults | Once your key works: `PasswordAuthentication no`, and `PermitRootLogin prohibit-password` if you deploy as root |
+| **Encryption of secrets at rest** | `.env.local` is readable by root, and by anyone with SSH access; a key to decrypt it would have to sit next to it | Your provider's disk encryption; treat SSH access to the server as access to the secrets |
+| **Off-site backups** | The dumps in `shared/backups/` are on the same disk as the database | Copy them elsewhere on a schedule; the volume `my-app-db-data` is the data itself |
+| **Container hardening beyond non-root** | No `cap_drop`, `no-new-privileges` or read-only root filesystem yet | Discussed for a future version |
+| **Intrusion detection, monitoring, alerting** | Out of scope | Your usual tools; Caddy's JSON access logs are in `/opt/frankendeploy/caddy/logs/` |
+| **Application security** | Your code, your dependencies | `composer audit`, Symfony's security advisories |
+
+A `server harden` command covering the first two lines, with an audit in `doctor`, is [being discussed](https://github.com/yoanbernabeu/frankendeploy/issues/95). Opinions welcome.
+
+## Who can do what
+
+| Actor | Can |
+|---|---|
+| Anyone on the Internet | Reach Caddy on 80/443, and your app through it. Nothing else answers |
+| Someone with your SSH key | Everything: deploy, read secrets, `docker exec` into containers. Protect the key with a passphrase; use a dedicated deploy key in CI |
+| Your application, if compromised | Read its own `.env.local`, talk to its own database and worker, reach the Internet. Not: other apps on the server, the Docker socket, the host filesystem, root |
+| Another application on the same server | Nothing of yours: different network, different directory, different database credentials |
+
+## Reporting a vulnerability
+
+Use "Report a vulnerability" in the [Security tab](https://github.com/yoanbernabeu/frankendeploy/security) of the repository rather than a public issue.

--- a/docs/src/content/docs/under-the-hood.md
+++ b/docs/src/content/docs/under-the-hood.md
@@ -1,0 +1,194 @@
+---
+title: Under the Hood
+description: Exactly what FrankenDeploy puts on your server and runs at each deploy
+---
+
+For people who want to see before they trust. Everything below is read from the source, and everything can be verified on the server with `ssh`, `docker ps`, `docker inspect`. Nothing here is required to use FrankenDeploy.
+
+## On the server
+
+### Files
+
+```
+/opt/frankendeploy/
+├── apps/
+│   └── my-app/
+│       ├── releases/
+│       │   ├── 20260901-140326/release      ← one directory per kept release
+│       │   └── 20260902-131358/release        (a marker file: the code lives in the image)
+│       ├── current -> releases/20260902-131358
+│       ├── shared/                           ← survives every deploy
+│       │   ├── .env.local                    600, mounted read-only in the containers
+│       │   ├── .db_credentials               600, the generated DATABASE_URL
+│       │   ├── backups/pgsql-<tag>.sql.gz    600, one dump per migration, keep_releases kept
+│       │   ├── var/log/
+│       │   └── var/sessions/                 + every entry of deploy.shared_dirs
+│       └── build/                            ← source tree of the last remote build
+└── caddy/
+    ├── Caddyfile                             ← global options, imports apps/*.caddy
+    ├── apps/my-app.caddy                     ← one file per app, written by deploy
+    └── logs/my-app.log                       ← JSON access log, 10 MB × 5
+```
+
+Everything under `apps/` belongs to the user you deploy with. The application code is not on disk: it is inside the Docker image, tagged with the release.
+
+### Containers
+
+| Container | Image | Started by | Network(s) | Published ports |
+|---|---|---|---|---|
+| `caddy` | `caddy:alpine` | `server setup` | `frankendeploy` + every `frankendeploy-<app>` | 80, 443, 443/udp |
+| `my-app` | `my-app:<tag>` | `deploy` | `frankendeploy-my-app` | none |
+| `my-app-worker` | `my-app:<tag>` | `deploy`, when `messenger.enabled` | `frankendeploy-my-app` | none |
+| `my-app-db` | `postgres:16-alpine`, `mysql:<v>`, `mariadb:<v>` | first `deploy`, when `database.managed` | `frankendeploy-my-app` | none |
+
+All of them run with `--restart unless-stopped`, so they come back after a reboot, and with `--log-driver json-file --log-opt max-size=10m --log-opt max-file=3`.
+
+### Networks
+
+`server setup` creates the `frankendeploy` bridge network for Caddy. The first deploy of an app creates `frankendeploy-<app>` and attaches Caddy to it with `docker network connect`. Docker's embedded DNS lets Caddy resolve `my-app` to the container, whatever its IP, and nothing outside the app's network can reach it. See [Network Isolation](/frankendeploy/guides/deployment/#network-isolation) for the migration of installations older than 0.15.
+
+### The app container, verbatim
+
+This is the command `deploy`, `rollback` and `env --reload` run (`buildAppRunCommand` in `internal/cmd/deploy.go`), for a PostgreSQL app with the default shared paths:
+
+```bash
+docker run -d --name my-app-new \
+  --network frankendeploy-my-app \
+  --restart unless-stopped \
+  --user 1000:1000 \
+  --log-driver json-file --log-opt max-size=10m --log-opt max-file=3 \
+  [--memory 512m] [--cpus 1.5] \
+  -e SERVER_NAME=:8080 -e APP_ENV=prod -e APP_DEBUG=0 \
+  -e DATABASE_URL='postgresql://my-app:<generated>@my-app-db:5432/my_app?serverVersion=16&charset=utf8' \
+  -e SYMFONY_TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 \
+  -e TRUSTED_PROXIES=127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 \
+  -v /opt/frankendeploy/apps/my-app/shared/var/log:/app/var/log \
+  -v /opt/frankendeploy/apps/my-app/shared/var/sessions:/app/var/sessions \
+  -v /opt/frankendeploy/apps/my-app/shared/.env.local:/app/.env.local:ro \
+  my-app:20260902-131358
+```
+
+- `--user 1000:1000`: the image's `app` user; nothing in the container runs as root.
+- `SERVER_NAME=:8080`: FrankenPHP's own Caddy listens on plain HTTP, port 8080, unprivileged. TLS ends at the front Caddy.
+- `.env.local` is mounted read-only: the app cannot alter its own secrets.
+- The trusted proxies are skipped when you define either variable in `.env.local` yourself.
+
+The worker container uses the same mounts and `DATABASE_URL`, with the command `php bin/console messenger:consume <transports> --time-limit=3600 --memory-limit=256M -vv`.
+
+### The database container
+
+```bash
+docker run -d --name my-app-db \
+  --network frankendeploy-my-app \
+  --restart unless-stopped \
+  --log-driver json-file --log-opt max-size=10m --log-opt max-file=3 \
+  -e POSTGRES_USER=my-app -e POSTGRES_PASSWORD=<generated> -e POSTGRES_DB=my_app \
+  -v my-app-db-data:/var/lib/postgresql/data \
+  postgres:16-alpine
+```
+
+The password is 24 random hex characters, generated once and saved in `shared/.db_credentials`. MySQL and MariaDB additionally get `MYSQL_RANDOM_ROOT_PASSWORD=1` / `MARIADB_RANDOM_ROOT_PASSWORD=1`: the app password is never the root password. Data lives in the named volume `my-app-db-data`; `app remove` deletes it unless `--keep-data`.
+
+### The generated Caddy configuration
+
+`server setup` writes `/opt/frankendeploy/caddy/Caddyfile`:
+
+```
+{
+    admin localhost:2019
+    email you@example.com
+}
+
+import /config/apps/*.caddy
+```
+
+The admin API only listens inside the container: reloads go through `docker exec caddy caddy reload`. Each deploy writes `apps/my-app.caddy`:
+
+```
+my-app.com {
+    reverse_proxy my-app:8080 {
+        transport http {
+            dial_timeout 5s
+            response_header_timeout 60s
+        }
+    }
+
+    encode zstd gzip
+
+    header {
+        Strict-Transport-Security "max-age=31536000"
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+
+    log {
+        output file /config/logs/my-app.log {
+            roll_size 10mb
+            roll_keep 5
+        }
+        format json
+    }
+}
+```
+
+No active health check on the upstream, deliberately: with a single upstream there is nothing to fail over to, and a probe timing out under load would turn a slow app into a 503 for everyone. The per-request timeouts bound the damage of a frozen container to one 504. HTTPS, HTTP/2, HTTP/3 and the certificate come from Caddy's defaults.
+
+## The image
+
+`frankendeploy build` writes a multi-stage `Dockerfile` (you can read and edit it; FrankenDeploy never overwrites a modified file):
+
+| Stage | Base | What happens |
+|---|---|---|
+| `frankenphp_upstream` | `dunglas/frankenphp:1-php8.4` | The FrankenPHP release, PHP version from `php.version` |
+| `node_build` | `node:22-slim` | Only with npm/yarn/pnpm assets: `npm ci`, then `assets.build_command` |
+| `frankenphp_base` | upstream | System packages (`dockerfile.extra_packages`), `install-php-extensions` for `php.extensions` and Composer, `php.ini_values`, the `app` user (uid 1000), the entrypoint, `HEALTHCHECK --start-period=60s curl -f http://localhost:8080<healthcheck_path>` |
+| `frankenphp_dev` | base | `APP_ENV=dev`, `XDEBUG_MODE=off`, `composer install` with dev dependencies, `frankenphp run --watch` |
+| `frankenphp_prod` | base | Production `php.ini` (opcache without timestamp validation, 256 MB, preload when `config/preload.php` exists), `composer install --no-dev`, the built assets copied from `node_build` or `asset-map:compile`, `cache:warmup`, `USER app` |
+
+`docker-entrypoint.sh` does one thing in production: wait for the database host of `DATABASE_URL` to accept TCP connections, then `exec frankenphp run`. Migrations are not its job; they run as a `pre_deploy` hook, before the traffic switch, where a failure can still abort the deploy.
+
+With `frankenphp.worker: true`, a `Caddyfile` for FrankenPHP is generated and copied into the image: it declares `public/index.php` as the worker script, so the Symfony kernel boots once and stays in memory.
+
+## A deploy, step by step
+
+`deploy.RunPipeline` in `internal/deploy/orchestrator.go` runs the sequence below. What happens on failure is decided once, there, and tested per scenario.
+
+| # | Step | On failure |
+|---|---|---|
+| 1 | Env pre-flight: `APP_SECRET`, `DATABASE_URL` for an external database | Abort before touching the server |
+| 2 | Generate missing artifacts, build the image (locally, or on the server from the transferred source), transfer it | Abort |
+| 3 | `EnsureAppNetwork`: create `frankendeploy-<app>`, attach Caddy, attach an older database | Abort |
+| 4 | Managed database: start it if stopped, create it on the first deploy | Abort |
+| 5 | `prepareRelease`: `releases/<tag>`, `shared/` paths, permissions | Abort |
+| 6 | Start `<app>-new` from the new image (the old `<app>` keeps serving) | Abort, remove `<app>-new` |
+| 7 | Managed database + migration hook: dump to `shared/backups/` | Abort unless `--force` |
+| 8 | `pre_deploy` hooks with `docker exec <app>-new …` | Abort unless `--force`; warn that the schema may already be migrated |
+| 9 | Health check: `curl -f http://localhost:8080<path>` inside `<app>-new`, up to 30 attempts over 90 s | Print the container's last 50 log lines, abort unless `--force` |
+| 10 | Swap: `docker rename <app> <app>-old`, `docker rename <app>-new <app>`, then stop `<app>-old`; update `current` | Restore `<app>-old` under its name, abort |
+| 11 | Recreate the worker on the new image; detach the app from the shared network if it was migrating | Warn |
+| 12 | `post_deploy` hooks in `<app>` | Warn |
+| 13 | Write `caddy/apps/<app>.caddy`, `caddy reload` | Abort on the app's first exposure (it would be running but unreachable), warn otherwise |
+| 14 | Retention: releases, images (`docker rmi`, never forced), backups beyond `keep_releases`; dangling layers after a remote build | Best effort |
+
+The swap is two renames. Caddy proxies to the name `my-app`; Docker's DNS follows the rename instantly, so no request meets a missing upstream. The old container is stopped only after the new one owns the name.
+
+`rollback` runs steps 3, 6, 9, 10, 11 with a kept image; `env --reload` runs 3, 6, 9, 10 with the current image.
+
+## What the CLI keeps on your machine
+
+The global configuration (servers, `remote_build`, `key_path`), in the user configuration directory (see [Global Config](/frankendeploy/config/global/)). Nothing else: no state about deployed releases, which is why any machine with the CLI and the SSH key can deploy or roll back.
+
+## Reading the code
+
+The repository is organised the way this page is:
+
+- `internal/cmd/`: one file per command; `deploy.go` builds the `docker run` commands
+- `internal/deploy/`: the pipeline (`orchestrator.go`), health checks, database, backups, networks, env files, retention
+- `internal/generator/`: the Dockerfile, entrypoint and Compose templates
+- `internal/caddy/`: the two Caddy templates above
+- `internal/ssh/`: the pure-Go SSH and SFTP client (no `ssh` binary needed on your machine)
+- `internal/scanner/`: what `init` detects in your project
+
+`frankendeploy deploy prod --verbose` prints every command sent to the server, with secrets masked.

--- a/docs/src/content/docs/upgrading.md
+++ b/docs/src/content/docs/upgrading.md
@@ -1,0 +1,67 @@
+---
+title: Upgrading
+description: How to update the CLI, and what each version changes on your server
+---
+
+## Updating the CLI
+
+```bash
+brew upgrade frankendeploy                       # Homebrew
+curl -fsSL https://raw.githubusercontent.com/yoanbernabeu/frankendeploy/main/scripts/install.sh | sh   # install script
+go install github.com/yoanbernabeu/frankendeploy/cmd/frankendeploy@latest                                # Go
+frankendeploy --version
+```
+
+Nothing is installed on the server for FrankenDeploy itself: the CLI runs everything over SSH with standard Docker commands. Updating the CLI is enough; the next `deploy` applies whatever changed.
+
+## What a new version changes on the server
+
+FrankenDeploy never changes a running application by itself. Changes of behaviour land on your server at your next `deploy` (or `rollback`, or `env --reload`), and are designed to be transparent. Here is what to expect, most recent first.
+
+### 0.16
+
+**Symfony trusts Caddy.** The app container now receives `SYMFONY_TRUSTED_PROXIES` and `TRUSTED_PROXIES` set to the private subnets. Symfony 7.2+ picks it up without configuration: absolute URLs switch to `https://`, session cookies get the `Secure` flag, the client IP becomes the visitor's. If you already defined either variable with `env set`, nothing changes. If your app is older than Symfony 7.2 and had no `framework.trusted_proxies`, add the wiring shown in [Behind the Proxy](/frankendeploy/guides/deployment/#behind-the-proxy) to benefit.
+
+### 0.15
+
+**One Docker network per application.** The next deploy of an existing app migrates it: the network `frankendeploy-<app>` is created, Caddy attached to it, the database container joins it, the new app container starts on it, and once the old container is stopped the database leaves the shared `frankendeploy` network. No downtime, no data touched. A deploy interrupted in the middle completes on the next one. `frankendeploy doctor` shows the status (`App network`).
+
+**`doctor`** got the `App network` check (0.15.1: only when Docker is present on the server).
+
+### 0.14
+
+**FrankenPHP worker mode with the native Symfony runtime.** Apps on `symfony/runtime` >= 7.4 no longer need `runtime/frankenphp-symfony`; `init` enables worker mode when it detects either. Existing configurations are unchanged.
+
+**No active health check in Caddy (0.14.1).** The generated `.caddy` file no longer probes the live container; per-request timeouts replace it. Applied when the app's Caddy configuration is rewritten, that is at the next deploy.
+
+### 0.13
+
+**`doctor`**, pure-Go SFTP transfers (no `scp`/`rsync` needed), OS detection in `server setup`, and the deployment pipeline extracted and tested per failure scenario. **The default `cache:warmup` post-deploy hook was removed** from what `init` generates (the cache is warmed at image build); an existing hook in your `frankendeploy.yaml` still runs, and can be deleted.
+
+### 0.12
+
+**Automatic database backup before migrations**, image pruning with `keep_releases`, log rotation on every container, optional `memory_limit` / `cpu_limit`.
+
+### 0.11
+
+**SSH**: ssh-agent, passphrase-protected keys, host key verification (`known_hosts`). A server whose host key was never recorded asks for confirmation on the next connection. **Env writes** enforce `chmod 600`; `env set --from-stdin`.
+
+### Before 0.11
+
+See the [changelog](https://github.com/yoanbernabeu/frankendeploy/blob/main/CHANGELOG.md).
+
+## Updating the server
+
+FrankenDeploy does not update the operating system, Docker, or the Caddy image. See the [Security Model](/frankendeploy/security/) for what is yours to schedule. Re-running `frankendeploy server setup prod --email …` is safe at any time and repairs what is missing; it does not upgrade Docker.
+
+To move the Caddy container to a newer `caddy:alpine`, on the server:
+
+```bash
+docker pull caddy:alpine
+```
+
+then `frankendeploy server setup prod --email …`, which recreates the container (certificates live in the `caddy_data` volume and are kept). The apps are not affected, but Caddy is down for a few seconds.
+
+## Downgrading
+
+Install the previous binary (releases keep every version) and deploy. Server-side changes are additive (a network, environment variables) and harmless to an older CLI.

--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -40,7 +40,11 @@ export const navigation: NavSection[] = [
     items: [
       { label: 'frankendeploy.yaml', href: '/frankendeploy/config/project/', order: 1 },
       { label: 'Global Config', href: '/frankendeploy/config/global/', order: 2 },
-      { label: 'Glossary', href: '/frankendeploy/glossary/', order: 3 },
+      { label: 'Under the Hood', href: '/frankendeploy/under-the-hood/', order: 3 },
+      { label: 'Security Model', href: '/frankendeploy/security/', order: 4 },
+      { label: 'Limits & Non-Goals', href: '/frankendeploy/limits/', order: 5 },
+      { label: 'Upgrading', href: '/frankendeploy/upgrading/', order: 6 },
+      { label: 'Glossary', href: '/frankendeploy/glossary/', order: 7 },
     ],
   },
   {


### PR DESCRIPTION
PR 2 of 3 of the documentation plan for the public launch: **the expert path**. Four reference pages, every statement read from the code.

| Page | Content |
|---|---|
| **Under the Hood** | The server layout (`/opt/frankendeploy` tree), the containers table (image, who starts it, networks, published ports), the networks, the app container's `docker run` verbatim, the database container, the generated Caddy configuration (global + per app), the image stages, the entrypoint, the deploy pipeline in 14 steps with the failure policy of each, what `rollback` and `env --reload` reuse, and a map of the code |
| **Security Model** | Threat model, what `server setup` does (with the command to verify each measure on the server), what every deploy does, what is deliberately not done and what to do instead, "who can do what", how to report a vulnerability. Links #95 |
| **Limits & Non-Goals** | One server per app, single database container, Symfony only, Ubuntu/Debian, HTTP-only ingress, one domain per app, ~30 apps, npm-only Node stage, no custom Dockerfile contract yet; numbers; stability policy |
| **Upgrading** | Updating the CLI, and what each version changes on the server at the next deploy (0.16 trusted proxies, 0.15 per-app networks, 0.14 worker mode and no active health check, 0.13, 0.12, 0.11); updating Caddy; downgrading |

Also: **Server Setup** keeps a short Security section pointing to the new page; Introduction, Quick Start, FAQ, First Deployment and Troubleshooting link to the new pages; the Troubleshooting health-check headings now show the exact message format (`health check failed on my-app-new: HTTP check failed (status: 500) (after 30 attempts)`); the Reference section of the sidebar lists the four pages.

`npm run build`: clean. No real domain or host in any example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK
