### PR TITLE
docs(nav): five sections by reading purpose

### DIFF
--- a/docs/src/utils/navigation.ts
+++ b/docs/src/utils/navigation.ts
@@ -12,7 +12,7 @@ export interface NavSection {
 
 export const navigation: NavSection[] = [
   {
-    title: 'Getting Started',
+    title: 'Start',
     items: [
       { label: 'Introduction', href: '/frankendeploy/getting-started/', order: 1 },
       { label: 'Before You Start', href: '/frankendeploy/before-you-start/', order: 2 },
@@ -35,8 +35,14 @@ export const navigation: NavSection[] = [
       { label: 'Workers & Scheduled Tasks', href: '/frankendeploy/guides/workers/', order: 9 },
       { label: 'Data & Backups', href: '/frankendeploy/guides/data-backups/', order: 10 },
       { label: 'CI/CD', href: '/frankendeploy/guides/ci-cd/', order: 11 },
-      { label: 'Troubleshooting', href: '/frankendeploy/guides/troubleshooting/', order: 12 },
-      { label: 'FAQ', href: '/frankendeploy/guides/faq/', order: 13 },
+    ],
+  },
+  {
+    title: 'Understand',
+    items: [
+      { label: 'Under the Hood', href: '/frankendeploy/under-the-hood/', order: 1 },
+      { label: 'Security Model', href: '/frankendeploy/security/', order: 2 },
+      { label: 'Limits & Non-Goals', href: '/frankendeploy/limits/', order: 3 },
     ],
   },
   {
@@ -44,11 +50,8 @@ export const navigation: NavSection[] = [
     items: [
       { label: 'frankendeploy.yaml', href: '/frankendeploy/config/project/', order: 1 },
       { label: 'Global Config', href: '/frankendeploy/config/global/', order: 2 },
-      { label: 'Under the Hood', href: '/frankendeploy/under-the-hood/', order: 3 },
-      { label: 'Security Model', href: '/frankendeploy/security/', order: 4 },
-      { label: 'Limits & Non-Goals', href: '/frankendeploy/limits/', order: 5 },
-      { label: 'Upgrading', href: '/frankendeploy/upgrading/', order: 6 },
-      { label: 'Glossary', href: '/frankendeploy/glossary/', order: 7 },
+      { label: 'Upgrading', href: '/frankendeploy/upgrading/', order: 3 },
+      { label: 'Glossary', href: '/frankendeploy/glossary/', order: 4 },
     ],
   },
   {
@@ -110,6 +113,13 @@ export const navigation: NavSection[] = [
           { label: 'pull', href: '/frankendeploy/commands/frankendeploy_env_pull/' },
         ],
       },
+    ],
+  },
+  {
+    title: 'Help',
+    items: [
+      { label: 'Troubleshooting', href: '/frankendeploy/guides/troubleshooting/', order: 1 },
+      { label: 'FAQ', href: '/frankendeploy/guides/faq/', order: 2 },
     ],
   },
 ];


### PR DESCRIPTION
The sidebar had thirteen entries under Guides, mixing tutorials, tasks, explanations and help. Now:

- **Start**: Introduction, Before You Start, Installation, Your First Deployment, Quick Start
- **Guides**: the eleven how-to pages, in the order of an application's life
- **Understand**: Under the Hood, Security Model, Limits & Non-Goals
- **Reference**: frankendeploy.yaml, Global Config, Upgrading, Glossary
- **CLI Commands**: unchanged (kept as its own section: the sidebar renders one level of nesting)
- **Help**: Troubleshooting, FAQ

No page moved or renamed; only the sidebar. Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JPWGmjwbx5j8VvVTFhuaYK